### PR TITLE
Babel environment variables accessible

### DIFF
--- a/src/webpack/production.client.babel.js
+++ b/src/webpack/production.client.babel.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import _registerAliases, { catalystResultMap } from "../scripts/registerAliases.js"
+import "../scripts/loadScriptsBeforeServerStarts.js"
 import MiniCssExtractPlugin from "mini-css-extract-plugin"
 import { mergeWithCustomize, customizeArray, customizeObject } from "webpack-merge"
 

--- a/src/webpack/production.ssr.babel.js
+++ b/src/webpack/production.ssr.babel.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import _registerAliases, { catalystResultMap } from "../scripts/registerAliases.js"
+import "../scripts/loadScriptsBeforeServerStarts.js"
 import path from "path"
 import nodeExternals from "webpack-node-externals"
 const { mergeWithCustomize, customizeArray, customizeObject } = require("webpack-merge")


### PR DESCRIPTION
This PR imports `loadScriptsBeforeServerStarts.js` that initiates env variables that can be accessed across the application, before this env vars were not accessible to babel config files

---



---



 **DeputyDev generated PR summary:** 



---



 **Size XS:** This PR changes include 2 lines and should take approximately 5-15 minutes to review



---

The provided Pull Request (PR) makes changes to two JavaScript files used for webpack configurations: `production.client.babel.js` and `production.ssr.babel.js`. The main modification is the addition of an import statement for a script named `loadScriptsBeforeServerStarts.js` in both files. 

This change suggests that the PR aims to ensure certain scripts are loaded before the server starts, potentially to set up environment variables or other necessary configurations before the webpack build process begins. 

By importing `loadScriptsBeforeServerStarts.js`, the PR likely addresses the need to initialize or configure some environment-specific settings or scripts that must be executed prior to the server's initialization. 

If you have specific questions or need further technical discussions about this PR, feel free to ask!

---

DeputyDev generated PR summary until 0b5be6dbe7003800f1692c1a40f7f3d3ee8db1fa