### PR TITLE
JSON file format loader fix

### DIFF
--- a/src/webpack/base.babel.js
+++ b/src/webpack/base.babel.js
@@ -188,7 +188,7 @@ export default {
             },
             {
                 // This loader loads fonts in src/static/fonts using file-loader
-                test: /\.(ttf|eot|woff2|json?)$/,
+                test: /\.(ttf|eot|woff2?)$/,
                 use: [
                     {
                         loader: "url-loader",


### PR DESCRIPTION
This PR removes the `json` file format from being loaded using the `url-loader`

---



---



 **DeputyDev generated PR summary:** 



---



 **Size XS:** This PR changes include 2 lines and should take approximately 5-15 minutes to review



---

The pull request addresses a fix related to the file format loader in the webpack configuration. Specifically, it removes the `json` file format from the list of files handled by the `url-loader`. This change suggests that JSON files should not be processed by the `url-loader`, which is typically used for loading font files or other binary assets.

Here's the change in the code:
```diff
- test: /\.(ttf|eot|woff2|json?)$/,
+ test: /\.(ttf|eot|woff2?)$/,
```

This suggests that the JSON files were mistakenly included in the loader's configuration and are now correctly excluded.

---

DeputyDev generated PR summary until 383c56e24f771c924364b1ae039de6569aca3878