### PR TITLE
Fix iOS camera preview controls issue with inline media playback config

### DIFF
--- a/src/native/bridge/useBaseHook.js
+++ b/src/native/bridge/useBaseHook.js
@@ -13,10 +13,7 @@ export const useBaseHook = (hookName) => {
     // Environment detection — live check at call time, never stale from SSR
     const isNative = useCallback(() => {
         if (typeof window === "undefined") return false
-        return !!(
-            window.WebBridge &&
-            (window.NativeBridge || window.webkit?.messageHandlers?.NativeBridge)
-        )
+        return !!(window.WebBridge && (window.NativeBridge || window.webkit?.messageHandlers?.NativeBridge))
     }, [])
 
     const isWeb = useCallback(() => {
@@ -184,7 +181,7 @@ export const useBaseHook = (hookName) => {
                 console.error(`❌ ${hookName} ${operationName} failed:`, err)
             }
         },
-        [hookName, isWeb, startProgress, handleNativeError]
+        [hookName, isWeb, startProgress, handleNativeError, isNative]
     )
 
     // Environment flags (computed values, not functions)

--- a/src/native/buildAppIos.js
+++ b/src/native/buildAppIos.js
@@ -682,6 +682,7 @@ public enum ConfigConstants {
                 if (addedKeys.has(key)) continue
 
                 configContent += "\n" + generateSwiftProperty(key, value)
+                addedKeys.add(key)
             }
         }
 
@@ -788,6 +789,13 @@ public enum ConfigConstants {
             addedKeys.add("edgeToEdge")
         } else {
             progress.log("EdgeToEdge config was processed from WEBVIEW_CONFIG", "info")
+        }
+
+        // Ensure inlineMediaPlaybackEnabled always exists (default to false if not configured)
+        if (!addedKeys.has("inlineMediaPlaybackEnabled")) {
+            progress.log("inlineMediaPlaybackEnabled not found in config, adding default (false)", "info")
+            configContent += "\n    public static let inlineMediaPlaybackEnabled = false"
+            addedKeys.add("inlineMediaPlaybackEnabled")
         }
 
         // Close the enum

--- a/src/native/iosnativeWebView/Sources/Core/Constants/ConfigConstants.swift
+++ b/src/native/iosnativeWebView/Sources/Core/Constants/ConfigConstants.swift
@@ -33,6 +33,7 @@ public enum ConfigConstants {
     }
 
     public static let useHttps = false
+    public static let inlineMediaPlaybackEnabled = false
 
     // iOS-specific configuration
     public static let appBundleId = "com.example.app"

--- a/src/native/iosnativeWebView/Sources/Core/Utils/WebKitConfig.swift
+++ b/src/native/iosnativeWebView/Sources/Core/Utils/WebKitConfig.swift
@@ -24,6 +24,7 @@ public enum WebKitConfig {
         } else {
             if legacyPrewarmedWebView == nil {
                 let configuration = WKWebViewConfiguration()
+                applyMediaPlaybackConfiguration(to: configuration)
                 configuration.processPool = sharedProcessPool
                 legacyPrewarmedWebView = WKWebView(frame: .zero, configuration: configuration)
                 logWithTimestamp("🔥 WebKit process pool prewarmed for legacy iOS versions")
@@ -38,6 +39,18 @@ public enum WebKitConfig {
             return
         } else {
             configuration.processPool = sharedProcessPool
+        }
+    }
+
+    /// Keep camera previews inline inside WKWebView instead of letting iOS treat
+    /// them like regular media playback with native transport controls.
+    public static func applyMediaPlaybackConfiguration(to configuration: WKWebViewConfiguration) {
+        configuration.allowsInlineMediaPlayback = true
+        configuration.allowsPictureInPictureMediaPlayback = false
+        configuration.allowsAirPlayForMediaPlayback = false
+
+        if #available(iOS 10.0, *) {
+            configuration.mediaTypesRequiringUserActionForPlayback = []
         }
     }
 }

--- a/src/native/iosnativeWebView/Sources/Core/Utils/WebKitConfig.swift
+++ b/src/native/iosnativeWebView/Sources/Core/Utils/WebKitConfig.swift
@@ -45,6 +45,10 @@ public enum WebKitConfig {
     /// Keep camera previews inline inside WKWebView instead of letting iOS treat
     /// them like regular media playback with native transport controls.
     public static func applyMediaPlaybackConfiguration(to configuration: WKWebViewConfiguration) {
+        guard ConfigConstants.inlineMediaPlaybackEnabled else {
+            return
+        }
+
         configuration.allowsInlineMediaPlayback = true
         configuration.allowsPictureInPictureMediaPlayback = false
         configuration.allowsAirPlayForMediaPlayback = false

--- a/src/native/iosnativeWebView/Sources/Core/WebView/WebView.swift
+++ b/src/native/iosnativeWebView/Sources/Core/WebView/WebView.swift
@@ -39,6 +39,7 @@ public struct WebView: UIViewRepresentable, Equatable {
 
         // Hook kept for legacy behavior; currently a no-op on iOS 15+.
         WebKitConfig.applySharedProcessPoolIfNeeded(to: configuration)
+        WebKitConfig.applyMediaPlaybackConfiguration(to: configuration)
 
         #if DEBUG
         configuration.preferences.setValue(true, forKey: "developerExtrasEnabled")


### PR DESCRIPTION
Added an opt-in iOS config flag, `WEBVIEW_CONFIG.ios.inlineMediaPlaybackEnabled`, to control the WKWebView media-playback settings that keep live camera/video previews inline and prevent iOS transport controls from appearing over camera feeds. The default remains false, so existing app behavior is unchanged unless the flag is explicitly enabled.