### PR TITLE
Universal App - Access control and protocol toggle

### DIFF
--- a/src/native/androidProject/app/src/main/java/io/yourname/androidproject/MainActivity.kt
+++ b/src/native/androidProject/app/src/main/java/io/yourname/androidproject/MainActivity.kt
@@ -115,7 +115,8 @@ class MainActivity : AppCompatActivity(), CoroutineScope by MainScope() {
                 // Use the local development server in debug mode
                 val local_ip = properties.getProperty("LOCAL_IP", "localhost")
                 val port = properties.getProperty("port", "3005")
-                currentUrl = "http://$local_ip:$port"
+                val protocol = properties.getProperty("protocol", "http")
+                currentUrl = "$protocol://$local_ip:$port"
             } else {
                 // In production, use the configured production URL or fallback to a file:// URL
                 currentUrl = properties.getProperty("PRODUCTION_URL", "")


### PR DESCRIPTION
This PR introduces two new configuration options:

Whitelisting toggle
Controlled via `accessControl.enabled` (default: false)
Allows enabling or disabling access control whitelisting.


Webview protocol configuration
Controlled via `WEBVIEW_CONFIG.protocol` (default: http)
Makes the protocol for opening the webview configurable instead of being fixed to http.

```
{
  "WEBVIEW_CONFIG": {
    "protocol": "https",
    "accessControl": {
      "enabled": true,
      "allowedUrls": [""]
    }
}
```