### PR TITLE
Test case for environment variables expose logic

### DIFF
--- a/template/config/config.json
+++ b/template/config/config.json
@@ -6,7 +6,7 @@
     "BUILD_OUTPUT_PATH": "build",
     "PUBLIC_STATIC_ASSET_PATH": "/assets/",
     "PUBLIC_STATIC_ASSET_URL": "http://localhost:3005",
-    "API_URL": "",
+    "API_URL": "random_api_url",
     "ANALYZE_BUNDLE": false,
     "CUSTOM_VAR": "custom",
     "CLIENT_ENV_VARIABLES": ["API_URL", "CUSTOM_VAR"]

--- a/template/src/js/pages/BreedDetails/BreedDetails.js
+++ b/template/src/js/pages/BreedDetails/BreedDetails.js
@@ -3,6 +3,7 @@ import { useCurrentRouteData, useParams, Link } from "@tata1mg/router"
 
 const BreedDetails = () => {
     const params = useParams()
+    const { API_URL, NODE_SERVER_HOSTNAME } = process.env
     const { data, error, isFetching } = useCurrentRouteData()
 
     if (isFetching) return <div className="container">Loading breed details...</div>
@@ -31,6 +32,8 @@ const BreedDetails = () => {
                     </div>
                 ))}
             </div>
+            <div data-testid={"client-var"}>{API_URL}</div>
+            <div data-testid={"server-var"}>{NODE_SERVER_HOSTNAME}</div>
         </div>
     )
 }

--- a/template/tests/main.spec.js
+++ b/template/tests/main.spec.js
@@ -37,9 +37,15 @@ test("Server middleware", async ({ page }) => {
     expect(json.message).toBe("With regards, from server")
 })
 
-// test("Environment variables on client", async ({ page }) => {
-//   await page.goto("http://localhost:3005");
-// });
+test("Environment variables on client", async ({ page }) => {
+    await page.goto("http://localhost:3005/breed/affenpinscher")
+    const clientVar = page.getByTestId("client-var")
+    const serverVar = page.getByTestId("server-var")
+    const clientText = await clientVar.textContent()
+    const serverText = await serverVar.textContent()
+    expect(clientText).toBe("random_api_url")
+    expect(serverText).toBe("")
+})
 
 // Currently breaking - needs to be fixed in catalyst
 // test("setMetaData on CSR", async ({ page }) => {


### PR DESCRIPTION
This PR adds a test case to check if correct environment variables are exposed to the client side

---



---



 **DeputyDev generated PR summary:** 



---



 **Size S:** This PR changes include 17 lines and should take approximately 15-30 minutes to review



---

The pull request implements the following changes:

1. **Configuration Update**:
   - The `config.json` file is updated to set a default value for `API_URL` as `"random_api_url"`. This variable is also added to `CLIENT_ENV_VARIABLES`, indicating it should be exposed to the client-side.

2. **Code Changes in `BreedDetails.js`**:
   - Environment variables `API_URL` and `NODE_SERVER_HOSTNAME` are accessed from `process.env` and displayed within the `BreedDetails` component using `data-testid` attributes `client-var` and `server-var`, respectively.

3. **Test Addition in `main.spec.js`**:
   - A test case is added to verify the presence of environment variables on the client. It checks that the `API_URL` is correctly exposed and accessible on the client-side, while `NODE_SERVER_HOSTNAME` remains undefined on the client.

**Resolution**:

If the objective was to explore environment variable exposure and ensure the client receives the right data, this PR achieves that by:
- Setting and verifying the exposure of specific variables.
  
If refinement is needed, consider adding comments to explain why `NODE_SERVER_HOSTNAME` is expected to be empty, for clarity.

**Corrective Code Blocks**:
```json
// Part of config.json, showing environment variable configuration.
{
    "BUILD_OUTPUT_PATH": "build",
    "PUBLIC_STATIC_ASSET_PATH": "/assets/",
    "PUBLIC_STATIC_ASSET_URL": "http://localhost:3005",
    "API_URL": "random_api_url",
    "ANALYZE_BUNDLE": false,
    "CUSTOM_VAR": "custom",
    "CLIENT_ENV_VARIABLES": ["API_URL", "CUSTOM_VAR"]
}
```
```javascript
// Part of BreedDetails.js where environment variables are displayed.
const BreedDetails = () => {
    const params = useParams()
    const { API_URL, NODE_SERVER_HOSTNAME } = process.env
    const { data, error, isFetching } = useCurrentRouteData()

    if (isFetching) return <div className="container">Loading breed details...</div>

    return (
        <div>
            {...}
            <div data-testid={"client-var"}>{API_URL}</div>
            <div data-testid={"server-var"}>{NODE_SERVER_HOSTNAME}</div>
        </div>
    )
}
```
```javascript
// Part of main.spec.js, testing the client-side exposure of environment variables.
test("Environment variables on client", async ({ page }) => {
    await page.goto("http://localhost:3005/breed/affenpinscher")
    const clientVar = page.getByTestId("client-var")
    const serverVar = page.getByTestId("server-var")
    const clientText = await clientVar.textContent()
    const serverText = await serverVar.textContent()
    expect(clientText).toBe("random_api_url")
    expect(serverText).toBe("")
})
```

---

DeputyDev generated PR summary until 6cea197974c2a1ac0e7680e7458ad6c3c8826584