### PR TITLE
Windows Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "chokidar": "^3.6.0",
                 "compression": "^1.7.4",
                 "cookie-parser": "^1.4.6",
+                "cross-env": "^7.0.3",
                 "css-hot-loader": "^1.4.4",
                 "css-loader": "^6.8.1",
                 "express": "^4.18.2",
@@ -5123,6 +5124,23 @@
                 "@types/node": "*",
                 "cosmiconfig": ">=8.2",
                 "typescript": ">=4"
+            }
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
             }
         },
         "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "chokidar": "^3.6.0",
         "compression": "^1.7.4",
         "cookie-parser": "^1.4.6",
+        "cross-env": "^7.0.3",
         "css-hot-loader": "^1.4.4",
         "css-loader": "^6.8.1",
         "express": "^4.18.2",

--- a/src/scripts/build.js
+++ b/src/scripts/build.js
@@ -1,8 +1,8 @@
 const path = require("path")
 const { spawnSync } = require("child_process")
 const { green, cyan, yellow } = require("picocolors")
-const { name } = require(`${process.env.PWD}/package.json`)
-const { BUILD_OUTPUT_PATH } = require(`${process.env.PWD}/config/config.json`)
+const { name } = require(`${process.cwd()}/package.json`)
+const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
 const { arrayToObject, printBundleInformation } = require("./scriptUtils.js")
 
 /**
@@ -15,11 +15,11 @@ function build() {
 
     const command = `
     node ./dist/scripts/checkVersion
-    rm -rf ${process.env.PWD}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js
+    rm -rf ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js
     APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress
     APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js
-    APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.env.PWD}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet 
-    APPLICATION=${name || "catalyst_app"} npx babel ${process.env.PWD}/server --out-dir ${process.env.PWD}/${BUILD_OUTPUT_PATH} --quiet
+    APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet 
+    APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet
     `
 
     console.log("Creating an optimized production build...")
@@ -30,7 +30,7 @@ function build() {
         shell: true,
         env: {
             ...process.env,
-            src_path: process.env.PWD,
+            src_path: process.cwd(),
             BUILD_OUTPUT_PATH: BUILD_OUTPUT_PATH,
             NODE_ENV: "production",
             IS_DEV_COMMAND: false,

--- a/src/scripts/build.js
+++ b/src/scripts/build.js
@@ -13,14 +13,20 @@ function build() {
     const argumentsObject = arrayToObject(commandLineArguments)
     const dirname = path.resolve(__dirname, "../../")
 
+    const checkVersion = "node ./dist/scripts/checkVersion"
+    const beforeServerScript = `rm -rf ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js`
+    const buildClient = `APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress`
+    const buildSSRServer = `APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js`
+    const buildServer = `APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`
+    const startServer = `APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`
+
     const command = `
-    node ./dist/scripts/checkVersion
-    rm -rf ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js
-    APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress
-    APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js
-    APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet 
-    APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet
-    `
+        start ${checkVersion} && 
+        start ${beforeServerScript} && 
+        start ${buildClient} && 
+        start ${buildSSRServer} && 
+        start ${buildServer} && 
+        start ${startServer}`
 
     console.log("Creating an optimized production build...")
 

--- a/src/scripts/build.js
+++ b/src/scripts/build.js
@@ -17,16 +17,10 @@ function build() {
     const beforeServerScript = `rm -rf ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js`
     const buildClient = `APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress`
     const buildSSRServer = `APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js`
-    const buildServer = `APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`
-    const startServer = `APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`
+    const buildInternalServer = `APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`
+    const buildServer = `APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`
 
-    const command = `
-        start ${checkVersion} && 
-        start ${beforeServerScript} && 
-        start ${buildClient} && 
-        start ${buildSSRServer} && 
-        start ${buildServer} && 
-        start ${startServer}`
+    const command = `start ${checkVersion} && start ${beforeServerScript} && start ${buildClient} && start ${buildSSRServer} && start ${buildInternalServer} && start ${startServer}`
 
     console.log("Creating an optimized production build...")
 

--- a/src/scripts/build.js
+++ b/src/scripts/build.js
@@ -20,7 +20,7 @@ function build() {
     const buildInternalServer = `APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`
     const buildServer = `APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`
 
-    const command = `start ${checkVersion} && start ${beforeServerScript} && start ${buildClient} && start ${buildSSRServer} && start ${buildInternalServer} && start ${startServer}`
+    const command = `start ${checkVersion} && ${beforeServerScript} && start ${buildClient} && start ${buildSSRServer} && start ${buildInternalServer} && start ${buildServer}`
 
     console.log("Creating an optimized production build...")
 

--- a/src/scripts/devBuild.js
+++ b/src/scripts/devBuild.js
@@ -20,7 +20,7 @@ function devBuild() {
     const buildInternalServer = `APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`
     const buildServer = `APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`
 
-    const command = `start ${checkVersion} && start ${beforeServerScript} && start ${buildClient} && start ${buildSSRServer} && start ${buildInternalServer} && start ${buildServer}`
+    const command = `start ${checkVersion} && ${beforeServerScript} && start ${buildClient} && start ${buildSSRServer} && start ${buildInternalServer} && start ${buildServer}`
 
     console.log("Creating an optimized local build...")
 

--- a/src/scripts/devBuild.js
+++ b/src/scripts/devBuild.js
@@ -17,16 +17,10 @@ function devBuild() {
     const beforeServerScript = `rm -rf ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js`
     const buildClient = `APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress`
     const buildSSRServer = ` APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js`
-    const buildServer = `APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`
-    const startServer = `APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`
+    const buildInternalServer = `APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`
+    const buildServer = `APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`
 
-    const command = `
-        start ${checkVersion} && 
-        start ${beforeServerScript} && 
-        start ${buildClient} && 
-        start ${buildSSRServer} && 
-        start ${buildServer} && 
-        start ${startServer}`
+    const command = `start ${checkVersion} && start ${beforeServerScript} && start ${buildClient} && start ${buildSSRServer} && start ${buildInternalServer} && start ${buildServer}`
 
     console.log("Creating an optimized local build...")
 

--- a/src/scripts/devBuild.js
+++ b/src/scripts/devBuild.js
@@ -13,14 +13,20 @@ function devBuild() {
     const argumentsObject = arrayToObject(commandLineArguments)
     const dirname = path.resolve(__dirname, "../../")
 
+    const checkVersion = "node ./dist/scripts/checkVersion"
+    const beforeServerScript = `rm -rf ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js`
+    const buildClient = `APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress`
+    const buildSSRServer = ` APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js`
+    const buildServer = `APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`
+    const startServer = `APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`
+
     const command = `
-    node ./dist/scripts/checkVersion
-    rm -rf ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js
-    APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress
-    APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js
-    APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet 
-    APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet
-    `
+        start ${checkVersion} && 
+        start ${beforeServerScript} && 
+        start ${buildClient} && 
+        start ${buildSSRServer} && 
+        start ${buildServer} && 
+        start ${startServer}`
 
     console.log("Creating an optimized local build...")
 

--- a/src/scripts/devBuild.js
+++ b/src/scripts/devBuild.js
@@ -1,8 +1,8 @@
 const path = require("path")
 const { spawnSync } = require("child_process")
 const { green, cyan, yellow } = require("picocolors")
-const { name } = require(`${process.env.PWD}/package.json`)
-const { BUILD_OUTPUT_PATH } = require(`${process.env.PWD}/config/config.json`)
+const { name } = require(`${process.cwd()}/package.json`)
+const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
 const { arrayToObject, printBundleInformation } = require("./scriptUtils.js")
 
 /**
@@ -15,11 +15,11 @@ function devBuild() {
 
     const command = `
     node ./dist/scripts/checkVersion
-    rm -rf ${process.env.PWD}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js
+    rm -rf ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js
     APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress
     APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js
-    APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.env.PWD}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet 
-    APPLICATION=${name || "catalyst_app"} npx babel ${process.env.PWD}/server --out-dir ${process.env.PWD}/${BUILD_OUTPUT_PATH} --quiet
+    APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet 
+    APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet
     `
 
     console.log("Creating an optimized local build...")
@@ -30,7 +30,7 @@ function devBuild() {
         shell: true,
         env: {
             ...process.env,
-            src_path: process.env.PWD,
+            src_path: process.cwd(),
             BUILD_OUTPUT_PATH: BUILD_OUTPUT_PATH,
             NODE_ENV: "production",
             IS_DEV_COMMAND: true,

--- a/src/scripts/devBuild.js
+++ b/src/scripts/devBuild.js
@@ -9,18 +9,21 @@ const { arrayToObject, printBundleInformation } = require("./scriptUtils.js")
  * @description - creates a production build of the application.
  */
 function devBuild() {
+    const isWindows = process.platform === "win32"
     const commandLineArguments = process.argv.slice(2)
     const argumentsObject = arrayToObject(commandLineArguments)
     const dirname = path.resolve(__dirname, "../../")
 
-    const checkVersion = "node ./dist/scripts/checkVersion"
-    const beforeServerScript = `rm -rf ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js`
-    const buildClient = `APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress`
-    const buildSSRServer = ` APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js`
-    const buildInternalServer = `APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`
-    const buildServer = `APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`
+    const commands = [
+        "node ./dist/scripts/checkVersion",
+        `${isWindows ? "rd -r -fo" : "rm -rf"} ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js`,
+        `cross-env APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress`,
+        ` cross-env APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js`,
+        `cross-env APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`,
+        `cross-env APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`,
+    ]
 
-    const command = `start ${checkVersion} && ${beforeServerScript} && start ${buildClient} && start ${buildSSRServer} && start ${buildInternalServer} && start ${buildServer}`
+    const command = commands.join(isWindows ? " && " : " ; ")
 
     console.log("Creating an optimized local build...")
 

--- a/src/scripts/devServe.js
+++ b/src/scripts/devServe.js
@@ -1,8 +1,8 @@
 const path = require("path")
 const { spawnSync } = require("child_process")
 const { arrayToObject } = require("./scriptUtils")
-const { name } = require(`${process.env.PWD}/package.json`)
-const { BUILD_OUTPUT_PATH } = require(`${process.env.PWD}/config/config.json`)
+const { name } = require(`${process.cwd()}/package.json`)
+const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
 
 /**
  * @description -  Serves production build of the application.
@@ -14,7 +14,7 @@ function devServe() {
     const dirname = path.resolve(__dirname, "../../")
 
     const command = `
-    APPLICATION=${name || "catalyst_app"} node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ${process.env.PWD}/${BUILD_OUTPUT_PATH}/startServer.js
+    APPLICATION=${name || "catalyst_app"} node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ${process.cwd()}/${BUILD_OUTPUT_PATH}/startServer.js
     `
 
     spawnSync(command, [], {
@@ -23,7 +23,7 @@ function devServe() {
         shell: true,
         env: {
             ...process.env,
-            src_path: process.env.PWD,
+            src_path: process.cwd(),
             BUILD_OUTPUT_PATH: BUILD_OUTPUT_PATH,
             NODE_ENV: "production",
             IS_DEV_COMMAND: true,

--- a/src/scripts/devServe.js
+++ b/src/scripts/devServe.js
@@ -13,9 +13,7 @@ function devServe() {
     const argumentsObject = arrayToObject(commandLineArguments)
     const dirname = path.resolve(__dirname, "../../")
 
-    const command = `
-    APPLICATION=${name || "catalyst_app"} node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ${process.cwd()}/${BUILD_OUTPUT_PATH}/startServer.js
-    `
+    const command = `cross-env APPLICATION=${name || "catalyst_app"} node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ${process.cwd()}/${BUILD_OUTPUT_PATH}/startServer.js`
 
     spawnSync(command, [], {
         cwd: dirname,

--- a/src/scripts/loadScriptsBeforeServerStarts.js
+++ b/src/scripts/loadScriptsBeforeServerStarts.js
@@ -26,5 +26,5 @@ if (process.env.NODE_ENV === "development")
         processorOpts: { parser: postcssScssParser.parse },
         generateScopedName: cssModulesIdentifierDev,
         devMode: true,
-        ignore: path.join(process.env.src_path, "/src/static/css/base/(?!.*.scss$).*"),
+        ignore: path.posix.join(process.env.src_path, "/src/static/css/base/(?!.*.scss$).*"),
     })

--- a/src/scripts/scriptUtils.js
+++ b/src/scripts/scriptUtils.js
@@ -2,7 +2,7 @@ const fs = require("fs")
 const path = require("path")
 const util = require("node:util")
 const { gray, cyan } = require("picocolors")
-const { BUILD_OUTPUT_PATH } = require(`${process.env.PWD}/config/config.json`)
+const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
 
 // Function to get file size synchronously
 function getFileSizeSync(filePath) {
@@ -17,7 +17,7 @@ function getFileSizeSync(filePath) {
 
 export const printBundleInformation = () => {
     let bundleList = []
-    const directoryPath = path.join(process.env.PWD, `${BUILD_OUTPUT_PATH}/public`)
+    const directoryPath = path.join(process.cwd(), `${BUILD_OUTPUT_PATH}/public`)
 
     try {
         const files = fs.readdirSync(directoryPath)

--- a/src/scripts/serve.js
+++ b/src/scripts/serve.js
@@ -1,8 +1,8 @@
 const path = require("path")
 const { spawnSync } = require("child_process")
 const { arrayToObject } = require("./scriptUtils")
-const { name } = require(`${process.env.PWD}/package.json`)
-const { BUILD_OUTPUT_PATH } = require(`${process.env.PWD}/config/config.json`)
+const { name } = require(`${process.cwd()}/package.json`)
+const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
 
 /**
  * @description -  Serves production build of the application.
@@ -14,7 +14,7 @@ function serve() {
     const dirname = path.resolve(__dirname, "../../")
 
     const command = `
-    APPLICATION=${name || "catalyst_app"} node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ${process.env.PWD}/${BUILD_OUTPUT_PATH}/startServer.js
+    APPLICATION=${name || "catalyst_app"} node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ${process.cwd()}/${BUILD_OUTPUT_PATH}/startServer.js
     `
 
     spawnSync(command, [], {
@@ -23,7 +23,7 @@ function serve() {
         shell: true,
         env: {
             ...process.env,
-            src_path: process.env.PWD,
+            src_path: process.cwd(),
             BUILD_OUTPUT_PATH: BUILD_OUTPUT_PATH,
             NODE_ENV: "production",
             IS_DEV_COMMAND: false,

--- a/src/scripts/serve.js
+++ b/src/scripts/serve.js
@@ -13,9 +13,7 @@ function serve() {
     const argumentsObject = arrayToObject(commandLineArguments)
     const dirname = path.resolve(__dirname, "../../")
 
-    const command = `
-    APPLICATION=${name || "catalyst_app"} node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ${process.cwd()}/${BUILD_OUTPUT_PATH}/startServer.js
-    `
+    const command = `cross-env APPLICATION=${name || "catalyst_app"} node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ${process.cwd()}/${BUILD_OUTPUT_PATH}/startServer.js`
 
     spawnSync(command, [], {
         cwd: dirname,

--- a/src/scripts/start.js
+++ b/src/scripts/start.js
@@ -1,8 +1,8 @@
 const path = require("path")
 const { spawnSync } = require("child_process")
 const { arrayToObject } = require("./scriptUtils")
-const { name } = require(`${process.env.PWD}/package.json`)
-const { BUILD_OUTPUT_PATH } = require(`${process.env.PWD}/config/config.json`)
+const { name } = require(`${process.cwd()}/package.json`)
+const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
 
 /**
  * @description - starts webpack dev server and node server.
@@ -14,7 +14,7 @@ function start() {
 
     const command = `
     node ./dist/scripts/checkVersion
-    npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL & npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.env.PWD}/server --watch-path=${process.env.PWD}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL
+    npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL & npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL
     `
 
     spawnSync(command, [], {
@@ -23,7 +23,7 @@ function start() {
         shell: true,
         env: {
             ...process.env,
-            src_path: process.env.PWD,
+            src_path: process.cwd(),
             NODE_ENV: "development",
             IS_DEV_COMMAND: false,
             APPLICATION: name || "catalyst_app",

--- a/src/scripts/start.js
+++ b/src/scripts/start.js
@@ -8,16 +8,19 @@ const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
  * @description - starts webpack dev server and node server.
  */
 function start() {
+    const isWindows = process.platform === "win32"
     const commandLineArguments = process.argv.slice(2)
     const argumentsObject = arrayToObject(commandLineArguments)
     const dirname = path.resolve(__dirname, "../../")
 
-    const versionCheck = "node ./dist/scripts/checkVersion"
-    const webpackDevServer =
-        "npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL"
-    const server = `npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL`
+    let command = `
+    node ./dist/scripts/checkVersion
+    npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL & npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.env.PWD}/server --watch-path=${process.env.PWD}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL
+    `
 
-    const command = `start ${versionCheck} && start ${webpackDevServer} && start ${server}`
+    if (isWindows) {
+        command = `node ./dist/scripts/checkVersion && start /b npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL && start /b npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL`
+    }
 
     spawnSync(command, [], {
         cwd: dirname,

--- a/src/scripts/start.js
+++ b/src/scripts/start.js
@@ -17,10 +17,7 @@ function start() {
         "npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL"
     const server = `npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL`
 
-    const command = `
-        start ${versionCheck} && 
-        start ${webpackDevServer} &&
-        start ${server}`
+    const command = `start ${versionCheck} && start ${webpackDevServer} && start ${server}`
 
     spawnSync(command, [], {
         cwd: dirname,

--- a/src/scripts/start.js
+++ b/src/scripts/start.js
@@ -17,7 +17,10 @@ function start() {
         "npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL"
     const server = `npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL`
 
-    const command = `start /b ${versionCheck} && start /b ${webpackDevServer} && start /b ${server}`
+    const command = `
+        start ${versionCheck} && 
+        start ${webpackDevServer} &&
+        start ${server}`
 
     spawnSync(command, [], {
         cwd: dirname,

--- a/src/scripts/start.js
+++ b/src/scripts/start.js
@@ -12,10 +12,13 @@ function start() {
     const argumentsObject = arrayToObject(commandLineArguments)
     const dirname = path.resolve(__dirname, "../../")
 
-    const command = `
-    node ./dist/scripts/checkVersion
-    npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL & npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL
-    `
+    const versionCheck = "node ./dist/scripts/checkVersion"
+    const webpackDevServer =
+        "npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL"
+    const server =
+        "npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL"
+
+    const command = `start /b ${versionCheck} && start /b ${webpackDevServer} && start /b ${server}`
 
     spawnSync(command, [], {
         cwd: dirname,

--- a/src/scripts/start.js
+++ b/src/scripts/start.js
@@ -15,8 +15,7 @@ function start() {
     const versionCheck = "node ./dist/scripts/checkVersion"
     const webpackDevServer =
         "npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL"
-    const server =
-        "npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL"
+    const server = `npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL`
 
     const command = `start /b ${versionCheck} && start /b ${webpackDevServer} && start /b ${server}`
 

--- a/src/scripts/start.js
+++ b/src/scripts/start.js
@@ -1,5 +1,5 @@
 const path = require("path")
-const { spawnSync } = require("child_process")
+const { spawnSync, spawn } = require("child_process")
 const { arrayToObject } = require("./scriptUtils")
 const { name } = require(`${process.cwd()}/package.json`)
 const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
@@ -19,23 +19,59 @@ function start() {
     `
 
     if (isWindows) {
-        command = `node ./dist/scripts/checkVersion && start /b npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL && start /b npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL`
-    }
+        spawn(
+            `node ./dist/scripts/checkVersion && start /b npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/webpack/development.client.babel --no-warnings=ExperimentalWarning --no-warnings=BABEL`,
+            [],
+            {
+                cwd: dirname,
+                stdio: "inherit",
+                shell: true,
+                env: {
+                    ...process.env,
+                    src_path: process.cwd(),
+                    NODE_ENV: "development",
+                    IS_DEV_COMMAND: false,
+                    APPLICATION: name || "catalyst_app",
+                    BUILD_OUTPUT_PATH: BUILD_OUTPUT_PATH,
+                    ...argumentsObject,
+                },
+            }
+        )
 
-    spawnSync(command, [], {
-        cwd: dirname,
-        stdio: "inherit",
-        shell: true,
-        env: {
-            ...process.env,
-            src_path: process.cwd(),
-            NODE_ENV: "development",
-            IS_DEV_COMMAND: false,
-            APPLICATION: name || "catalyst_app",
-            BUILD_OUTPUT_PATH: BUILD_OUTPUT_PATH,
-            ...argumentsObject,
-        },
-    })
+        spawn(
+            `node ./dist/scripts/checkVersion && npx babel-node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ./dist/server/startServer.js --watch-path=${process.cwd()}/server --watch-path=${process.cwd()}/src --ignore='__IGNORE__' --no-warnings=ExperimentalWarning --no-warnings=BABEL`,
+            [],
+            {
+                cwd: dirname,
+                stdio: "inherit",
+                shell: true,
+                env: {
+                    ...process.env,
+                    src_path: process.cwd(),
+                    NODE_ENV: "development",
+                    IS_DEV_COMMAND: false,
+                    APPLICATION: name || "catalyst_app",
+                    BUILD_OUTPUT_PATH: BUILD_OUTPUT_PATH,
+                    ...argumentsObject,
+                },
+            }
+        )
+    } else {
+        spawnSync(command, [], {
+            cwd: dirname,
+            stdio: "inherit",
+            shell: true,
+            env: {
+                ...process.env,
+                src_path: process.cwd(),
+                NODE_ENV: "development",
+                IS_DEV_COMMAND: false,
+                APPLICATION: name || "catalyst_app",
+                BUILD_OUTPUT_PATH: BUILD_OUTPUT_PATH,
+                ...argumentsObject,
+            },
+        })
+    }
 }
 
 start()

--- a/src/webpack/production.client.babel.js
+++ b/src/webpack/production.client.babel.js
@@ -49,6 +49,7 @@ const clientConfig = mergeWithCustomize({
                     name(module) {
                         const moduleFileName = module
                             .identifier()
+                            .replace(/\\/g, "/")
                             .split("/")
                             .reverse()
                             .slice(0, 3)
@@ -64,6 +65,7 @@ const clientConfig = mergeWithCustomize({
             name(module) {
                 const moduleFileName = module
                     .identifier()
+                    .replace(/\\/g, "/")
                     .split("/")
                     .reverse()
                     .slice(0, 3)


### PR DESCRIPTION
This PR adds windows support to catalyst

---



---



 **DeputyDev generated PR summary:** 



---



 **Size L:** This PR changes include 110 lines and should take approximately 1-3 hours to review



---

The provided Pull Request (PR) is focused on adding Windows support to the project. Here's a summary of the changes made:

1. **`cross-env` Package Addition**: 
   - The `cross-env` package is added to the `package.json` file to ensure environment variables are set correctly across different operating systems, particularly for Windows.

2. **Path Handling**: 
   - Replaced `process.env.PWD` with `process.cwd()` to ensure compatibility with Windows, as `process.env.PWD` is not set by default on Windows systems.

3. **Command Execution**: 
   - Modified shell commands to use `cross-env` for setting environment variables.
   - Adjusted command concatenation to use `&&` on Windows instead of `;`, which is not supported by default in Windows command shells.
   - Added platform checks (`process.platform === "win32"`) to conditionally execute Windows-specific commands, such as using `rd -r -fo` instead of `rm -rf`.

4. **Path Separators in Webpack Config**: 
   - Replaced backslashes with forward slashes in module identifiers within Webpack configurations to handle path differences between Unix-like systems and Windows.

5. **Ignore Path Handling**: 
   - Used `path.posix.join` for ignoring paths to ensure compatibility with Windows file paths.

These changes collectively improve the build and serve scripts, making them cross-platform compatible, and specifically address issues that could arise when running the project on Windows.

Here's the corrective code for the path handling and environment setup:
```javascript
const { name } = require(`${process.cwd()}/package.json`)
const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)

const commands = [
    "node ./dist/scripts/checkVersion",
    `${isWindows ? "rd -r -fo" : "rm -rf"} ${process.cwd()}/${BUILD_OUTPUT_PATH} & node ./dist/scripts/loadScriptsBeforeServerStarts.js`,
    `cross-env APPLICATION=${name || "catalyst_app"} webpack --config ./dist/webpack/production.client.babel.js --progress`,
    `cross-env APPLICATION=${name || "catalyst_app"} SSR=true webpack --config ./dist/webpack/production.ssr.babel.js`,
    `cross-env APPLICATION=${name || "catalyst_app"} npx babel ./dist/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --ignore '**/*.test.js,./dist/server/renderer/handler.js' --quiet`,
    `cross-env APPLICATION=${name || "catalyst_app"} npx babel ${process.cwd()}/server --out-dir ${process.cwd()}/${BUILD_OUTPUT_PATH} --quiet`,
]

const command = commands.join(isWindows ? " && " : " ; ")
```

---

DeputyDev generated PR summary until f3126ae23fc277b1792fdda7d7940ed6ad8b3a79