### PR TITLE
Utility vendor common name fix

### DIFF
--- a/src/webpack/development.client.babel.js
+++ b/src/webpack/development.client.babel.js
@@ -51,7 +51,12 @@ const webpackConfig = merge(baseConfig, {
                               const moduleFileName = module
                                   .identifier()
                                   .split("/")
-                                  .reduceRight((item) => item)
+                                  .reverse()
+                                  .slice(0, 3)
+                                  .reduce((item, current) => {
+                                      item = current + "." + item
+                                      return item
+                                  }, [])
                               return `npm.${moduleFileName}`
                           },
                       },

--- a/src/webpack/development.client.babel.js
+++ b/src/webpack/development.client.babel.js
@@ -50,7 +50,8 @@ const webpackConfig = merge(baseConfig, {
                           name(module) {
                               const moduleFileName = module
                                   .identifier()
-                                  .split("/")
+                                  .split("node_modules")?.[1]
+                                  ?.split("/")
                                   .reverse()
                                   .slice(0, 3)
                                   .reduce((item, current) => {


### PR DESCRIPTION
This PR changes the naming scheme for modules created through the default `utilityVendor` option to include hashes in the name for local development too, so that modules with same characters with different casing can co-exist

---



---



 **DeputyDev generated PR summary:** 



---



 **Size XS:** This PR changes include 7 lines and should take approximately 5-15 minutes to review



---

The pull request titled "Utility vendor common name fix" addresses an issue in the `development.client.babel.js` file. The primary change involves modifying how the `moduleFileName` is constructed within a Webpack configuration. Here's a breakdown of what the change does:

- **Original Code**: 
  - The `moduleFileName` was being derived by splitting the module identifier by "/", then using `reduceRight` to get the last segment of the path. This would typically return the file name or last directory name.

- **Updated Code**:
  - The new approach reverses the array of path segments, takes the first three elements, and then uses `reduce` to concatenate these segments into a string with periods `.` as separators. This results in a `moduleFileName` that includes more of the path structure, potentially making it more descriptive by including up to three segments of the path.

This change likely aims to create a more informative or unique identifier for modules by including more context from the path, which can be useful for debugging or logging purposes. 

Here's the corrective code for the update:
```javascript
const moduleFileName = module
    .identifier()
    .split("/")
    .reverse()
    .slice(0, 3)
    .reduce((item, current) => {
        item = current + "." + item
        return item
    }, [])
return `npm.${moduleFileName}`
```

This change would make the module naming more consistent and potentially avoid conflicts by incorporating a broader path context.

---

DeputyDev generated PR summary until c7ac3bc48954db7fb6c6feeb93ce0d90d58620d9