### PR TITLE
Use DPI to calculate keyboard height

### DIFF
--- a/src/native/androidProject/app/src/main/java/io/yourname/androidproject/utils/KeyboardUtil.kt
+++ b/src/native/androidProject/app/src/main/java/io/yourname/androidproject/utils/KeyboardUtil.kt
@@ -2,6 +2,7 @@ package io.yourname.androidproject.utils
 
 import android.app.Activity
 import android.graphics.Rect
+import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
@@ -13,6 +14,32 @@ class KeyboardUtil(
 ) {
     private var originalHeight: Int = 0
     private var listener: ViewTreeObserver.OnGlobalLayoutListener? = null
+    
+    // Keyboard detection threshold in dp - commonly used values are 120-150dp
+    private val keyboardThresholdDp = 120f
+    
+    // Calculate minimum keyboard height in pixels based on device density
+    private val keyboardThresholdPx: Int by lazy {
+        dpToPx(keyboardThresholdDp)
+    }
+    
+    /**
+     * Convert density-independent pixels to pixels
+     */
+    private fun dpToPx(dp: Float): Int {
+        return TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            dp,
+            activity.resources.displayMetrics
+        ).toInt()
+    }
+    
+    /**
+     * Convert pixels to density-independent pixels
+     */
+    private fun pxToDp(px: Int): Float {
+        return px / activity.resources.displayMetrics.density
+    }
 
     fun initialize() {
         val rootView = activity.findViewById<ViewGroup>(android.R.id.content)
@@ -23,9 +50,15 @@ class KeyboardUtil(
         listener = ViewTreeObserver.OnGlobalLayoutListener {
             val rect = Rect()
             rootView.getWindowVisibleDisplayFrame(rect)
-            val keyboardHeight = activity.resources.displayMetrics.heightPixels - rect.height()
+            val screenHeight = activity.resources.displayMetrics.heightPixels
+            val visibleHeight = rect.height()
+            val keyboardHeight = screenHeight - visibleHeight
             
-            if (keyboardHeight > 200) {
+            // Use density-independent threshold and consider screen size
+            // Also add a minimum percentage of screen height as additional validation
+            val minScreenPercentage = (screenHeight * 0.15).toInt() // 15% of screen height
+            val effectiveThreshold = maxOf(keyboardThresholdPx, minScreenPercentage)
+            if (keyboardHeight > effectiveThreshold) {
                 // Keyboard visible - resize
                 val params = webViewContainer.layoutParams as ConstraintLayout.LayoutParams
                 params.height = originalHeight - keyboardHeight


### PR DESCRIPTION
The current implementation to resize webview when keyboard is open uses a fixed value of 200px which can be too less for devices with high DPI. This uses Device Density to figure out keyboard height and resize webview