### PR TITLE
Add support for https URL schemes

### DIFF
--- a/src/native/buildAppIos.js
+++ b/src/native/buildAppIos.js
@@ -4,13 +4,18 @@ const path = require("path")
 const TerminalProgress = require("./TerminalProgress.js").default
 
 const pwd = `${process.cwd()}/node_modules/catalyst-core/dist/native`
-const { WEBVIEW_CONFIG, BUILD_OUTPUT_PATH, NODE_SERVER_HOSTNAME } = require(
+const { WEBVIEW_CONFIG, BUILD_OUTPUT_PATH, NODE_SERVER_HOSTNAME, NODE_SERVER_PORT } = require(
     `${process.env.PWD}/config/config.json`
 )
 
 // Configuration constants
 const iosConfig = WEBVIEW_CONFIG.ios
-const url = `http://${NODE_SERVER_HOSTNAME}:${WEBVIEW_CONFIG.port}`
+
+const protocol = WEBVIEW_CONFIG.useHttps ? "https" : "http"
+const ip = NODE_SERVER_HOSTNAME ?? null
+const port = NODE_SERVER_PORT ? (WEBVIEW_CONFIG.useHttps ? 403 : NODE_SERVER_PORT) : null
+let url = port ? `${protocol}://${ip}:${port}` : `${protocol}://${ip}`
+
 const PROJECT_DIR = `${pwd}/iosnativeWebView`
 const SCHEME_NAME = "iosnativeWebView"
 const APP_BUNDLE_ID = iosConfig.appBundleId || "com.debug.webview"

--- a/src/native/buildAppIos.js
+++ b/src/native/buildAppIos.js
@@ -40,10 +40,8 @@ const progressConfig = {
 
 const progress = new TerminalProgress(steps, "Catalyst iOS Build", progressConfig)
 
-async function generateConfigConstants() {
-    progress.start("config")
+async function updateInfoPlist() {
     try {
-        // Update Info.plist with dynamic app name
         const infoPlistPath = path.join(PROJECT_DIR, PROJECT_NAME, "Info.plist")
 
         if (fs.existsSync(infoPlistPath)) {
@@ -67,7 +65,15 @@ async function generateConfigConstants() {
                 }
             }
         }
+    } catch (err) {
+        progress.fail("config", err)
+        process.exit(1)
+    }
+}
 
+async function generateConfigConstants() {
+    progress.start("config")
+    try {
         // Update ConfigConstants.swift
         const configOutputPath = path.join(PROJECT_DIR, PROJECT_NAME, "ConfigConstants.swift")
 
@@ -624,6 +630,7 @@ async function main() {
         progress.log("Starting build process from: " + originalDir, "info")
 
         await generateConfigConstants()
+        await updateInfoPlist()
 
         progress.log("Changing directory to: " + PROJECT_DIR, "info")
         process.chdir(PROJECT_DIR)


### PR DESCRIPTION
this PR adds support for https supported urls in ios webview. User can add the url to `NODE_SERVER_HOSTNAME` in `config.json`.