### PR TITLE
Add OpenTelemetry spans across SSR handler and extract pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,15 @@
                 "husky": "^9.0.11",
                 "lint-staged": "^15.2.2",
                 "prettier": "^3.2.5"
+            },
+            "peerDependencies": {
+                "@opentelemetry/auto-instrumentations-node": "^0.64.1",
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/exporter-trace-otlp-grpc": "^0.208.0",
+                "@opentelemetry/instrumentation-express": "^0.54.0",
+                "@opentelemetry/instrumentation-http": "^0.205.0",
+                "@opentelemetry/resources": "^2.0.0",
+                "@opentelemetry/sdk-node": "^0.205.0"
             }
         },
         "node_modules/@babel/cli": {
@@ -2115,6 +2124,37 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/@grpc/grpc-js": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+            "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+            "peer": true,
+            "dependencies": {
+                "@grpc/proto-loader": "^0.8.0",
+                "@js-sdsl/ordered-map": "^4.4.2"
+            },
+            "engines": {
+                "node": ">=12.10.0"
+            }
+        },
+        "node_modules/@grpc/proto-loader": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+            "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+            "peer": true,
+            "dependencies": {
+                "lodash.camelcase": "^4.3.0",
+                "long": "^5.0.0",
+                "protobufjs": "^7.5.3",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2197,6 +2237,16 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@js-sdsl/ordered-map": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+            "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+            "peer": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/js-sdsl"
             }
         },
         "node_modules/@leichtgewicht/ip-codec": {
@@ -2340,6 +2390,2853 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+            "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+            "peer": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/api-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.205.0.tgz",
+            "integrity": "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/auto-instrumentations-node": {
+            "version": "0.64.6",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.64.6.tgz",
+            "integrity": "sha512-8oIzHcEX5uEgJ/5hiStl7MhpPTLk8mywZPHIYWo5UiEiTkvc5uYjv/TyOGeiDhcjzo0nhvm7a6Y+eonq3m1sLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/instrumentation-amqplib": "^0.52.3",
+                "@opentelemetry/instrumentation-aws-lambda": "^0.57.2",
+                "@opentelemetry/instrumentation-aws-sdk": "^0.61.2",
+                "@opentelemetry/instrumentation-bunyan": "^0.51.4",
+                "@opentelemetry/instrumentation-cassandra-driver": "^0.51.3",
+                "@opentelemetry/instrumentation-connect": "^0.49.2",
+                "@opentelemetry/instrumentation-cucumber": "^0.21.2",
+                "@opentelemetry/instrumentation-dataloader": "^0.23.3",
+                "@opentelemetry/instrumentation-dns": "^0.49.2",
+                "@opentelemetry/instrumentation-express": "^0.54.3",
+                "@opentelemetry/instrumentation-fastify": "^0.50.3",
+                "@opentelemetry/instrumentation-fs": "^0.25.2",
+                "@opentelemetry/instrumentation-generic-pool": "^0.49.2",
+                "@opentelemetry/instrumentation-graphql": "^0.53.3",
+                "@opentelemetry/instrumentation-grpc": "^0.205.0",
+                "@opentelemetry/instrumentation-hapi": "^0.52.3",
+                "@opentelemetry/instrumentation-http": "^0.205.0",
+                "@opentelemetry/instrumentation-ioredis": "^0.53.3",
+                "@opentelemetry/instrumentation-kafkajs": "^0.15.3",
+                "@opentelemetry/instrumentation-knex": "^0.50.2",
+                "@opentelemetry/instrumentation-koa": "^0.54.2",
+                "@opentelemetry/instrumentation-lru-memoizer": "^0.50.3",
+                "@opentelemetry/instrumentation-memcached": "^0.49.3",
+                "@opentelemetry/instrumentation-mongodb": "^0.58.3",
+                "@opentelemetry/instrumentation-mongoose": "^0.52.3",
+                "@opentelemetry/instrumentation-mysql": "^0.51.3",
+                "@opentelemetry/instrumentation-mysql2": "^0.52.3",
+                "@opentelemetry/instrumentation-nestjs-core": "^0.52.2",
+                "@opentelemetry/instrumentation-net": "^0.49.2",
+                "@opentelemetry/instrumentation-oracledb": "^0.31.3",
+                "@opentelemetry/instrumentation-pg": "^0.58.3",
+                "@opentelemetry/instrumentation-pino": "^0.52.3",
+                "@opentelemetry/instrumentation-redis": "^0.54.4",
+                "@opentelemetry/instrumentation-restify": "^0.51.2",
+                "@opentelemetry/instrumentation-router": "^0.50.2",
+                "@opentelemetry/instrumentation-runtime-node": "^0.19.2",
+                "@opentelemetry/instrumentation-socket.io": "^0.52.3",
+                "@opentelemetry/instrumentation-tedious": "^0.24.3",
+                "@opentelemetry/instrumentation-undici": "^0.16.2",
+                "@opentelemetry/instrumentation-winston": "^0.50.2",
+                "@opentelemetry/resource-detector-alibaba-cloud": "^0.31.8",
+                "@opentelemetry/resource-detector-aws": "^2.5.3",
+                "@opentelemetry/resource-detector-azure": "^0.13.2",
+                "@opentelemetry/resource-detector-container": "^0.7.8",
+                "@opentelemetry/resource-detector-gcp": "^0.40.3",
+                "@opentelemetry/resources": "^2.0.0",
+                "@opentelemetry/sdk-node": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.4.1",
+                "@opentelemetry/core": "^2.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/context-async-hooks": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.1.0.tgz",
+            "integrity": "sha512-zOyetmZppnwTyPrt4S7jMfXiSX9yyfF0hxlA8B5oo2TtKl+/RGCy7fi4DrBfIf3lCPrkKsRBWZZD7RFojK7FDg==",
+            "peer": true,
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/core": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+            "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.205.0.tgz",
+            "integrity": "sha512-jQlw7OHbqZ8zPt+pOrW2KGN7T55P50e3NXBMr4ckPOF+DWDwSy4W7mkG09GpYWlQAQ5C9BXg5gfUlv5ldTgWsw==",
+            "peer": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0",
+                "@opentelemetry/sdk-logs": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-AeuLfrciGYffqsp4EUTdYYc6Ee2BQS+hr08mHZk1C524SFWx0WnfcTnV0NFXbVURUNU6DZu1DhS89zRRrcx/hg==",
+            "peer": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+            "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+            "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.205.0.tgz",
+            "integrity": "sha512-5JteMyVWiro4ghF0tHQjfE6OJcF7UBUcoEqX3UIQ5jutKP1H+fxFdyhqjjpmeHMFxzOHaYuLlNR1Bn7FOjGyJg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0",
+                "@opentelemetry/sdk-logs": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+            "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+            "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.205.0.tgz",
+            "integrity": "sha512-q3VS9wS+lpZ01txKxiDGBtBpTNge3YhbVEFDgem9ZQR9eI3EZ68+9tVZH9zJcSxI37nZPJ6lEEZO58yEjYZsVA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+            "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+            "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.205.0.tgz",
+            "integrity": "sha512-1Vxlo4lUwqSKYX+phFkXHKYR3DolFHxCku6lVMP1H8sVE3oj4wwmwxMzDsJ7zF+sXd8M0FCr+ckK4SnNNKkV+w==",
+            "peer": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.205.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-metrics": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-AeuLfrciGYffqsp4EUTdYYc6Ee2BQS+hr08mHZk1C524SFWx0WnfcTnV0NFXbVURUNU6DZu1DhS89zRRrcx/hg==",
+            "peer": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+            "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+            "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.205.0.tgz",
+            "integrity": "sha512-fFxNQ/HbbpLmh1pgU6HUVbFD1kNIjrkoluoKJkh88+gnmpFD92kMQ8WFNjPnSbjg2mNVnEkeKXgCYEowNW+p1w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-metrics": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+            "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+            "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.205.0.tgz",
+            "integrity": "sha512-qIbNnedw9QfFjwpx4NQvdgjK3j3R2kWH/2T+7WXAm1IfMFe9fwatYxE61i7li4CIJKf8HgUC3GS8Du0C3D+AuQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.205.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-metrics": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+            "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+            "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-prometheus": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.205.0.tgz",
+            "integrity": "sha512-xsot/Qm9VLDTag4GEwAunD1XR1U8eBHTLAgO7IZNo2JuD/c/vL7xmDP7mQIUr6Lk3gtj/yGGIR2h3vhTeVzv4w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-metrics": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.208.0.tgz",
+            "integrity": "sha512-E/eNdcqVUTAT7BC+e8VOw/krqb+5rjzYkztMZ/o+eyJl+iEY6PfczPXpwWuICwvsm0SIhBoh9hmYED5Vh5RwIw==",
+            "peer": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/otlp-exporter-base": "0.208.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.208.0",
+                "@opentelemetry/otlp-transformer": "0.208.0",
+                "@opentelemetry/resources": "2.2.0",
+                "@opentelemetry/sdk-trace-base": "2.2.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.205.0.tgz",
+            "integrity": "sha512-vr2bwwPCSc9u7rbKc74jR+DXFvyMFQo9o5zs+H/fgbK672Whw/1izUKVf+xfWOdJOvuwTnfWxy+VAY+4TSo74Q==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+            "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+            "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.205.0.tgz",
+            "integrity": "sha512-bGtFzqiENO2GpJk988mOBMe0MfeNpTQjbLm/LBijas6VRyEDQarUzdBHpFlu89A25k1+BCntdWGsWTa9Ai4FyA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+            "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+            "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.1.0.tgz",
+            "integrity": "sha512-0mEI0VDZrrX9t5RE1FhAyGz+jAGt96HSuXu73leswtY3L5YZD11gtcpARY2KAx/s6Z2+rj5Mhj566JsI2C7mfA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.205.0.tgz",
+            "integrity": "sha512-cgvm7tvQdu9Qo7VurJP84wJ7ZV9F6WqDDGZpUc6rUEXwjV7/bXWs0kaYp9v+1Vh1+3TZCD3i6j/lUBcPhu8NhA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-amqplib": {
+            "version": "0.52.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.52.3.tgz",
+            "integrity": "sha512-QlAPNC4lsZ5v1Xy62gRrSk1ow5Bmdm1BDIwiuDUkRjsQ+LjtLfoI5mwGSn6fASYKHqNRBDrYXX4ibmiD/PqNHA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-aws-lambda": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.57.2.tgz",
+            "integrity": "sha512-yT9nUUDW7K0HSXihfhUbMk4sULA4VRqFGCfTGdqTFQ01lS5EMUUscDxCq4DCD3ZFMbK9wwbZxURxdm94x7YkZA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "@types/aws-lambda": "8.10.152"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-aws-sdk": {
+            "version": "0.61.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.61.2.tgz",
+            "integrity": "sha512-5tzZ9hcgAx4j+7st9i3pUcmQduRa94gFZGhRRsIQFbH07nIJ1SNwJFMC6WoQ/+WQkwaK/aF5Qw5LS0J+mrI+yg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.34.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-bunyan": {
+            "version": "0.51.4",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.51.4.tgz",
+            "integrity": "sha512-SObxTjC8l/FcxNitNy/+NT1xBEwCXIZkg8CPRMu3f1Q3a095ee89Z3dHInSj/DWZnxH8hUxAhMU+rG3dIuYgkA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "^0.205.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@types/bunyan": "1.8.11"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
+            "version": "0.51.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.51.3.tgz",
+            "integrity": "sha512-ICwlV29HFQO/vbDw+f1H65+OKkktsHS7huRO430l9q4AE/gGXcaepypwN8QHs0/gX2PFWovVQ7Dw4Rml/4Y86g==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-connect": {
+            "version": "0.49.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.49.2.tgz",
+            "integrity": "sha512-e0Yhz4Q3qb99kqosdNm1OAG1zlswqnTnsBl7wc/p6al6bdaEMSPbSME8pbaKltvHeW0RnmXVvOzu9OD4shvl+Q==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "@types/connect": "3.4.38"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-cucumber": {
+            "version": "0.21.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.21.2.tgz",
+            "integrity": "sha512-G9fiMEmNb1icrRZOTobqEoUNfyoa2qwkABPAhyGWZt290jHfXWPBI2baGhZKsR00Y+X1HGzn12J536acbubqlw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-dataloader": {
+            "version": "0.23.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.23.3.tgz",
+            "integrity": "sha512-DUxM3tsOxuxA12BFzYHgcuRfI885iiI+VptGe3v0uE16hmVeOB7DiVetoOfpPSke/ePtVHmFAR4fgfDuI93ugQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-dns": {
+            "version": "0.49.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.49.2.tgz",
+            "integrity": "sha512-J4gyDoXR5s35O0iG/eOZUz3Iu6twFxYiPD5kAI1fAOmkSB60oRjJseOSd9L5UBS5ghD1kTRh9VEIek6PP2w5Gw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-express": {
+            "version": "0.54.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.54.3.tgz",
+            "integrity": "sha512-bJeZ5Mtt7medH7i2iTbLdWUKdtrhllJh4Wzf7lonE2VyTxRt848hXn+ZsCjgvtPXCIH5pVF0bgtMCwpI1z+01A==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-fastify": {
+            "version": "0.50.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.50.3.tgz",
+            "integrity": "sha512-ZLKIIx+zz7qpoeBlzOENks4u0rjysICIYGXjhyFpS/Jjo5b17FLL3ULACGq0ApCRC+ruVR0Hb2OGyqlVE7oEEQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-fs": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.25.2.tgz",
+            "integrity": "sha512-KA2Yw7xQPNbRooZvZ7K/zwYG1kshrXEfI6uCTgTJ/hs357kYVIulXYZ8Q65Dkccd0PGzQJ/e4YFx8RW4gQT9WQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-generic-pool": {
+            "version": "0.49.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.49.2.tgz",
+            "integrity": "sha512-mh32irpVMxWiaHld+Xfuje6uCE1HNJgVKi1w0OBp/Y1WnkGS2E6sDVcWujqX2UnEMmJj5+WYHJBXJJqFVgF8LA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-graphql": {
+            "version": "0.53.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.53.3.tgz",
+            "integrity": "sha512-18PAQESPdHIGs0lvaVdPp2D1tLcQezbxIGGUS3eNszfWRDxfqE/XCcCOyJKSrhBw1djuvE+KVf9ej/DVyV28SQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-grpc": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.205.0.tgz",
+            "integrity": "sha512-IB5eKpb/7/x+tyWUVIIyY5KcAtODy/YbcDKPdnlJl8sMCFPByjNxti/lzOfPajYBPOXsN91g7H7cN0L1aSlerQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-hapi": {
+            "version": "0.52.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.52.3.tgz",
+            "integrity": "sha512-r/9ysT/Fksq4dvJ1DBKcBQ/5Ah8mMxwcsAFxtuRso20tXSGrM9BYKquK8eY7jKvNpfIc5xMRJMhuAD4/NviZdQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-http": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.205.0.tgz",
+            "integrity": "sha512-6fOgRlV7ypBuEzCQP7vXkLQxz3UL1FhE24rAlMRbwGvPAnZLvutcG/fq9FI/n+VU23dOpYexocYsXCf5oy/AXw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/instrumentation": "0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0",
+                "forwarded-parse": "2.1.2"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-ioredis": {
+            "version": "0.53.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.53.3.tgz",
+            "integrity": "sha512-afCzr4OSHWDfvVRx5ni92zEgNPoq2akoe+/nubWkGPKHFLsJwYO/ihAaky1i6m9d3tBO571g9rlnUvDlvoKSoQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/redis-common": "^0.38.2"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-kafkajs": {
+            "version": "0.15.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.15.3.tgz",
+            "integrity": "sha512-2HnNz6kDkuCjiZQHM7lCarzCs8uCMqrr04mhEgDLNDha0Dy341NjDTlWbgtNWNuN5vYeIP8/8g6iw0Ann22DbA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.30.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-knex": {
+            "version": "0.50.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.50.2.tgz",
+            "integrity": "sha512-pSQHrJFNpAs/FPam3FCp+aCWSjiaK4BpnXm70W0q6+T5IvkTVkRWFye80pw1zS4JRMh93U3OcJoKwP1M6nL62A==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.33.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-koa": {
+            "version": "0.54.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.54.2.tgz",
+            "integrity": "sha512-xJrP3ayEE4bY9kr7eHvi2P2rou9O+ALUTUo+TcJj2wEp1LFpucY87UyHJrmiJ6proGVgbbDgXJsxn7a5G0ABRA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.36.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.9.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+            "version": "0.50.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.50.3.tgz",
+            "integrity": "sha512-6Y2mL7Wk36lspfdOBST3vQQi1grXHvieeAd18LPtljyzCI5gCr6wBKp2Bpj82lMOYZ/O6w8gqIJMv0KjC6ZfSA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-memcached": {
+            "version": "0.49.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.49.3.tgz",
+            "integrity": "sha512-TfK46vWMVc7o5a2QyC64P6HCTdaPuxEIEhtDUWRGSlK0grZp8BKyTXy5kpMD8u7+azzhEmyrHjkm95ld38CuDg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@types/memcached": "^2.2.6"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mongodb": {
+            "version": "0.58.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.58.3.tgz",
+            "integrity": "sha512-19MwzolRIceDoZ4LPl2S0h2eI/8nLdA50Bqz6ERF4Uhk5ZUZO5aHNmsIpjJF+zxvXX3Gsa5A8WK0hm5nO5Ng7w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mongoose": {
+            "version": "0.52.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.52.3.tgz",
+            "integrity": "sha512-dieUbMnfwqxR8nNZyr21zFuYJs5zDu7E9uODjowg6ftK14bY638ryDhc2W4Gc4Z89PlxoUkCHunViXQBG6Q0Ew==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mysql": {
+            "version": "0.51.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.51.3.tgz",
+            "integrity": "sha512-wHvyPQayIF4tqWpgwALnQAj/aTgTD7GOSEvA4PQZFvqYrUtnWXQ4df9NspLikhH3C8girq3c4s2UGk39LDL3tw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@types/mysql": "2.15.27"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mysql2": {
+            "version": "0.52.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.52.3.tgz",
+            "integrity": "sha512-LhAl41NORbYimktfOMYOXJ483YYjL4OsjA9psRDshX56JOhQL/oL88LZbR+Jx4lEnOKMvrKk3VLqBZLa4KPIrA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/sql-common": "^0.41.2"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-nestjs-core": {
+            "version": "0.52.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.52.2.tgz",
+            "integrity": "sha512-kL91hPGEjUI08VcDJeNwYKP2EpynAnymF0wr4Irqp5uHeyvE/hTX4R3DmpDP80IZ/aQ5WVxuWiaBlVP7cERu/w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.30.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-net": {
+            "version": "0.49.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.49.2.tgz",
+            "integrity": "sha512-rfFpCIxDMMSeUKVg3xCyGGfAANxNP4BHqFAcChWDbFSL8Y9a9ztqR7TPidKgiLb+fbKfrr9ZupwdMeKJH+zsOA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-oracledb": {
+            "version": "0.31.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-oracledb/-/instrumentation-oracledb-0.31.3.tgz",
+            "integrity": "sha512-8lxYujVWhR+bRUGCZZFTEslRKQOlpjm27wIJvsk3e7Yb1s8g5PMQqUr+7U4hPGJX+GpvF4qszJZe6lX/6pfzbg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "@types/oracledb": "6.5.2"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-pg": {
+            "version": "0.58.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.58.3.tgz",
+            "integrity": "sha512-eGyrTHDx3WA9JiCbBQO1OUc8B9InqCJvC87uY1hSuOXU6HtawCEml1epuAVQY3cizK7Tc3IH0EYSR/q4w/kHyw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.34.0",
+                "@opentelemetry/sql-common": "^0.41.2",
+                "@types/pg": "8.15.5",
+                "@types/pg-pool": "2.0.6"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-pino": {
+            "version": "0.52.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.52.3.tgz",
+            "integrity": "sha512-GPFxhqgmW7wNdwq5rGu8vA/YswUdF84m3p00cH12S8rb9MVKUdNdPlUROO85xE0O0yI1yfNkRzZ+l0R4iZIOrg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "^0.205.0",
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-redis": {
+            "version": "0.54.4",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.54.4.tgz",
+            "integrity": "sha512-/XBICeY+tYZ04YNX6R2UKBgjCqj+xeLUKGJrbu8r4fGHV+hMsjLH9754xtdpuay1fecE7neCu4dX3Fr1NLWIEQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/redis-common": "^0.38.2",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-restify": {
+            "version": "0.51.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.51.2.tgz",
+            "integrity": "sha512-B4LMIDdgIpQw73J1qNoBRnhmvwS/gqnpzCwcddHv0zGNbK/+RntTEFRAZ8erfRYK/Kaz77DqmeoeCTHxatIoqw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-router": {
+            "version": "0.50.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.50.2.tgz",
+            "integrity": "sha512-S0+ZL5cmV4FuCkJq70Ar6pnAHVbSmRH8BziUJ3PIeLKTsx193XKZeHDSo27841GFsrNF7VVWnFEbnYxhynn/MQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-runtime-node": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.19.2.tgz",
+            "integrity": "sha512-sMDfMY5Be0HfK84bEN0M+FgGpyswfP6N90AGyZO3wK14DfvOQ542AWwyHos5vvpRFzDBm57y7OMqyaH//o9jDg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-socket.io": {
+            "version": "0.52.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.52.3.tgz",
+            "integrity": "sha512-Ryy1FJ9EnHjj9HUcLIoIZNqJkq1B4+78sCBBb3IMylzAS+IVdojz7K/9bwHDj4o+o1oHo/G337ML71ZY/Q4krw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-tedious": {
+            "version": "0.24.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.24.3.tgz",
+            "integrity": "sha512-3qVIWFQ0R0EkGU6zIX/jhKFDU2QirLSR5Z44RIcRHw4rDgrpwujoz46moDqvKHysPTA7vMTsHEzg5bP6dgok3w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@types/tedious": "^4.0.14"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-undici": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.16.2.tgz",
+            "integrity": "sha512-JU0TOlwK472KxJl+4Gnf0H7UkZMZJtombC0x1D3dZ6BjES3teOzUEOvupifHmLSgZ7dlMvEK8xBMz5D2La0N5g==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.205.0",
+                "@opentelemetry/semantic-conventions": "^1.24.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.7.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-winston": {
+            "version": "0.50.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.50.2.tgz",
+            "integrity": "sha512-vrS7ozNmB+S3v6z9vyFZXPXQ8ygTdWA9alPnEc10JYupvN1YRKQNspSRkx12dsrqsbkbybo/Dk9SFdbhKGrpeg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "^0.205.0",
+                "@opentelemetry/instrumentation": "^0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+            "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/otlp-transformer": "0.208.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.208.0.tgz",
+            "integrity": "sha512-fGvAg3zb8fC0oJAzfz7PQppADI2HYB7TSt/XoCaBJFi1mSquNUjtHXEoviMgObLAa1NRIgOC1lsV1OUKi+9+lQ==",
+            "peer": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/otlp-exporter-base": "0.208.0",
+                "@opentelemetry/otlp-transformer": "0.208.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+            "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.208.0",
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/resources": "2.2.0",
+                "@opentelemetry/sdk-logs": "0.208.0",
+                "@opentelemetry/sdk-metrics": "2.2.0",
+                "@opentelemetry/sdk-trace-base": "2.2.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+            "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-b3": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.1.0.tgz",
+            "integrity": "sha512-yOdHmFseIChYanddMMz0mJIFQHyjwbNhoxc65fEAA8yanxcBPwoFDoh1+WBUWAO/Z0NRgk+k87d+aFIzAZhcBw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.1.0.tgz",
+            "integrity": "sha512-QYo7vLyMjrBCUTpwQBF/e+rvP7oGskrSELGxhSvLj5gpM0az9oJnu/0O4l2Nm7LEhAff80ntRYKkAcSwVgvSVQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/redis-common": {
+            "version": "0.38.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
+            "integrity": "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==",
+            "peer": true,
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
+            "version": "0.31.11",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.31.11.tgz",
+            "integrity": "sha512-R/asn6dAOWMfkLeEwqHCUz0cNbb9oiHVyd11iwlypeT/p9bR1lCX5juu5g/trOwxo62dbuFcDbBdKCJd3O2Edg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/resources": "^2.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-aws": {
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-2.15.0.tgz",
+            "integrity": "sha512-+aiEkI+JA94XVIJtltt3XKYbLSaHRqHFdvGOwulBpfNKtEIWDEkKm3qfTl7Q0q9gY9621oXMU1sT5MM7koCnyA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/resources": "^2.0.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-azure": {
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.13.2.tgz",
+            "integrity": "sha512-YdRHZHdyDh6QcCkMK3eL/Nf0erN7xrz2TFRhN/DUAPaAzg0fECmq555B4lcxPsK9NeZajVOBvHu3z95ZAKYFdw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/resources": "^2.0.0",
+                "@opentelemetry/semantic-conventions": "^1.37.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-container": {
+            "version": "0.7.11",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.7.11.tgz",
+            "integrity": "sha512-XUxnGuANa/EdxagipWMXKYFC7KURwed9/V0+NtYjFmwWHzV9/J4IYVGTK8cWDpyUvAQf/vE4sMa3rnS025ivXQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/resources": "^2.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/resource-detector-gcp": {
+            "version": "0.40.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.40.3.tgz",
+            "integrity": "sha512-C796YjBA5P1JQldovApYfFA/8bQwFfpxjUbOtGhn1YZkVTLoNQN+kvBwgALfTPWzug6fWsd0xhn9dzeiUcndag==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/resources": "^2.0.0",
+                "gcp-metadata": "^6.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+            "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.7.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+            "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.208.0",
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/resources": "2.2.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
+            "version": "0.208.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+            "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+            "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/resources": "2.2.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.205.0.tgz",
+            "integrity": "sha512-Y4Wcs8scj/Wy1u61pX1ggqPXPtCsGaqx/UnFu7BtRQE1zCQR+b0h56K7I0jz7U2bRlPUZIFdnNLtoaJSMNzz2g==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/exporter-logs-otlp-grpc": "0.205.0",
+                "@opentelemetry/exporter-logs-otlp-http": "0.205.0",
+                "@opentelemetry/exporter-logs-otlp-proto": "0.205.0",
+                "@opentelemetry/exporter-metrics-otlp-grpc": "0.205.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.205.0",
+                "@opentelemetry/exporter-metrics-otlp-proto": "0.205.0",
+                "@opentelemetry/exporter-prometheus": "0.205.0",
+                "@opentelemetry/exporter-trace-otlp-grpc": "0.205.0",
+                "@opentelemetry/exporter-trace-otlp-http": "0.205.0",
+                "@opentelemetry/exporter-trace-otlp-proto": "0.205.0",
+                "@opentelemetry/exporter-zipkin": "2.1.0",
+                "@opentelemetry/instrumentation": "0.205.0",
+                "@opentelemetry/propagator-b3": "2.1.0",
+                "@opentelemetry/propagator-jaeger": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "@opentelemetry/sdk-trace-node": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.205.0.tgz",
+            "integrity": "sha512-ZBksUk84CcQOuDJB65yu5A4PORkC4qEsskNwCrPZxDLeWjPOFZNSWt0E0jQxKCY8PskLhjNXJYo12YaqsYvGFA==",
+            "peer": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.205.0.tgz",
+            "integrity": "sha512-AeuLfrciGYffqsp4EUTdYYc6Ee2BQS+hr08mHZk1C524SFWx0WnfcTnV0NFXbVURUNU6DZu1DhS89zRRrcx/hg==",
+            "peer": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/otlp-exporter-base": "0.205.0",
+                "@opentelemetry/otlp-transformer": "0.205.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
+            "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/sdk-logs": "0.205.0",
+                "@opentelemetry/sdk-metrics": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.205.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+            "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.205.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+            "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+            "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/resources": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.2.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.1.0.tgz",
+            "integrity": "sha512-SvVlBFc/jI96u/mmlKm86n9BbTCbQ35nsPoOohqJX6DXH92K0kTe73zGY5r8xoI1QkjR9PizszVJLzMC966y9Q==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/context-async-hooks": "2.1.0",
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/sdk-trace-base": "2.1.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+            "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+            "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.1.0",
+                "@opentelemetry/resources": "2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+            "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+            "peer": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/sql-common": {
+            "version": "0.41.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+            "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.1.0"
+            }
+        },
         "node_modules/@parcel/watcher": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
@@ -2458,6 +5355,70 @@
             "version": "1.0.0-next.29",
             "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
             "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="
+        },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+            "peer": true
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "peer": true
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "peer": true
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "peer": true
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "peer": true,
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+            "peer": true
+        },
+        "node_modules/@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+            "peer": true
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+            "peer": true
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+            "peer": true
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+            "peer": true
         },
         "node_modules/@remix-run/router": {
             "version": "1.23.1",
@@ -2797,6 +5758,12 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/@types/aws-lambda": {
+            "version": "8.10.152",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.152.tgz",
+            "integrity": "sha512-soT/c2gYBnT5ygwiHPmd9a1bftj462NWVk2tKCc1PYHSIacB2UwbTS2zYG4jzag1mRDuzg/OjtxQjQ2NKRB6Rw==",
+            "peer": true
+        },
         "node_modules/@types/body-parser": {
             "version": "1.19.6",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -2810,6 +5777,15 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
             "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/bunyan": {
+            "version": "1.8.11",
+            "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.11.tgz",
+            "integrity": "sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2925,10 +5901,28 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
         },
+        "node_modules/@types/memcached": {
+            "version": "2.2.10",
+            "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
+            "integrity": "sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/mime": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+        },
+        "node_modules/@types/mysql": {
+            "version": "2.15.27",
+            "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+            "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/node": {
             "version": "25.0.3",
@@ -2944,6 +5938,35 @@
             "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/oracledb": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@types/oracledb/-/oracledb-6.5.2.tgz",
+            "integrity": "sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/pg": {
+            "version": "8.15.5",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+            "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*",
+                "pg-protocol": "*",
+                "pg-types": "^2.2.0"
+            }
+        },
+        "node_modules/@types/pg-pool": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+            "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+            "peer": true,
+            "dependencies": {
+                "@types/pg": "*"
             }
         },
         "node_modules/@types/prop-types": {
@@ -3016,6 +6039,15 @@
             "version": "0.3.36",
             "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
             "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/tedious": {
+            "version": "4.0.14",
+            "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+            "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -3269,6 +6301,15 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/acorn-import-attributes": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+            "peer": true,
+            "peerDependencies": {
+                "acorn": "^8"
+            }
+        },
         "node_modules/acorn-import-phases": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
@@ -3298,6 +6339,15 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "peer": true,
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -3383,7 +6433,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3780,6 +6829,15 @@
                 "node": "*"
             }
         },
+        "node_modules/bignumber.js": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+            "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+            "peer": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4064,6 +7122,12 @@
                 "node": ">=6.0"
             }
         },
+        "node_modules/cjs-module-lexer": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "peer": true
+        },
         "node_modules/clean-css": {
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -4118,7 +7182,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.1",
@@ -4132,7 +7195,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -4147,7 +7209,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -4158,20 +7219,17 @@
         "node_modules/cliui/node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/cliui/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "node_modules/cliui/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4180,7 +7238,6 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -4194,7 +7251,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -6057,6 +9113,12 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "peer": true
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6400,6 +9462,12 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/forwarded-parse": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+            "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+            "peer": true
+        },
         "node_modules/fresh": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -6471,6 +9539,61 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/gaxios": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "peer": true,
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "is-stream": "^2.0.0",
+                "node-fetch": "^2.6.9",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/gaxios/node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/gaxios/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "peer": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/gcp-metadata": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+            "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+            "peer": true,
+            "dependencies": {
+                "gaxios": "^6.1.1",
+                "google-logging-utils": "^0.0.2",
+                "json-bigint": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/generator-function": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -6491,7 +9614,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
@@ -6699,6 +9821,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/google-logging-utils": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+            "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+            "peer": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/gopd": {
@@ -7065,6 +10196,19 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
         },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "peer": true,
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/human-signals": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -7235,6 +10379,18 @@
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/import-in-the-middle": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+            "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+            "peer": true,
+            "dependencies": {
+                "acorn": "^8.14.0",
+                "acorn-import-attributes": "^1.9.5",
+                "cjs-module-lexer": "^1.2.2",
+                "module-details-from-path": "^1.0.3"
             }
         },
         "node_modules/import-local": {
@@ -7951,6 +11107,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/json-bigint": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+            "peer": true,
+            "dependencies": {
+                "bignumber.js": "^9.0.0"
+            }
+        },
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -8189,8 +11354,7 @@
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-            "dev": true
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
         },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
@@ -8356,6 +11520,12 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
+        },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "peer": true
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
@@ -8600,6 +11770,12 @@
             "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
             "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q=="
         },
+        "node_modules/module-details-from-path": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+            "peer": true
+        },
         "node_modules/moment": {
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -8699,6 +11875,26 @@
             "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "bin": {
                 "semver": "bin/semver"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "peer": true,
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/node-forge": {
@@ -9215,6 +12411,37 @@
                 "url": "https://github.com/sponsors/Borewit"
             }
         },
+        "node_modules/pg-int8": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+            "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+            "peer": true,
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/pg-protocol": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+            "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+            "peer": true
+        },
+        "node_modules/pg-types": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+            "peer": true,
+            "dependencies": {
+                "pg-int8": "1.0.1",
+                "postgres-array": "~2.0.0",
+                "postgres-bytea": "~1.0.0",
+                "postgres-date": "~1.0.4",
+                "postgres-interval": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9523,6 +12750,45 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         },
+        "node_modules/postgres-array": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postgres-bytea": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+            "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postgres-date": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+            "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postgres-interval": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+            "peer": true,
+            "dependencies": {
+                "xtend": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9577,6 +12843,30 @@
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
                 "react-is": "^16.13.1"
+            }
+        },
+        "node_modules/protobufjs": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+            "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+            "hasInstallScript": true,
+            "peer": true,
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/node": ">=13.7.0",
+                "long": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/proxy-addr": {
@@ -9994,7 +13284,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10005,6 +13294,20 @@
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-in-the-middle": {
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+            "peer": true,
+            "dependencies": {
+                "debug": "^4.3.5",
+                "module-details-from-path": "^1.0.3",
+                "resolve": "^1.22.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
             }
         },
         "node_modules/requires-port": {
@@ -11120,7 +14423,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -11384,6 +14686,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "peer": true
         },
         "node_modules/triple-beam": {
             "version": "1.4.1",
@@ -11830,6 +15138,12 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "peer": true
+        },
         "node_modules/webpack": {
             "version": "5.104.1",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
@@ -12120,6 +15434,16 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "peer": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -12386,11 +15710,19 @@
                 }
             }
         },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -12419,7 +15751,6 @@
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -12437,7 +15768,6 @@
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
             "engines": {
                 "node": ">=12"
             }
@@ -12445,14 +15775,12 @@
         "node_modules/yargs/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "node_modules/yargs/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -12461,7 +15789,6 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,15 @@
         "winston": "^3.11.0",
         "winston-daily-rotate-file": "^5.0.0"
     },
+    "peerDependencies": {
+        "@opentelemetry/auto-instrumentations-node": "^0.64.1",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.208.0",
+        "@opentelemetry/instrumentation-express": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.205.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-node": "^0.205.0"
+    },
     "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",
         "@commitlint/cli": "^19.3.0",

--- a/src/otel.js
+++ b/src/otel.js
@@ -3,9 +3,13 @@ import { NodeSDK } from "@opentelemetry/sdk-node"
 import { resourceFromAttributes } from "@opentelemetry/resources"
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-node"
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics"
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
-import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http"
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc"
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-grpc"
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node"
+import { TraceIdRatioBasedSampler, ParentBasedSampler } from "@opentelemetry/sdk-trace-node"
+import { OTLPTraceExporter as OTLPTraceExporterHTTP } from "@opentelemetry/exporter-trace-otlp-http"
+import { OTLPMetricExporter as OTLPMetricExporterHTTP } from "@opentelemetry/exporter-metrics-otlp-http"
+import { trace } from "@opentelemetry/api"
 
 import {
     ATTR_SERVICE_NAME,
@@ -18,48 +22,63 @@ function init(config = {}) {
         serviceName = "catalyst-server",
         serviceVersion = "1.0.0",
         environment = "development",
-        traceUrl = "http://localhost:4318/v1/traces",
-        metricUrl = "http://localhost:4318/v1/metrics",
+        traceUrl = "http://localhost:4317",
+        metricUrl = "http://localhost:4317",
+        traceProtocol = "grpc", // "grpc" or "http"
+        metricProtocol, // "grpc" or "http" - if not provided, metrics will be disabled
         traceHeaders = {},
         metricHeaders = {},
+        batchProcessorConfig = {},
         exportIntervalMillis = 10000,
-        exportTimeoutMillis = 10000,
+        instrumentations,
+        samplingRate = 1.0,
+        grpcCredentials,
     } = config
 
     try {
-        const otlpTraceExporter = new OTLPTraceExporter({
-            url: traceUrl,
-            headers: traceHeaders,
+        const otlpTraceExporter = createTraceExporter(traceProtocol, traceUrl, traceHeaders, grpcCredentials)
+
+        // Create metric exporter only if metricProtocol is specified
+        let otlpMetricExporter = null
+        let metricReader = null
+        if (metricProtocol) {
+            otlpMetricExporter = createMetricExporter(metricProtocol, metricUrl, metricHeaders, grpcCredentials)
+            metricReader = new PeriodicExportingMetricReader({
+                exporter: otlpMetricExporter,
+                exportIntervalMillis,
+            })
+        }
+
+        const sampler = new ParentBasedSampler({
+            root: new TraceIdRatioBasedSampler(samplingRate),
         })
 
-        const otlpMetricExporter = new OTLPMetricExporter({
-            url: metricUrl,
-            headers: metricHeaders,
-        })
-
-        const sdk = new NodeSDK({
+        const sdkConfig = {
             resource: resourceFromAttributes({
                 [ATTR_SERVICE_NAME]: serviceName,
                 [ATTR_SERVICE_VERSION]: serviceVersion,
                 [ATTR_DEPLOYMENT_ENVIRONMENT]: environment,
             }),
-            spanProcessor: new BatchSpanProcessor(otlpTraceExporter, {
-                exportTimeoutMillis,
-                scheduledDelayMillis: exportIntervalMillis,
-                maxQueueSize: 100,
-                maxExportBatchSize: 10,
-            }),
-            metricReader: new PeriodicExportingMetricReader({
-                exporter: otlpMetricExporter,
-                exportIntervalMillis,
-            }),
-            instrumentations: [getNodeAutoInstrumentations()],
-        })
+            spanProcessor: new BatchSpanProcessor(otlpTraceExporter, batchProcessorConfig),
+            instrumentations: instrumentations ?? [getNodeAutoInstrumentations()],
+            sampler,
+        }
+
+        // Add metric reader only if metrics are enabled
+        if (metricReader) {
+            sdkConfig.metricReader = metricReader
+        }
+
+        const sdk = new NodeSDK(sdkConfig)
 
         sdk.start()
         logger.info("✅ OpenTelemetry started successfully")
 
-        const meter = initializeCustomMetrics(serviceName, serviceVersion)
+        // Initialize custom metrics only if metrics are enabled
+        let meter = null
+        if (metricProtocol) {
+            meter = initializeCustomMetrics(serviceName, serviceVersion)
+        }
 
         const gracefulShutdown = (signal) => {
             logger.info(`📡 Received ${signal}, shutting down OpenTelemetry gracefully...`)
@@ -78,6 +97,64 @@ function init(config = {}) {
     } catch (error) {
         logger.error("❌ Failed to initialize OpenTelemetry:", error)
         throw error
+    }
+}
+
+/**
+ * Creates a trace exporter based on the specified protocol
+ * @param {string} protocol - "grpc" or "http"
+ * @param {string} url - Exporter endpoint URL
+ * @param {object} headers - Headers to include in requests
+ * @param {Function} [grpcCredentials] - gRPC Credentials (optional)
+ * @returns {OTLPTraceExporter|OTLPTraceExporterHTTP} Configured trace exporter
+ */
+function createTraceExporter(protocol, url, headers = {}, grpcCredentials) {
+    if (protocol.toLowerCase() === "http") {
+        logger.info(`📡 Creating HTTP trace exporter for URL: ${url}`)
+        return new OTLPTraceExporterHTTP({
+            url: url,
+            headers: headers,
+        })
+    } else if (protocol.toLowerCase() === "grpc") {
+        logger.info(`📡 Creating gRPC trace exporter for URL: ${url}`)
+        return new OTLPTraceExporter({
+            url: url,
+            headers: headers,
+            credentials: grpcCredentials,
+        })
+    } else {
+        throw new Error(
+            `❌ Unsupported trace protocol: ${protocol}. Supported protocols are "grpc" and "http"`
+        )
+    }
+}
+
+/**
+ * Creates a metric exporter based on the specified protocol
+ * @param {string} protocol - "grpc" or "http"
+ * @param {string} url - Exporter endpoint URL
+ * @param {object} headers - Headers to include in requests
+ * @param {Function} [grpcCredentials] - gRPC Credentials (optional)
+ * @returns {OTLPMetricExporter|OTLPMetricExporterHTTP} Configured metric exporter
+ */
+function createMetricExporter(protocol, url, headers = {}, grpcCredentials) {
+    if (protocol.toLowerCase() === "http") {
+        logger.info(`📊 Creating HTTP metric exporter for URL: ${url}`)
+        return new OTLPMetricExporterHTTP({
+            url: url,
+            headers: headers,
+        })
+    } else if (protocol.toLowerCase() === "grpc") {
+        logger.info(`📊 Creating gRPC metric exporter for URL: ${url}`)
+        return new OTLPMetricExporter({
+            url: url,
+            headers: headers,
+            credentials: grpcCredentials,
+        })
+    } else {
+        throw new Error(
+            `❌ Unsupported metric protocol: ${protocol}. Supported protocols are "grpc" and "http"`
+        )
     }
 }
 
@@ -142,4 +219,63 @@ function initializeCustomMetrics(serviceName, serviceVersion) {
     return meter
 }
 
-export default { init }
+/**
+ * Wraps a synchronous function and measures total execution time.
+ * Creates a single OpenTelemetry span per function call.
+ * Use this instead of withObservability when the wrapped function is synchronous,
+ * so the return type and call sites remain unchanged.
+ *
+ * @param {string} serviceName - The name of the service
+ * @param {Function} fn - The synchronous function to wrap
+ * @param {string} name - Span name (optional)
+ * @returns {Function} Wrapped function (still synchronous)
+ */
+export function withSyncObservability(serviceName, fn, name) {
+    const tracer = trace.getTracer(serviceName)
+    const spanName = name || fn.name || "anonymousFunction"
+
+    return function (...args) {
+        return tracer.startActiveSpan(spanName, (span) => {
+            try {
+                return fn(...args)
+            } catch (err) {
+                span.recordException(err)
+                span.setStatus({ code: 2, message: err.message })
+                throw err
+            } finally {
+                span.end()
+            }
+        })
+    }
+}
+
+/**
+ * Wraps a function (sync or async) and measures total execution time.
+ * Creates a single OpenTelemetry span per function call.
+ *
+ * @param {string} serviceName - The name of the service
+ * @param {Function} fn - The function to wrap
+ * @param {string} name - Span name (optional)
+ * @returns {Function} Wrapped function
+ */
+export function withObservability(serviceName, fn, name) {
+    const tracer = trace.getTracer(serviceName)
+    const spanName = name || fn.name || "anonymousFunction"
+
+    return async function (...args) {
+        return tracer.startActiveSpan(spanName, async (span) => {
+            try {
+                const result = await fn(...args)
+                return result
+            } catch (err) {
+                span.recordException(err)
+                span.setStatus({ code: 2, message: err.message })
+                throw err
+            } finally {
+                span.end()
+            }
+        })
+    }
+}
+
+export default { init, withObservability, withSyncObservability }

--- a/src/server/renderer/extract.js
+++ b/src/server/renderer/extract.js
@@ -1,5 +1,8 @@
 import path from "path"
 import fs from "fs"
+import { withSyncObservability } from "../../otel"
+
+const SSR_SERVICE = process.env.SERVICE_NAME || `pwa-${process.env.APPLICATION}-node-server-otel`
 
 export function cachePreloadJSLinks(key, data) {
     if (!process.preloadJSLinkCache) {
@@ -95,60 +98,68 @@ function fetchPreloadJSLinkCache(key) {
  * @param {object} res - response object
  * @param {string} route - route path
  */
-export default function (res, route) {
-    try {
-        const requestPath = route.path
-        const cachedCss = fetchCachedCSS(requestPath)
-        const cachedPreloadJSLinks = fetchPreloadJSLinkCache(requestPath)
+export default withSyncObservability(
+    SSR_SERVICE,
+    function extractAssets(res, route) {
+        try {
+            const requestPath = route.path
+            const cachedCss = fetchCachedCSS(requestPath)
+            const cachedPreloadJSLinks = fetchPreloadJSLinkCache(requestPath)
 
-        if (cachedCss || cachedPreloadJSLinks) {
-            res.locals.pageCss = cachedCss
-            res.locals.preloadJSLinks = cachedPreloadJSLinks
-            return
+            if (cachedCss || cachedPreloadJSLinks) {
+                res.locals.pageCss = cachedCss
+                res.locals.preloadJSLinks = cachedPreloadJSLinks
+                return
+            }
+
+            logger.info({
+                message: "Cache Missed",
+                uri: requestPath,
+            })
+        } catch (error) {
+            logger.error("Error in extracting assets:" + error)
+        }
+    },
+    "extractAssets"
+)
+
+export const cacheAndFetchAssets = withSyncObservability(
+    SSR_SERVICE,
+    function cacheAndFetchAssets({ webExtractor, res, isBot }) {
+        // For bot first fold css and js would become complete page css and js
+        let firstFoldCss = ""
+        let firstFoldJS = ""
+        const isProd = process.env.NODE_ENV === "production"
+
+        const { routePath, preloadJSLinks } = res.locals
+
+        const linkElements = webExtractor.getLinkElements()
+
+        // We want to cache/or check for update css on every call
+        // We want to extract script tags for every call that will get added to body.
+        // Their corresponding preloaded link script tags are already present in head.
+        if (routePath) {
+            if (isProd) {
+                firstFoldCss = cacheCSS(routePath, linkElements)
+                if (firstFoldCss?.length) firstFoldCss = `<style>${firstFoldCss}</style>`
+            } else {
+                cacheCSS(routePath, linkElements)
+                firstFoldCss = webExtractor.getStyleTags()
+            }
+            // firstFoldJS = webExtractor.getScriptTags({ nonce: cspNonce })
+            firstFoldJS = webExtractor.getScriptTags()
         }
 
-        logger.info({
-            message: "Cache Missed",
-            uri: requestPath,
-        })
-    } catch (error) {
-        logger.error("Error in extracting assets:" + error)
-    }
-}
-
-export const cacheAndFetchAssets = ({ webExtractor, res, isBot }) => {
-    // For bot first fold css and js would become complete page css and js
-    let firstFoldCss = ""
-    let firstFoldJS = ""
-    const isProd = process.env.NODE_ENV === "production"
-
-    const { routePath, preloadJSLinks } = res.locals
-
-    const linkElements = webExtractor.getLinkElements()
-
-    // We want to cache/or check for update css on every call
-    // We want to extract script tags for every call that will get added to body.
-    // Their corresponding preloaded link script tags are already present in head.
-    if (routePath) {
-        if (isProd) {
-            firstFoldCss = cacheCSS(routePath, linkElements)
-            if (firstFoldCss?.length) firstFoldCss = `<style>${firstFoldCss}</style>`
-        } else {
-            cacheCSS(routePath, linkElements)
-            firstFoldCss = webExtractor.getStyleTags()
+        // This block will run for the first time and cache preloaded JS Links for second render
+        // firstFoldJS ->scripts gets inject in body
+        // firstFoldCss -> Inline css gets injected in body only for the first render
+        if (!isProd || isBot || (routePath && !preloadJSLinks)) {
+            // For production, we inject link tags with preload/prefetch using getLinkElements and inlining them via file reads
+            // For local, given we have assets in memory we dont read from file rather directly inject via link elements returned without preload/prefetch
+            !isBot && cachePreloadJSLinks(routePath, linkElements)
         }
-        // firstFoldJS = webExtractor.getScriptTags({ nonce: cspNonce })
-        firstFoldJS = webExtractor.getScriptTags()
-    }
 
-    // This block will run for the first time and cache preloaded JS Links for second render
-    // firstFoldJS ->scripts gets inject in body
-    // firstFoldCss -> Inline css gets injected in body only for the first render
-    if (!isProd || isBot || (routePath && !preloadJSLinks)) {
-        // For production, we inject link tags with preload/prefetch using getLinkElements and inlining them via file reads
-        // For local, given we have assets in memory we dont read from file rather directly inject via link elements returned without preload/prefetch
-        !isBot && cachePreloadJSLinks(routePath, linkElements)
-    }
-
-    return { firstFoldCss, firstFoldJS }
-}
+        return { firstFoldCss, firstFoldJS }
+    },
+    "cacheAndFetchAssets"
+)

--- a/src/server/renderer/handler.js
+++ b/src/server/renderer/handler.js
@@ -3,6 +3,7 @@ import path from "path"
 import React from "react"
 
 import extractAssets, { cacheAndFetchAssets } from "./extract"
+import { withObservability, withSyncObservability } from "../../otel"
 import { Provider } from "react-redux"
 import { Head, Body } from "./document"
 import { StaticRouter } from "react-router-dom/server"
@@ -22,12 +23,23 @@ import {
 import CustomDocument from "@catalyst/template/server/document.js"
 import { getRoutes } from "@catalyst/template/src/js/routes/utils.js"
 import {
-    onRouteMatch,
-    onFetcherSuccess,
-    onFetcherError,
-    onRenderError,
-    onRequestError,
+    onRouteMatch as _onRouteMatch,
+    onFetcherSuccess as _onFetcherSuccess,
+    onFetcherError as _onFetcherError,
+    onRenderError as _onRenderError,
+    onRequestError as _onRequestError,
 } from "@catalyst/template/server/index.js"
+
+const SSR_SERVICE = process.env.SERVICE_NAME || `pwa-${process.env.APPLICATION}-node-server-otel`
+
+const traceHandlerHook = (fn, spanName) =>
+    typeof fn === "function" ? withSyncObservability(SSR_SERVICE, fn, spanName) : fn
+
+const onRouteMatch = traceHandlerHook(_onRouteMatch, "onRouteMatch")
+const onFetcherSuccess = traceHandlerHook(_onFetcherSuccess, "onFetcherSuccess")
+const onFetcherError = traceHandlerHook(_onFetcherError, "onFetcherError")
+const onRenderError = traceHandlerHook(_onRenderError, "onRenderError")
+const onRequestError = traceHandlerHook(_onRequestError, "onRequestError")
 
 const storePath = path.resolve(`${process.env.src_path}/src/js/store/index.js`)
 
@@ -78,8 +90,25 @@ const parseSafeAreaFromHeaders = (req) => {
     }
 }
 
-// matches request route with routes defined in the application.
-const getMatchRoutes = (routes, req, res, store, context, fetcherData, basePath = "", webExtractor) => {
+// Dry-run render wrapped separately so it appears as a distinct span within getMatchRoutes.
+const renderToStringWithObservability = withSyncObservability(
+    SSR_SERVICE,
+    function dryRunRender(webExtractor, store, context, req, fetcherData) {
+        renderToString(
+            <ChunkExtractorManager extractor={webExtractor}>
+                <Provider store={store}>
+                    <StaticRouter context={context} location={req.originalUrl}>
+                        <ServerRouter store={store} intialData={fetcherData} />
+                    </StaticRouter>
+                </Provider>
+            </ChunkExtractorManager>
+        )
+    },
+    "renderToString"
+)
+
+// Internal recursive implementation — called directly to avoid creating a new span per recursion.
+const _getMatchRoutes = (routes, req, res, store, context, fetcherData, basePath = "", webExtractor) => {
     return routes.reduce((matches, route) => {
         const { path } = route
         const match = matchPath(
@@ -94,15 +123,7 @@ const getMatchRoutes = (routes, req, res, store, context, fetcherData, basePath 
             }
             if (!res.locals.pageCss && !res.locals.preloadJSLinks) {
                 //moving routing logic outside of the App and using ServerRoutes for creating routes on server instead
-                renderToString(
-                    <ChunkExtractorManager extractor={webExtractor}>
-                        <Provider store={store}>
-                            <StaticRouter context={context} location={req.originalUrl}>
-                                <ServerRouter store={store} intialData={fetcherData} />
-                            </StaticRouter>
-                        </Provider>
-                    </ChunkExtractorManager>
-                )
+                renderToStringWithObservability(webExtractor, store, context, req, fetcherData)
             }
             const wc = route.component
             matches.push({
@@ -113,7 +134,7 @@ const getMatchRoutes = (routes, req, res, store, context, fetcherData, basePath 
         }
         if (!match && route.children) {
             // recursively try to match nested routes
-            const nested = getMatchRoutes(
+            const nested = _getMatchRoutes(
                 route.children,
                 req,
                 res,
@@ -131,6 +152,20 @@ const getMatchRoutes = (routes, req, res, store, context, fetcherData, basePath 
         return matches
     }, [])
 }
+
+const getMatchRoutes = withSyncObservability(SSR_SERVICE, _getMatchRoutes, "getMatchRoutes")
+
+const tracedResWriteFirstFoldCss = withSyncObservability(
+    SSR_SERVICE,
+    (res, chunk) => res.write(chunk),
+    "res.write.firstFoldCss"
+)
+const tracedResWriteFirstFoldJS = withSyncObservability(
+    SSR_SERVICE,
+    (res, chunk) => res.write(chunk),
+    "res.write.firstFoldJS"
+)
+const tracedResEnd = withSyncObservability(SSR_SERVICE, (res) => res.end(), "res.end")
 
 // Preloads chunks required for rendering document
 const getComponent = (store, context, req, fetcherData) => {
@@ -242,9 +277,9 @@ const renderMarkUp = async (
                 },
                 onAllReady() {
                     const { firstFoldCss, firstFoldJS } = cacheAndFetchAssets({ webExtractor, res, isBot })
-                    res.write(firstFoldCss)
-                    res.write(firstFoldJS)
-                    res.end()
+                    tracedResWriteFirstFoldCss(res, firstFoldCss)
+                    tracedResWriteFirstFoldJS(res, firstFoldJS)
+                    tracedResEnd(res)
                     cleanupGlobalThis()
                     resolve()
                 },
@@ -270,12 +305,21 @@ const renderMarkUp = async (
     }
 }
 
+const tracedAppServerSideFunction = withObservability(
+    SSR_SERVICE,
+    (args) => App.serverSideFunction(args),
+    "App.serverSideFunction"
+)
+const tracedServerDataFetcher = withObservability(SSR_SERVICE, serverDataFetcher, "serverDataFetcher")
+const tracedRenderMarkUp = withObservability(SSR_SERVICE, renderMarkUp, "renderMarkUp")
+const tracedGetMetaData = withSyncObservability(SSR_SERVICE, getMetaData, "getMetaData")
+
 /**
  * middleware for document handling
  * @param {object} req - request object
  * @param {object} res - response object
  */
-export default async function (req, res) {
+async function _handler(req, res) {
     try {
         let context = {}
         let fetcherData = {}
@@ -314,7 +358,7 @@ export default async function (req, res) {
 
         try {
             // Executing app server side function
-            await App.serverSideFunction({ store, req, res })
+            await tracedAppServerSideFunction({ store, req, res })
 
             if (res.headersSent) {
                 return Promise.resolve(res)
@@ -322,7 +366,7 @@ export default async function (req, res) {
 
             try {
                 // Executing serverFetcher functions with serverDataFetcher provided by router and returning document
-                fetcherData = await serverDataFetcher(
+                fetcherData = await tracedServerDataFetcher(
                     { routes: routes, req, res, url: req.originalUrl },
                     { store }
                 )
@@ -331,7 +375,7 @@ export default async function (req, res) {
                     return Promise.resolve(res)
                 }
 
-                allTags = getMetaData(allMatches, fetcherData)
+                allTags = tracedGetMetaData(allMatches, fetcherData)
 
                 // function defined by user which needs to run after SSR functions are executed
                 safeCall(onFetcherSuccess, { req, res, fetcherData })
@@ -341,7 +385,17 @@ export default async function (req, res) {
                 }
 
                 return new Promise((resolve, reject) => {
-                    renderMarkUp(null, req, res, allTags, fetcherData, store, matches, context, webExtractor)
+                    tracedRenderMarkUp(
+                        null,
+                        req,
+                        res,
+                        allTags,
+                        fetcherData,
+                        store,
+                        matches,
+                        context,
+                        webExtractor
+                    )
                         .then(resolve)
                         .catch(reject)
                 })
@@ -355,7 +409,17 @@ export default async function (req, res) {
                 }
 
                 return new Promise((resolve, reject) => {
-                    renderMarkUp(404, req, res, allTags, fetcherData, store, matches, context, webExtractor)
+                    tracedRenderMarkUp(
+                        404,
+                        req,
+                        res,
+                        allTags,
+                        fetcherData,
+                        store,
+                        matches,
+                        context,
+                        webExtractor
+                    )
                         .then(resolve)
                         .catch(reject)
                 })
@@ -363,7 +427,7 @@ export default async function (req, res) {
         } catch (error) {
             logger.error("Error in executing serverSideFunction inside App: " + error)
             return new Promise((resolve, reject) => {
-                renderMarkUp(
+                tracedRenderMarkUp(
                     error.status_code,
                     req,
                     res,
@@ -385,3 +449,7 @@ export default async function (req, res) {
         return Promise.reject(error)
     }
 }
+
+const handler = withObservability(SSR_SERVICE, _handler, "handler")
+
+export default handler


### PR DESCRIPTION
 ## Summary

  Adds OpenTelemetry tracing across the SSR request pipeline so that individual stages of each request surface as
  spans in the trace. Inspiration was taken from `feature/handler-observability-v3`; only the observability
  instrumentation was pulled in — unrelated refactors on that branch (CSS cache rewrite, per-route `ChunkExtractor`
  cache, safe-area removal, new `onAppServerSide*` hooks, `fetcherData.error` flow change) are intentionally left out.

  ## Changes

  **`src/otel.js`**
  - Adds `withObservability` (async-safe) and `withSyncObservability` wrappers that start an active span, record
  exceptions, and close the span in `finally`.
  - Adds dual transport support for traces and metrics (`grpc` and `http`), selected via new `traceProtocol` /
  `metricProtocol` options.
  - Metrics are now opt-in — initialised only when `metricProtocol` is provided.
  - Adds `ParentBasedSampler` + `TraceIdRatioBasedSampler` driven by a new `samplingRate` option (default `1.0`).
  - Exposes `batchProcessorConfig`, `instrumentations`, and `grpcCredentials` passthroughs on `init()`.

  **`src/server/renderer/extract.js`**
  - Wraps the default export (`extractAssets`) and `cacheAndFetchAssets` with `withSyncObservability`.
  - Existing CSS-cache / preload-JS behaviour is unchanged.

  **`src/server/renderer/handler.js`**
  - Defines `SSR_SERVICE` (`process.env.SERVICE_NAME` → `pwa-${APPLICATION}-node-server-otel`).
  - Wraps user lifecycle hooks (`onRouteMatch`, `onFetcherSuccess`, `onFetcherError`, `onRenderError`,
  `onRequestError`) via a `traceHandlerHook` helper that no-ops when the hook isn't a function.
  - Splits `getMatchRoutes` into an internal `_getMatchRoutes` (recursive, no span-per-frame) and a wrapped outer
  span.
  - Isolates the dry-run `renderToString` inside `getMatchRoutes` into its own `renderToString` span.
  - Wraps `App.serverSideFunction`, `serverDataFetcher`, `getMetaData`, and `renderMarkUp`.
  - Wraps `res.write(firstFoldCss)`, `res.write(firstFoldJS)`, and `res.end()` during the `onAllReady` stream
  completion so TTFB-relevant writes are visible on the trace.
  - Default export is now `withObservability(_handler, "handler")` — every request yields a root SSR span.

  Safe-area header handling, extractor creation per-request, and the existing error-flow semantics are preserved
  exactly as on `main`.

  ## Span tree (per SSR request)

  handler
  ├── getMatchRoutes
  │   └── renderToString          (dry-run for ChunkExtractor)
  ├── onRouteMatch                (if defined)
  ├── App.serverSideFunction
  ├── serverDataFetcher
  ├── getMetaData
  ├── onFetcherSuccess / onFetcherError
  └── renderMarkUp
      ├── res.write.firstFoldCss
      ├── res.write.firstFoldJS
      ├── res.end
      └── onRenderError           (on failure)

  ## Dependencies

  `src/otel.js` now imports gRPC exporters and sampler primitives in addition to the existing HTTP exporters.
  Consuming apps must ensure the following are installed (install command for reference):

  ```bash
  npm install --save \
    @opentelemetry/auto-instrumentations-node@^0.64.1 \
    @opentelemetry/core@^2.0.0 \
    @opentelemetry/exporter-trace-otlp-grpc@^0.208.0 \
    @opentelemetry/instrumentation-express@^0.54.0 \
    @opentelemetry/instrumentation-http@^0.205.0 \
    @opentelemetry/resources@^2.0.0 \
    @opentelemetry/sdk-node@^0.205.0

  Backward compatibility

  - init() defaults (traceProtocol: "grpc", traceUrl: "http://localhost:4317", metrics disabled when metricProtocol is
   omitted) are a behavioural change vs. the prior HTTP-only default. Existing consumers that relied on HTTP + metrics
   must pass traceProtocol: "http", traceUrl: ".../v1/traces", and metricProtocol: "http" explicitly.
  - All span wrappers are transparent — return values and thrown errors are preserved.

  Test plan

  - Start an app on this build with an OTLP collector reachable at localhost:4317 (gRPC) and confirm one root handler
  span per request with the child tree above
  - Verify the renderToString dry-run span fires only on a cache-miss route (first hit)
  - Verify user hooks (onRouteMatch, onFetcherSuccess, etc.) show up as spans when defined in the template and are
  absent when not
  - Exercise App.serverSideFunction throwing — confirm onRenderError span records the exception and status
  - Switch traceProtocol: "http" and confirm traces still flow through the HTTP exporter
  - Enable metricProtocol: "http" and confirm custom gauges (CPU, memory) emit at the configured interval
  - Run the existing SSR integration suite to confirm no response-body regression from the res.write/res.end wrapping