### PR TITLE
Support for react compiler config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,6 @@
 module.exports = (api) => {
     api.cache(true)
 
-    const EXPERIMENTS = JSON.parse(process.env.EXPERIMENTS || "{}")
-
     return {
         presets: [
             [
@@ -23,10 +21,7 @@ module.exports = (api) => {
             ["@babel/preset-react", { runtime: "automatic" }],
         ],
         compact: true,
-        plugins: [
-            ...(EXPERIMENTS?.ENABLE_COMPILER ? [["babel-plugin-react-compiler", { target: "18" }]] : []),
-            "@loadable/babel-plugin",
-        ],
+        plugins: ["@loadable/babel-plugin"],
         env: {
             test: {
                 presets: ["@babel/preset-react"],

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.0.1-beta.11] - 21-02-2024
+
+-   Add support for custom react compiler config
+-   Add support for typescript
+-   Fix json import issue
+-   Fix common name module conflict issue
+
 ## [0.0.1-beta.10] - 06-02-2024
 
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "catalyst-core",
-    "version": "0.0.1-beta.10",
+    "version": "0.0.1-beta.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "catalyst-core",
-            "version": "0.0.1-beta.10",
+            "version": "0.0.1-beta.11",
             "license": "MIT",
             "dependencies": {
                 "@babel/cli": "^7.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "catalyst-core",
-    "version": "0.0.1-beta.10",
+    "version": "0.0.1-beta.11",
     "main": "index.js",
     "description": "Web framework that provides great performance out of the box",
     "bin": {

--- a/src/webpack/babel.config.client.js
+++ b/src/webpack/babel.config.client.js
@@ -1,10 +1,10 @@
 import customWebpackConfig from "@catalyst/template/webpackConfig.js"
 
-const isCompilerEnabled = !!customWebpackConfig.reactCompilerConfig
+const isCompilerEnabled = !!customWebpackConfig.reactCompiler
 
 const reactCompilerOptions =
-    typeof customWebpackConfig.reactCompilerConfig === "object"
-        ? customWebpackConfig.reactCompilerConfig
+    typeof customWebpackConfig.reactCompiler === "object"
+        ? customWebpackConfig.reactCompiler
         : { target: "18" }
 
 export default {

--- a/src/webpack/babel.config.client.js
+++ b/src/webpack/babel.config.client.js
@@ -1,3 +1,5 @@
+import customWebpackConfig from "@catalyst/template/webpackConfig.js"
+
 const EXPERIMENTS = JSON.parse(process.env.EXPERIMENTS || "{}")
 
 export default {
@@ -21,7 +23,9 @@ export default {
         ["@babel/preset-react", { runtime: "automatic" }],
     ],
     plugins: [
-        ...(EXPERIMENTS?.ENABLE_COMPILER ? [["babel-plugin-react-compiler", { target: "18" }]] : []),
+        ...(EXPERIMENTS?.ENABLE_COMPILER
+            ? [["babel-plugin-react-compiler", customWebpackConfig.reactCompilerConfig || { target: "18" }]]
+            : []),
         "@loadable/babel-plugin",
     ],
     env: {

--- a/src/webpack/babel.config.client.js
+++ b/src/webpack/babel.config.client.js
@@ -1,6 +1,11 @@
 import customWebpackConfig from "@catalyst/template/webpackConfig.js"
 
-const EXPERIMENTS = JSON.parse(process.env.EXPERIMENTS || "{}")
+const isCompilerEnabled = !!customWebpackConfig.reactCompilerConfig
+
+const reactCompilerOptions =
+    typeof customWebpackConfig.reactCompilerConfig === "object"
+        ? customWebpackConfig.reactCompilerConfig
+        : { target: "18" }
 
 export default {
     babelrc: false,
@@ -23,9 +28,7 @@ export default {
         ["@babel/preset-react", { runtime: "automatic" }],
     ],
     plugins: [
-        ...(EXPERIMENTS?.ENABLE_COMPILER
-            ? [["babel-plugin-react-compiler", customWebpackConfig.reactCompilerConfig || { target: "18" }]]
-            : []),
+        ...(isCompilerEnabled ? [["babel-plugin-react-compiler", reactCompilerOptions]] : []),
         "@loadable/babel-plugin",
     ],
     env: {

--- a/src/webpack/babel.config.ssr.js
+++ b/src/webpack/babel.config.ssr.js
@@ -1,10 +1,10 @@
 import customWebpackConfig from "@catalyst/template/webpackConfig.js"
 
-const isCompilerEnabled = !!customWebpackConfig.reactCompilerConfig
+const isCompilerEnabled = !!customWebpackConfig.reactCompiler
 
 const reactCompilerOptions =
-    typeof customWebpackConfig.reactCompilerConfig === "object"
-        ? customWebpackConfig.reactCompilerConfig
+    typeof customWebpackConfig.reactCompiler === "object"
+        ? customWebpackConfig.reactCompiler
         : { target: "18" }
 
 export default {

--- a/src/webpack/babel.config.ssr.js
+++ b/src/webpack/babel.config.ssr.js
@@ -1,3 +1,5 @@
+import customWebpackConfig from "@catalyst/template/webpackConfig.js"
+
 const EXPERIMENTS = JSON.parse(process.env.EXPERIMENTS || "{}")
 
 export default {
@@ -21,7 +23,9 @@ export default {
         ["@babel/preset-react", { runtime: "automatic" }],
     ],
     plugins: [
-        ...(EXPERIMENTS?.ENABLE_COMPILER ? [["babel-plugin-react-compiler", { target: "18" }]] : []),
+        ...(EXPERIMENTS?.ENABLE_COMPILER
+            ? [["babel-plugin-react-compiler", customWebpackConfig.reactCompilerConfig || { target: "18" }]]
+            : []),
         "@loadable/babel-plugin",
     ],
     env: {

--- a/src/webpack/babel.config.ssr.js
+++ b/src/webpack/babel.config.ssr.js
@@ -1,6 +1,11 @@
 import customWebpackConfig from "@catalyst/template/webpackConfig.js"
 
-const EXPERIMENTS = JSON.parse(process.env.EXPERIMENTS || "{}")
+const isCompilerEnabled = !!customWebpackConfig.reactCompilerConfig
+
+const reactCompilerOptions =
+    typeof customWebpackConfig.reactCompilerConfig === "object"
+        ? customWebpackConfig.reactCompilerConfig
+        : { target: "18" }
 
 export default {
     babelrc: false,
@@ -23,9 +28,7 @@ export default {
         ["@babel/preset-react", { runtime: "automatic" }],
     ],
     plugins: [
-        ...(EXPERIMENTS?.ENABLE_COMPILER
-            ? [["babel-plugin-react-compiler", customWebpackConfig.reactCompilerConfig || { target: "18" }]]
-            : []),
+        ...(isCompilerEnabled ? [["babel-plugin-react-compiler", reactCompilerOptions]] : []),
         "@loadable/babel-plugin",
     ],
     env: {


### PR DESCRIPTION
This PR introduces feature to add a custom react compiler config object to babel

---



---



 **DeputyDev generated PR summary:** 



---



 **Size M:** This PR changes include 32 lines and should take approximately 30-60 minutes to review



---

The pull request titled "Support for react compiler config" introduces several changes aimed at enhancing the configuration and flexibility of the React compiler setup within a project. Here’s a summary of what the PR does:

1. **Babel Configuration Changes**:
   - The `babel.config.js` file has been simplified by removing the `EXPERIMENTS` check for enabling the `babel-plugin-react-compiler`. The plugin is no longer conditionally added based on environment variables in this configuration.
   - The `@loadable/babel-plugin` remains as a standard plugin.

2. **Custom Webpack Configuration**:
   - In both `babel.config.client.js` and `babel.config.ssr.js`, the PR introduces the import of a custom Webpack configuration from `@catalyst/template/webpackConfig.js`.
   - The React compiler plugin (`babel-plugin-react-compiler`) now uses a custom configuration if available (`customWebpackConfig.reactCompilerConfig`), providing more flexibility and customization options.

3. **Version and Changelog Updates**:
   - The `package.json` version is updated from `0.0.1-beta.10` to `0.0.1-beta.11`.
   - The `changelog.md` is updated to include the new version with notes on added support for custom React compiler config, TypeScript, and fixes for JSON import issues and common name module conflicts.

Overall, this PR enhances the project's configurability by allowing custom React compiler settings and makes necessary updates to the package version and changelog to reflect these changes.

---

DeputyDev generated PR summary until f5a4d262a766407e45ee03518eb8cc918d4c7350