### PR TITLE
Add `appInfo` field to deviceInfo API

### DIFF
--- a/src/native/androidProject/app/src/main/java/io/yourname/androidproject/NativeBridge.kt
+++ b/src/native/androidProject/app/src/main/java/io/yourname/androidproject/NativeBridge.kt
@@ -268,7 +268,7 @@ class NativeBridge(
     fun getDeviceInfo(options: String?) {
         BridgeUtils.safeExecute(webView, BridgeUtils.WebEvents.ON_DEVICE_INFO_ERROR, "get device info") {
             mainActivity.runOnUiThread {
-                val deviceInfo = DeviceInfoUtils.getDeviceInfo(mainActivity)
+                val deviceInfo = DeviceInfoUtils.getDeviceInfo(mainActivity, properties)
                 BridgeUtils.logDebug(TAG, "Device info retrieved: $deviceInfo")
                 BridgeUtils.notifyWeb(webView, BridgeUtils.WebEvents.ON_DEVICE_INFO_SUCCESS, deviceInfo.toString())
             }

--- a/src/native/androidProject/app/src/main/java/io/yourname/androidproject/utils/DeviceInfoUtils.kt
+++ b/src/native/androidProject/app/src/main/java/io/yourname/androidproject/utils/DeviceInfoUtils.kt
@@ -6,13 +6,14 @@ import android.util.DisplayMetrics
 import android.view.WindowManager
 import org.json.JSONObject
 import io.yourname.androidproject.BuildConfig
+import java.util.Properties
 
 object DeviceInfoUtils {
     private const val TAG = "DeviceInfoUtils"
-    
-    fun getDeviceInfo(context: Context): JSONObject {
+
+    fun getDeviceInfo(context: Context, properties: Properties? = null): JSONObject {
         val deviceInfo = JSONObject()
-        
+
         try {
             // Basic device information
             deviceInfo.apply {
@@ -20,7 +21,7 @@ object DeviceInfoUtils {
                 put("manufacturer", Build.MANUFACTURER)
                 put("platform", "android")
             }
-            
+
             // Screen dimensions only
             val displayMetrics = getDisplayMetrics(context)
             deviceInfo.apply {
@@ -28,14 +29,18 @@ object DeviceInfoUtils {
                 put("screenHeight", displayMetrics.heightPixels)
                 put("screenDensity", displayMetrics.density.toDouble())
             }
-            
+
+            // Add appInfo from properties if available
+            val appInfo = properties?.getProperty("appInfo")
+            deviceInfo.put("appInfo", appInfo ?: JSONObject.NULL)
+
         } catch (e: Exception) {
             BridgeUtils.logError(TAG, "Error getting device info", e)
             return JSONObject().apply {
                 put("error", "Failed to get device info: ${e.message}")
             }
         }
-        
+
         return deviceInfo
     }
     

--- a/src/native/bridge/WebBridge.js
+++ b/src/native/bridge/WebBridge.js
@@ -286,6 +286,7 @@ class WebBridge {
                 screenWidth: "screenWidth",
                 screenHeight: "screenHeight",
                 screenDensity: "screenDensity",
+                appInfo: "appInfo",
             },
             ios: {
                 model: "model",
@@ -294,6 +295,7 @@ class WebBridge {
                 screenWidth: "screenWidth",
                 screenHeight: "screenHeight",
                 screenDensity: "screenDensity",
+                appInfo: "appInfo",
             },
         }
 

--- a/src/native/iosnativeWebView/iosnativeWebView/DeviceInfoUtils.swift
+++ b/src/native/iosnativeWebView/iosnativeWebView/DeviceInfoUtils.swift
@@ -25,7 +25,7 @@ class DeviceInfoUtils {
             let screen = UIScreen.main
 
             // Basic device information
-            let deviceInfo: [String: Any] = [
+            var deviceInfo: [String: Any] = [
                 "model": device.model,
                 "manufacturer": "Apple",
                 "platform": "ios",
@@ -35,6 +35,13 @@ class DeviceInfoUtils {
                 "screenHeight": Int(screen.bounds.height * screen.scale),
                 "screenDensity": screen.scale
             ]
+
+            // Add appInfo from ConfigConstants if available
+            if let appInfo = ConfigConstants.appInfo {
+                deviceInfo["appInfo"] = appInfo
+            } else {
+                deviceInfo["appInfo"] = NSNull()
+            }
 
             logger.debug("Device info retrieved successfully: \(deviceInfo.description)")
             return deviceInfo


### PR DESCRIPTION

  ## 📋 Summary

  Added support for a configurable `appInfo` string field in the deviceInfo API response. This allows apps to identify different builds by passing a custom identifier through the
  WebView configuration, which is then returned in the deviceInfo API call.

  ## 🎯 Motivation

  Need to distinguish between different builds of the same application (e.g., production vs staging, different client builds) by including build-specific metadata in the device
  information. This helps with:

  - Build identification and tracking
  - Environment-specific logic in web apps
  - Analytics and debugging per build variant

  ## 🔧 Changes

  ### Android (`src/native/androidProject/`)

  #### **DeviceInfoUtils.kt**
  - Added optional `properties: Properties?` parameter to `getDeviceInfo()`
  - Reads `appInfo` from properties and includes it in the device info JSON response
  - Returns `null` if `appInfo` is not configured

  #### **NativeBridge.kt**
  - Updated `getDeviceInfo()` to pass `properties` to `DeviceInfoUtils.getDeviceInfo()`

  ### iOS (`src/native/iosnativeWebView/`)

  #### **DeviceInfoUtils.swift**
  - Modified `getDeviceInfo()` to read `ConfigConstants.appInfo`
  - Includes `appInfo` in device info dictionary
  - Returns `NSNull()` if `appInfo` is not configured

  ### Web Bridge (`src/native/bridge/`)

  #### **WebBridge.js**
  - Added `appInfo` to `DEVICE_INFO_KEY_MAP` for both Android and iOS platforms
  - Ensures proper key mapping in `parseDeviceInfo()`

  ## 🏗️ Build System Integration

  The implementation leverages existing build system automation:

  - **Android**: `build.gradle.kts` `generateWebViewConfig` task automatically extracts `appInfo` from `config.json` to `webview_config.properties`
  - **iOS**: `buildAppIos.js` `generateConfigConstants()` automatically includes `appInfo` in `ConfigConstants.swift`

  ## 📖 Usage

  ### Configuration

  Add `appInfo` to `config/config.json`:

  ```json
  {
    "WEBVIEW_CONFIG": {
      "appInfo": "production-v1.2.3",
      "LOCAL_IP": "www.example.com",
      ...
    }
  }
```
  API Response

  The deviceInfo API now returns:
  ```json
  {
    "model": "iPhone 15 Pro",
    "manufacturer": "Apple",
    "platform": "ios",
    "screenWidth": 1179,
    "screenHeight": 2556,
    "screenDensity": 3,
    "appInfo": "production-v1.2.3"  // ← New field
  }
```
  Web App Integration

  const deviceInfo = await WebBridge.getDeviceInfo()
  console.log(deviceInfo.appInfo) // "production-v1.2.3" or null

  📝 Behavior

  | Property         | Value                    |
  |------------------|--------------------------|
  | Field Type       | Optional                 |
  | Default Value    | null when not configured |
  | Data Type        | String                   |
  | Platform Support | Android & iOS            |

  ✅ Testing

  - ✅ Android: DeviceInfoUtils properly reads from properties
  - ✅ iOS: DeviceInfoUtils properly reads from ConfigConstants
  - ✅ Web Bridge: Correctly parses and maps the appInfo field
  - ✅ Backward compatibility: Works without appInfo in config (returns null)

  🚨 Breaking Changes

  None. This is a backward-compatible addition.

  📁 Files Changed

  src/native/androidProject/app/src/main/java/io/yourname/androidproject/
  ├── utils/DeviceInfoUtils.kt
  └── NativeBridge.kt

  src/native/iosnativeWebView/iosnativeWebView/
  └── DeviceInfoUtils.swift

  src/native/bridge/
  └── WebBridge.js