### PR TITLE
Fix: Access Control Configuration Source for iOS

### DIFF
--- a/src/native/buildAppIos.js
+++ b/src/native/buildAppIos.js
@@ -515,8 +515,8 @@ public enum ConfigConstants {
         }
 
         // Add URL whitelisting configuration if it exists
-        if (iosConfig.accessControl) {
-            const accessControl = iosConfig.accessControl
+        if (WEBVIEW_CONFIG.accessControl) {
+            const accessControl = WEBVIEW_CONFIG.accessControl
 
             configContent += `
     public static let accessControlEnabled = ${accessControl.enabled || false}`


### PR DESCRIPTION
**Changes:**
- Updated iOS build process to read `accessControl` configuration from `WEBVIEW_CONFIG` instead of `iosConfig`

**Impact:**
- Ensures access control settings (URL whitelisting) are correctly applied from the webview configuration during iOS app build
- Fixes configuration mismatch that could lead to incorrect access control behavior

**Files Modified:**
- `src/native/buildAppIos.js`