### PR TITLE
Monorepo pipeline changes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,8 @@
 node_modules/*
 router/*
 scripts/*
+!scripts/release/
+!scripts/release/sync-cca-templates.js
 server/*
 webpack/*
 dist/*
@@ -9,3 +11,15 @@ caching.js
 index.js
 logger.js
 template/build
+
+apps/docs/config.json
+apps/docs/server/config.json
+apps/docs/login-page/src/config.json
+apps/docs/static/js/config.js
+apps/docs/.docusaurus/
+apps/docs/public-docs/
+apps/docs/build/
+packages/*/dist/
+packages/catalyst-core/template/logs/
+packages/catalyst-core/template/playwright-report/
+packages/catalyst-core/template/test-results/

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -177,9 +177,55 @@ jobs:
                         TARGET_BASE_VERSION=$(node -p "require('${PACKAGE_FILE}').version" | sed 's/-.*//')
                       fi
 
-                      LATEST_PRERELEASE=$(npm view "$PACKAGE_NAME@>=${TARGET_BASE_VERSION}-${RELEASE_TAG}.0 <${TARGET_BASE_VERSION}-${RELEASE_TAG}.9999" version --json 2>/dev/null | node -e 'let data="";process.stdin.on("data",c=>data+=c);process.stdin.on("end",()=>{if(!data.trim()) return; const value=JSON.parse(data); const versions=Array.isArray(value)?value:[value]; versions.forEach(v=>console.log(v));});' | sort -V | tail -1 | sed "s/.*-${RELEASE_TAG}\.\([0-9]*\).*/\1/" || echo "-1")
-                      if [ -z "$LATEST_PRERELEASE" ]; then
+                      NPM_VIEW_OUTPUT=$(mktemp)
+                      NPM_VIEW_ERROR=$(mktemp)
+                      NODE_PARSE_ERROR=$(mktemp)
+                      NPM_VIEW_QUERY="$PACKAGE_NAME@>=${TARGET_BASE_VERSION}-${RELEASE_TAG}.0 <${TARGET_BASE_VERSION}-${RELEASE_TAG}.9999"
+
+                      if npm view "$NPM_VIEW_QUERY" version --json > "$NPM_VIEW_OUTPUT" 2> "$NPM_VIEW_ERROR"; then
+                        if ! LATEST_PRERELEASE=$(node -e '
+                          const tag = process.argv[1]
+                          let data = ""
+                          process.stdin.on("data", (chunk) => (data += chunk))
+                          process.stdin.on("end", () => {
+                            try {
+                              if (!data.trim()) {
+                                console.log("-1")
+                                return
+                              }
+
+                              const value = JSON.parse(data)
+                              const versions = (Array.isArray(value) ? value : [value]).filter(Boolean)
+                              const prereleasePattern = new RegExp(`-${tag}\\.(\\d+)$`)
+                              const prereleaseNumbers = versions
+                                .map((version) => String(version).match(prereleasePattern))
+                                .filter(Boolean)
+                                .map((match) => Number(match[1]))
+
+                              console.log(prereleaseNumbers.length ? Math.max(...prereleaseNumbers) : -1)
+                            } catch (error) {
+                              console.error(error.message)
+                              process.exit(1)
+                            }
+                          })
+                        ' "$RELEASE_TAG" < "$NPM_VIEW_OUTPUT" 2> "$NODE_PARSE_ERROR"); then
+                          echo "::error::Failed to parse npm prerelease response for $NPM_VIEW_QUERY"
+                          cat "$NODE_PARSE_ERROR"
+                          exit 1
+                        fi
+                      elif grep -qiE 'E404|No match found|not in this registry' "$NPM_VIEW_ERROR"; then
                         LATEST_PRERELEASE=-1
+                      else
+                        echo "::error::Failed to query npm prereleases for $NPM_VIEW_QUERY"
+                        cat "$NPM_VIEW_ERROR"
+                        exit 1
+                      fi
+
+                      rm -f "$NPM_VIEW_OUTPUT" "$NPM_VIEW_ERROR" "$NODE_PARSE_ERROR"
+
+                      if ! echo "$LATEST_PRERELEASE" | grep -qE '^-?[0-9]+$'; then
+                        echo "::error::Invalid latest prerelease number '$LATEST_PRERELEASE' for $NPM_VIEW_QUERY"
+                        exit 1
                       fi
 
                       NEXT_PRERELEASE=$((LATEST_PRERELEASE + 1))

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,8 +12,13 @@ on:
                     - latest
                     - canary
                 default: beta
-            version_bump:
-                description: "Version bump type"
+            prepare_core:
+                description: "Prepare catalyst-core"
+                required: true
+                type: boolean
+                default: true
+            core_version_bump:
+                description: "catalyst-core version bump type"
                 required: true
                 type: choice
                 options:
@@ -23,8 +28,28 @@ on:
                     - release
                     - custom
                 default: custom
-            custom_version:
-                description: "Custom version"
+            core_custom_version:
+                description: "Custom catalyst-core version"
+                required: false
+                type: string
+            prepare_cca:
+                description: "Prepare create-catalyst-app"
+                required: true
+                type: boolean
+                default: false
+            cca_version_bump:
+                description: "create-catalyst-app version bump type"
+                required: true
+                type: choice
+                options:
+                    - patch
+                    - minor
+                    - major
+                    - release
+                    - custom
+                default: custom
+            cca_custom_version:
+                description: "Custom create-catalyst-app version"
                 required: false
                 type: string
             dry_run:
@@ -33,7 +58,7 @@ on:
                 type: boolean
                 default: false
             publish_internal:
-                description: "Publish internal"
+                description: "Publish internal package(s) immediately"
                 required: true
                 type: boolean
                 default: false
@@ -53,46 +78,64 @@ jobs:
             - name: Validate branch and inputs
               run: |
                   BRANCH="${{ github.ref_name }}"
-                  RELEASE_TAG="${{ github.event.inputs.release_tag }}"
-                  VERSION_BUMP="${{ github.event.inputs.version_bump }}"
-                  CUSTOM_VERSION="${{ github.event.inputs.custom_version }}"
-                  PUBLISH_INTERNAL="${{ inputs.publish_internal }}"
+                  RELEASE_TAG="${{ inputs.release_tag }}"
 
-                  if [ "$PUBLISH_INTERNAL" != "true" ] && { [ "$BRANCH" == "main" ] || [ "$BRANCH" == "canary" ]; }; then
-                    echo "::error::prepare-release must run from a working branch, not '$BRANCH'"
-                    exit 1
-                  fi
+                  validate_custom_version() {
+                    PACKAGE_LABEL="$1"
+                    VERSION_BUMP="$2"
+                    CUSTOM_VERSION="$3"
 
-                  if [ "$VERSION_BUMP" == "custom" ] && [ -z "$CUSTOM_VERSION" ]; then
-                    echo "::error::Custom version selected but 'custom_version' is empty"
-                    exit 1
-                  fi
+                    if [ "$VERSION_BUMP" != "custom" ]; then
+                      return
+                    fi
 
-                  if [ "$VERSION_BUMP" == "custom" ]; then
+                    if [ -z "$CUSTOM_VERSION" ]; then
+                      echo "::error::$PACKAGE_LABEL custom version is empty"
+                      exit 1
+                    fi
+
                     if ! echo "$CUSTOM_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
-                      echo "::error::Invalid version format '$CUSTOM_VERSION'. Expected: X.Y.Z or X.Y.Z-prerelease"
+                      echo "::error::Invalid $PACKAGE_LABEL version format '$CUSTOM_VERSION'. Expected X.Y.Z or X.Y.Z-prerelease"
                       exit 1
                     fi
 
                     if [ "$RELEASE_TAG" == "beta" ] && ! echo "$CUSTOM_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$'; then
-                      echo "::error::Beta releases require X.Y.Z-beta.N"
+                      echo "::error::$PACKAGE_LABEL beta releases require X.Y.Z-beta.N"
                       exit 1
                     fi
 
                     if [ "$RELEASE_TAG" == "canary" ] && ! echo "$CUSTOM_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-canary\.[0-9]+$'; then
-                      echo "::error::Canary releases require X.Y.Z-canary.N"
+                      echo "::error::$PACKAGE_LABEL canary releases require X.Y.Z-canary.N"
                       exit 1
                     fi
 
                     if [ "$RELEASE_TAG" == "latest" ] && ! echo "$CUSTOM_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$'; then
-                      echo "::error::Latest releases require either X.Y.Z or X.Y.Z-beta.N"
+                      echo "::error::$PACKAGE_LABEL latest releases require either X.Y.Z or X.Y.Z-beta.N"
                       exit 1
                     fi
+                  }
+
+                  if [ "${{ inputs.prepare_core }}" != "true" ] && [ "${{ inputs.prepare_cca }}" != "true" ]; then
+                    echo "::error::Select at least one package to prepare"
+                    exit 1
                   fi
 
-                  if [ "$RELEASE_TAG" != "latest" ] && [ "$VERSION_BUMP" == "release" ]; then
+                  if [ "${{ inputs.publish_internal }}" != "true" ] && { [ "$BRANCH" == "main" ] || [ "$BRANCH" == "canary" ]; }; then
+                    echo "::error::prepare-release must run from a working branch, not '$BRANCH'"
+                    exit 1
+                  fi
+
+                  if [ "$RELEASE_TAG" != "latest" ] && { { [ "${{ inputs.prepare_core }}" == "true" ] && [ "${{ inputs.core_version_bump }}" == "release" ]; } || { [ "${{ inputs.prepare_cca }}" == "true" ] && [ "${{ inputs.cca_version_bump }}" == "release" ]; }; }; then
                     echo "::error::'release' bump is only valid for latest releases"
                     exit 1
+                  fi
+
+                  if [ "${{ inputs.prepare_core }}" == "true" ]; then
+                    validate_custom_version "catalyst-core" "${{ inputs.core_version_bump }}" "${{ inputs.core_custom_version }}"
+                  fi
+
+                  if [ "${{ inputs.prepare_cca }}" == "true" ]; then
+                    validate_custom_version "create-catalyst-app" "${{ inputs.cca_version_bump }}" "${{ inputs.cca_custom_version }}"
                   fi
 
             - name: Setup Node.js
@@ -101,74 +144,208 @@ jobs:
                   node-version: "20"
                   registry-url: "https://registry.npmjs.org"
 
-            - name: Read current version
-              id: current_version
+            - name: Compute and apply target versions
+              id: versions
               run: |
-                  VERSION=$(node -p "require('./package.json').version")
-                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-            - name: Compute target version
-              id: version
-              run: |
-                  RELEASE_TAG="${{ github.event.inputs.release_tag }}"
-                  VERSION_BUMP="${{ github.event.inputs.version_bump }}"
-                  PACKAGE_NAME="catalyst-core"
-                  CURRENT_VERSION=$(node -p "require('./package.json').version")
-                  CURRENT_BASE_VERSION=$(echo "$CURRENT_VERSION" | sed 's/-.*//')
-
-                  if [ "$VERSION_BUMP" == "custom" ]; then
-                    TARGET_VERSION="${{ github.event.inputs.custom_version }}"
-                  elif [ "$RELEASE_TAG" == "beta" ] || [ "$RELEASE_TAG" == "canary" ]; then
-                    if [ "$VERSION_BUMP" == "patch" ] && echo "$CURRENT_VERSION" | grep -q -- "-${RELEASE_TAG}\."; then
-                      TARGET_BASE_VERSION="$CURRENT_BASE_VERSION"
-                    else
-                      npm version "$VERSION_BUMP" --no-git-tag-version
-                      TARGET_BASE_VERSION=$(node -p "require('./package.json').version" | sed 's/-.*//')
-                    fi
-
-                    LATEST_PRERELEASE=$(npm view "$PACKAGE_NAME@>=${TARGET_BASE_VERSION}-${RELEASE_TAG}.0 <${TARGET_BASE_VERSION}-${RELEASE_TAG}.9999" version --json 2>/dev/null | node -e 'let data="";process.stdin.on("data",c=>data+=c);process.stdin.on("end",()=>{if(!data.trim()) return; const value=JSON.parse(data); const versions=Array.isArray(value)?value:[value]; versions.forEach(v=>console.log(v));});' | sort -V | tail -1 | sed "s/.*-${RELEASE_TAG}\.\([0-9]*\).*/\1/" || echo "-1")
-                    if [ -z "$LATEST_PRERELEASE" ]; then
-                      LATEST_PRERELEASE=-1
-                    fi
-
-                    NEXT_PRERELEASE=$((LATEST_PRERELEASE + 1))
-                    TARGET_VERSION="${TARGET_BASE_VERSION}-${RELEASE_TAG}.${NEXT_PRERELEASE}"
-                  else
-                    if [ "$VERSION_BUMP" == "release" ]; then
-                      if [ "$CURRENT_VERSION" == "$CURRENT_BASE_VERSION" ]; then
-                        echo "::error::Current version '$CURRENT_VERSION' is already stable"
-                        exit 1
-                      fi
-                      TARGET_VERSION="$CURRENT_BASE_VERSION"
-                    else
-                      npm version "$VERSION_BUMP" --no-git-tag-version
-                      TARGET_VERSION=$(node -p "require('./package.json').version")
-                    fi
-                  fi
-
-                  npm version "$TARGET_VERSION" --no-git-tag-version --allow-same-version
-                  echo "version=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
-
-            - name: Check version availability on npm
-              run: |
-                  VERSION="${{ steps.version.outputs.version }}"
-                  PACKAGE_NAME="catalyst-core"
+                  RELEASE_TAG="${{ inputs.release_tag }}"
+                  CORE_PACKAGE_NAME="catalyst-core"
+                  CCA_PACKAGE_NAME="create-catalyst-app"
 
                   if [ "${{ inputs.publish_internal }}" == "true" ]; then
+                    CORE_PACKAGE_NAME="catalyst-core-internal"
+                    CCA_PACKAGE_NAME="create-catalyst-app-internal"
+                  fi
+
+                  set_target_version() {
+                    WORKSPACE_NAME="$1"
+                    PACKAGE_NAME="$2"
+                    PACKAGE_FILE="$3"
+                    VERSION_BUMP="$4"
+                    CUSTOM_VERSION="$5"
+                    OUTPUT_PREFIX="$6"
+
+                    CURRENT_VERSION=$(node -p "require('${PACKAGE_FILE}').version")
+                    CURRENT_BASE_VERSION=$(echo "$CURRENT_VERSION" | sed 's/-.*//')
+
+                    if [ "$VERSION_BUMP" == "custom" ]; then
+                      TARGET_VERSION="$CUSTOM_VERSION"
+                    elif [ "$RELEASE_TAG" == "beta" ] || [ "$RELEASE_TAG" == "canary" ]; then
+                      if [ "$VERSION_BUMP" == "patch" ] && echo "$CURRENT_VERSION" | grep -q -- "-${RELEASE_TAG}\."; then
+                        TARGET_BASE_VERSION="$CURRENT_BASE_VERSION"
+                      else
+                        npm version "$VERSION_BUMP" --workspace "$WORKSPACE_NAME" --no-git-tag-version
+                        TARGET_BASE_VERSION=$(node -p "require('${PACKAGE_FILE}').version" | sed 's/-.*//')
+                      fi
+
+                      LATEST_PRERELEASE=$(npm view "$PACKAGE_NAME@>=${TARGET_BASE_VERSION}-${RELEASE_TAG}.0 <${TARGET_BASE_VERSION}-${RELEASE_TAG}.9999" version --json 2>/dev/null | node -e 'let data="";process.stdin.on("data",c=>data+=c);process.stdin.on("end",()=>{if(!data.trim()) return; const value=JSON.parse(data); const versions=Array.isArray(value)?value:[value]; versions.forEach(v=>console.log(v));});' | sort -V | tail -1 | sed "s/.*-${RELEASE_TAG}\.\([0-9]*\).*/\1/" || echo "-1")
+                      if [ -z "$LATEST_PRERELEASE" ]; then
+                        LATEST_PRERELEASE=-1
+                      fi
+
+                      NEXT_PRERELEASE=$((LATEST_PRERELEASE + 1))
+                      TARGET_VERSION="${TARGET_BASE_VERSION}-${RELEASE_TAG}.${NEXT_PRERELEASE}"
+                    else
+                      if [ "$VERSION_BUMP" == "release" ]; then
+                        if [ "$CURRENT_VERSION" == "$CURRENT_BASE_VERSION" ]; then
+                          echo "::error::$PACKAGE_NAME version '$CURRENT_VERSION' is already stable"
+                          exit 1
+                        fi
+                        TARGET_VERSION="$CURRENT_BASE_VERSION"
+                      else
+                        npm version "$VERSION_BUMP" --workspace "$WORKSPACE_NAME" --no-git-tag-version
+                        TARGET_VERSION=$(node -p "require('${PACKAGE_FILE}').version")
+                      fi
+                    fi
+
+                    npm pkg set version="$TARGET_VERSION" --workspace "$WORKSPACE_NAME"
+                    echo "${OUTPUT_PREFIX}_current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+                    echo "${OUTPUT_PREFIX}_version=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
+                  }
+
+                  if [ "${{ inputs.prepare_core }}" == "true" ]; then
+                    set_target_version "packages/catalyst-core" "$CORE_PACKAGE_NAME" "./packages/catalyst-core/package.json" "${{ inputs.core_version_bump }}" "${{ inputs.core_custom_version }}" "core"
+                  fi
+
+                  if [ "${{ inputs.prepare_cca }}" == "true" ]; then
+                    set_target_version "packages/create-catalyst-app" "$CCA_PACKAGE_NAME" "./packages/create-catalyst-app/package.json" "${{ inputs.cca_version_bump }}" "${{ inputs.cca_custom_version }}" "cca"
+                  fi
+
+            - name: Apply internal package names
+              if: inputs.publish_internal
+              run: |
+                  if [ "${{ inputs.prepare_core }}" == "true" ]; then
+                    npm pkg set name=catalyst-core-internal --workspace packages/catalyst-core
+                  fi
+
+                  if [ "${{ inputs.prepare_cca }}" == "true" ]; then
+                    npm pkg set name=create-catalyst-app-internal --workspace packages/create-catalyst-app
+                  fi
+
+            - name: Resolve create-catalyst-app template catalyst dependency
+              id: template_core
+              if: inputs.prepare_cca
+              run: |
+                  RELEASE_TAG="${{ inputs.release_tag }}"
+                  PREPARE_CORE="${{ inputs.prepare_core }}"
+                  PUBLISH_INTERNAL="${{ inputs.publish_internal }}"
+
+                  validate_template_dependency_version() {
+                    PACKAGE_NAME="$1"
+                    VERSION="$2"
+
+                    if [ "$RELEASE_TAG" == "beta" ] && ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$'; then
+                      echo "::error::$PACKAGE_NAME beta template dependency must be X.Y.Z-beta.N (current: $VERSION)"
+                      exit 1
+                    fi
+
+                    if [ "$RELEASE_TAG" == "canary" ] && ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-canary\.[0-9]+$'; then
+                      echo "::error::$PACKAGE_NAME canary template dependency must be X.Y.Z-canary.N (current: $VERSION)"
+                      exit 1
+                    fi
+
+                    if [ "$RELEASE_TAG" == "latest" ] && ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                      echo "::error::$PACKAGE_NAME latest template dependency must be a stable X.Y.Z release (current: $VERSION)"
+                      exit 1
+                    fi
+                  }
+
+                  PACKAGE_NAME="catalyst-core"
+                  if [ "$PUBLISH_INTERNAL" == "true" ]; then
                     PACKAGE_NAME="catalyst-core-internal"
                   fi
 
-                  if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
-                    echo "::error::Version $VERSION already exists on npm for $PACKAGE_NAME"
-                    exit 1
+                  if [ "$PREPARE_CORE" == "true" ]; then
+                    TARGET_VERSION="${{ steps.versions.outputs.core_version }}"
+                  else
+                    TARGET_VERSION=$(npm view "$PACKAGE_NAME@$RELEASE_TAG" version 2>/dev/null || true)
+                    if [ -z "$TARGET_VERSION" ]; then
+                      echo "::error::Could not resolve $PACKAGE_NAME@$RELEASE_TAG for create-catalyst-app templates"
+                      exit 1
+                    fi
+                  fi
+
+                  validate_template_dependency_version "$PACKAGE_NAME" "$TARGET_VERSION"
+
+                  echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+                  echo "version=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
+
+            - name: Sync create-catalyst-app template dependency versions
+              if: inputs.prepare_cca
+              run: |
+                  node scripts/release/sync-cca-templates.js --package-name="${{ steps.template_core.outputs.package_name }}" --package-version="${{ steps.template_core.outputs.version }}"
+
+            - name: Validate create-catalyst-app template dependency versions
+              if: inputs.prepare_cca
+              run: |
+                  node scripts/release/sync-cca-templates.js --check --package-name="${{ steps.template_core.outputs.package_name }}" --package-version="${{ steps.template_core.outputs.version }}"
+
+            - name: Update workspace lockfile
+              run: npm install --package-lock-only --ignore-scripts
+
+            - name: Check version availability on npm
+              run: |
+                  check_version_available() {
+                    PACKAGE_NAME="$1"
+                    VERSION="$2"
+
+                    if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
+                      echo "::error::Version $VERSION already exists on npm for $PACKAGE_NAME"
+                      exit 1
+                    fi
+                  }
+
+                  if [ "${{ inputs.prepare_core }}" == "true" ]; then
+                    PACKAGE_NAME="catalyst-core"
+                    if [ "${{ inputs.publish_internal }}" == "true" ]; then
+                      PACKAGE_NAME="catalyst-core-internal"
+                    fi
+                    check_version_available "$PACKAGE_NAME" "${{ steps.versions.outputs.core_version }}"
+                  fi
+
+                  if [ "${{ inputs.prepare_cca }}" == "true" ]; then
+                    PACKAGE_NAME="create-catalyst-app"
+                    if [ "${{ inputs.publish_internal }}" == "true" ]; then
+                      PACKAGE_NAME="create-catalyst-app-internal"
+                    fi
+                    check_version_available "$PACKAGE_NAME" "${{ steps.versions.outputs.cca_version }}"
                   fi
 
             - name: Write release metadata
               if: ${{ !inputs.publish_internal }}
               run: |
-                  VERSION="${{ steps.version.outputs.version }}"
-                  TAG="${{ github.event.inputs.release_tag }}"
-                  printf '{\n  "tag": "%s",\n  "version": "%s"\n}\n' "$TAG" "$VERSION" > .release-meta.json
+                  RELEASE_TAG="${{ inputs.release_tag }}"
+                  PREPARE_CORE="${{ inputs.prepare_core }}"
+                  PREPARE_CCA="${{ inputs.prepare_cca }}"
+                  CORE_VERSION="${{ steps.versions.outputs.core_version }}"
+                  CCA_VERSION="${{ steps.versions.outputs.cca_version }}"
+                  TEMPLATE_CORE_VERSION="${{ steps.template_core.outputs.version }}"
+                  export RELEASE_TAG PREPARE_CORE PREPARE_CCA CORE_VERSION CCA_VERSION TEMPLATE_CORE_VERSION
+
+                  node - <<'NODE'
+                  const fs = require("fs")
+
+                  const metadata = {
+                    tag: process.env.RELEASE_TAG,
+                    packages: {},
+                  }
+
+                  if (process.env.PREPARE_CORE === "true") {
+                    metadata.packages["catalyst-core"] = {
+                      publish: true,
+                      version: process.env.CORE_VERSION,
+                    }
+                  }
+
+                  if (process.env.PREPARE_CCA === "true") {
+                    metadata.packages["create-catalyst-app"] = {
+                      publish: true,
+                      version: process.env.CCA_VERSION,
+                      templateCatalystCoreVersion: process.env.TEMPLATE_CORE_VERSION,
+                    }
+                  }
+
+                  fs.writeFileSync(".release-meta.json", `${JSON.stringify(metadata, null, 2)}\n`)
+                  NODE
 
             - name: Configure Git
               if: ${{ !inputs.dry_run && !inputs.publish_internal }}
@@ -180,112 +357,104 @@ jobs:
               id: commit_prepare
               if: ${{ !inputs.dry_run && !inputs.publish_internal }}
               run: |
-                  VERSION="${{ steps.version.outputs.version }}"
-                  git add package.json package-lock.json .release-meta.json
+                  /usr/bin/git add .release-meta.json package-lock.json packages/catalyst-core/package.json packages/create-catalyst-app/package.json packages/create-catalyst-app/templates/*/package.json
 
                   if git diff --cached --quiet; then
                     echo "::error::No version changes to commit"
                     exit 1
                   fi
 
-                  git commit -m "chore: prepare release v$VERSION [skip ci]"
+                  PACKAGE_LABELS=()
+                  if [ "${{ inputs.prepare_core }}" == "true" ]; then
+                    PACKAGE_LABELS+=("catalyst-core@${{ steps.versions.outputs.core_version }}")
+                  fi
+                  if [ "${{ inputs.prepare_cca }}" == "true" ]; then
+                    PACKAGE_LABELS+=("create-catalyst-app@${{ steps.versions.outputs.cca_version }}")
+                  fi
+
+                  git commit -m "chore: prepare release ${PACKAGE_LABELS[*]} [skip ci]"
                   git push
 
-            - name: Rename package (internal)
-              if: inputs.publish_internal
-              run: npm pkg set name=catalyst-core-internal
-
             - name: Replace in source files (internal)
-              if: inputs.publish_internal
+              if: inputs.publish_internal && inputs.prepare_core
               run: |
-                  echo "Files containing 'catalyst-core' in source:"
-                  grep -rl "catalyst-core" ./src --include="*.js" --include="*.ts" || echo "No matches found"
-
-                  echo ""
-                  echo "Replacing 'catalyst-core' with 'catalyst-core-internal' in source files..."
-                  find ./src -type f \( -name "*.js" -o -name "*.ts" \) -exec perl -0pi -e 's/catalyst-core(?!-internal)(?![[:alnum:]_-])/catalyst-core-internal/g' {} \;
+                  find ./packages/catalyst-core/src -type f \( -name "*.js" -o -name "*.ts" \) -exec perl -0pi -e 's/catalyst-core(?!-internal)(?![[:alnum:]_-])/catalyst-core-internal/g' {} \;
 
             - name: Install dependencies for internal publish
               if: inputs.publish_internal
-              run: npm install
+              run: npm install --ignore-scripts
 
             - name: Build package for internal publish
-              if: inputs.publish_internal
-              run: npm run prepare
+              if: inputs.publish_internal && inputs.prepare_core
+              run: npm run prepare --workspace packages/catalyst-core
 
             - name: Update npm for OIDC support
               if: ${{ inputs.publish_internal && !inputs.dry_run }}
               run: npm install -g npm@latest
 
-            - name: Publish internal package
-              id: publish_internal
-              if: ${{ inputs.publish_internal && !inputs.dry_run }}
-              run: npm publish --tag ${{ github.event.inputs.release_tag }} --access public
+            - name: Publish internal catalyst-core package
+              id: publish_internal_core
+              if: ${{ inputs.publish_internal && inputs.prepare_core && !inputs.dry_run }}
+              run: npm publish --workspace packages/catalyst-core --tag ${{ inputs.release_tag }} --access public
+
+            - name: Verify internal catalyst dependency for create-catalyst-app
+              if: ${{ inputs.publish_internal && inputs.prepare_cca && !inputs.dry_run }}
+              run: |
+                  if [ "${{ inputs.prepare_core }}" == "true" ]; then
+                    echo "catalyst-core-internal was published in this run"
+                    exit 0
+                  fi
+
+                  TEMPLATE_CORE_VERSION=$(node -p "const pk=require('./packages/create-catalyst-app/templates/none-js/package.json'); pk.dependencies['catalyst-core-internal']")
+                  if [ -z "$TEMPLATE_CORE_VERSION" ]; then
+                    echo "::error::create-catalyst-app internal templates are missing catalyst-core-internal"
+                    exit 1
+                  fi
+
+                  npm view "catalyst-core-internal@$TEMPLATE_CORE_VERSION" version
+
+            - name: Publish internal create-catalyst-app package
+              id: publish_internal_cca
+              if: ${{ inputs.publish_internal && inputs.prepare_cca && !inputs.dry_run }}
+              run: npm publish --workspace packages/create-catalyst-app --tag ${{ inputs.release_tag }} --access public
 
             - name: Final summary
               if: always()
               run: |
                   STATUS="${{ job.status }}"
-                  RELEASE_TAG="${{ github.event.inputs.release_tag }}"
-                  VERSION_BUMP="${{ github.event.inputs.version_bump }}"
-                  CUSTOM_VERSION="${{ github.event.inputs.custom_version }}"
+                  RELEASE_TAG="${{ inputs.release_tag }}"
                   DRY_RUN="${{ inputs.dry_run }}"
                   PUBLISH_INTERNAL="${{ inputs.publish_internal }}"
-                  CURRENT_VERSION="${{ steps.current_version.outputs.version }}"
-                  TARGET_VERSION="${{ steps.version.outputs.version }}"
+                  PREPARE_CORE="${{ inputs.prepare_core }}"
+                  PREPARE_CCA="${{ inputs.prepare_cca }}"
+                  CORE_CURRENT="${{ steps.versions.outputs.core_current }}"
+                  CORE_TARGET="${{ steps.versions.outputs.core_version }}"
+                  CCA_CURRENT="${{ steps.versions.outputs.cca_current }}"
+                  CCA_TARGET="${{ steps.versions.outputs.cca_version }}"
                   COMMIT_OUTCOME="${{ steps.commit_prepare.outcome }}"
-                  INTERNAL_PUBLISH_OUTCOME="${{ steps.publish_internal.outcome }}"
+                  INTERNAL_CORE_PUBLISH_OUTCOME="${{ steps.publish_internal_core.outcome }}"
+                  INTERNAL_CCA_PUBLISH_OUTCOME="${{ steps.publish_internal_cca.outcome }}"
 
-                  if [ -n "$CUSTOM_VERSION" ]; then
-                    REQUESTED_VERSION="$CUSTOM_VERSION"
-                  else
-                    REQUESTED_VERSION="-"
+                  echo "status=$STATUS"
+                  echo "release_tag=$RELEASE_TAG"
+                  echo "dry_run=$DRY_RUN"
+                  echo "publish_internal=$PUBLISH_INTERNAL"
+
+                  if [ "$PREPARE_CORE" == "true" ]; then
+                    echo "catalyst-core: $CORE_CURRENT -> $CORE_TARGET"
+                  fi
+
+                  if [ "$PREPARE_CCA" == "true" ]; then
+                    echo "create-catalyst-app: $CCA_CURRENT -> $CCA_TARGET"
                   fi
 
                   if [ "$PUBLISH_INTERNAL" == "true" ]; then
-                    COMMIT_ACTION="not applicable"
-                  elif [ "$DRY_RUN" == "true" ]; then
-                    COMMIT_ACTION="skipped (dry_run=true)"
-                  elif [ "$COMMIT_OUTCOME" == "success" ]; then
-                    COMMIT_ACTION="committed and pushed version files"
-                  elif [ "$COMMIT_OUTCOME" == "failure" ]; then
-                    COMMIT_ACTION="failed"
+                    if [ "$PREPARE_CORE" == "true" ]; then
+                      echo "internal_catalyst-core_publish=${INTERNAL_CORE_PUBLISH_OUTCOME:-not run}"
+                    fi
+                    if [ "$PREPARE_CCA" == "true" ]; then
+                      echo "internal_create-catalyst-app_publish=${INTERNAL_CCA_PUBLISH_OUTCOME:-not run}"
+                    fi
                   else
-                    COMMIT_ACTION="not run"
+                    echo "commit_prepare=${COMMIT_OUTCOME:-not run}"
                   fi
-
-                  if [ "$PUBLISH_INTERNAL" != "true" ]; then
-                    INTERNAL_ACTION="not requested"
-                  elif [ "$DRY_RUN" == "true" ]; then
-                    INTERNAL_ACTION="would publish catalyst-core-internal@$TARGET_VERSION with dist-tag $RELEASE_TAG"
-                  elif [ "$INTERNAL_PUBLISH_OUTCOME" == "success" ]; then
-                    INTERNAL_ACTION="published catalyst-core-internal@$TARGET_VERSION with dist-tag $RELEASE_TAG"
-                  elif [ "$INTERNAL_PUBLISH_OUTCOME" == "failure" ]; then
-                    INTERNAL_ACTION="internal publish failed"
-                  else
-                    INTERNAL_ACTION="not run"
-                  fi
-
-                  if [ "$PUBLISH_INTERNAL" == "true" ]; then
-                    METADATA_ACTION="not written"
-                  elif [ "$DRY_RUN" == "true" ]; then
-                    METADATA_ACTION="would write .release-meta.json for $RELEASE_TAG"
-                  else
-                    METADATA_ACTION="wrote .release-meta.json for $RELEASE_TAG"
-                  fi
-
-                  {
-                    echo "prepare-release summary"
-                    echo "- status: $STATUS"
-                    echo "- branch: ${{ github.ref_name }}"
-                    echo "- release_tag: $RELEASE_TAG"
-                    echo "- version_bump: $VERSION_BUMP"
-                    echo "- custom_version: $REQUESTED_VERSION"
-                    echo "- current_version: ${CURRENT_VERSION:-not read}"
-                    echo "- target_version: ${TARGET_VERSION:-not computed}"
-                    echo "- dry_run: $DRY_RUN"
-                    echo "- publish_internal: $PUBLISH_INTERNAL"
-                    echo "- metadata_action: $METADATA_ACTION"
-                    echo "- commit_action: $COMMIT_ACTION"
-                    echo "- internal_publish_action: $INTERNAL_ACTION"
-                  } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,9 @@ jobs:
                       CCA_METADATA_VERSION=$(node -p "const meta=require('./.release-meta.json'); meta.packages?.['create-catalyst-app']?.version || ''")
                       REASON="auto publish on push via release metadata"
 
-                      if [ "$PUBLISH_CORE" == "true" ] || [ "$PUBLISH_CCA" == "true" ]; then
+                      if [ -z "$CHANNEL" ]; then
+                        REASON="release metadata missing channel"
+                      elif [ "$PUBLISH_CORE" == "true" ] || [ "$PUBLISH_CCA" == "true" ]; then
                         SHOULD_RUN=true
                       else
                         REASON="release metadata selected no packages"
@@ -370,17 +372,16 @@ jobs:
                   fi
 
                   SUMMARY=$(printf '%s\n' "${SUMMARY_LINES[@]}")
+                  DESCRIPTION=$(printf '%s\n\nPublished by: %s\nBranch: %s' "$SUMMARY" "${{ github.actor }}" "${{ github.ref_name }}")
+                  PAYLOAD=$(jq -n \
+                    --arg text "✅ Package Publish Completed" \
+                    --arg title "${{ github.repository }}" \
+                    --arg description "$DESCRIPTION" \
+                    '{text: $text, attachments: [{title: $title, description: $description, color: "#00C851"}]}')
 
                   curl -X POST "${{ secrets.FLOCK_WEBHOOK_URL }}" \
                     -H "Content-Type: application/json" \
-                    -d "{
-                      \"text\": \"✅ Package Publish Completed\",
-                      \"attachments\": [{
-                        \"title\": \"${{ github.repository }}\",
-                        \"description\": \"$SUMMARY\n\nPublished by: ${{ github.actor }}\nBranch: ${{ github.ref_name }}\",
-                        \"color\": \"#00C851\"
-                      }]
-                    }"
+                    -d "$PAYLOAD"
 
             - name: Final summary
               if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,16 @@ on:
                     - latest
                     - canary
                 default: beta
+            publish_core:
+                description: "Publish catalyst-core"
+                required: true
+                type: boolean
+                default: true
+            publish_cca:
+                description: "Publish create-catalyst-app"
+                required: true
+                type: boolean
+                default: false
             dry_run:
                 description: "Dry run"
                 required: true
@@ -46,19 +56,27 @@ jobs:
                   BEFORE_SHA="${{ github.event.before }}"
                   AFTER_SHA="${{ github.sha }}"
                   SHOULD_RUN=false
-                  PACKAGE_NAME=""
                   CHANNEL=""
                   DRY_RUN=false
                   REASON=""
-                  METADATA_VERSION=""
+                  PUBLISH_CORE=false
+                  PUBLISH_CCA=false
+                  CORE_METADATA_VERSION=""
+                  CCA_METADATA_VERSION=""
 
                   if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
-                    SHOULD_RUN=true
-                    PACKAGE_NAME="catalyst-core"
-                    CHANNEL="${{ github.event.inputs.publish_channel }}"
+                    CHANNEL="${{ inputs.publish_channel }}"
                     DRY_RUN="${{ inputs.dry_run }}"
+                    PUBLISH_CORE="${{ inputs.publish_core }}"
+                    PUBLISH_CCA="${{ inputs.publish_cca }}"
                     REASON="manual dispatch"
-                  elif [ "$BRANCH" == "canary" ]; then
+
+                    if [ "$PUBLISH_CORE" == "true" ] || [ "$PUBLISH_CCA" == "true" ]; then
+                      SHOULD_RUN=true
+                    else
+                      REASON="manual dispatch without any selected package"
+                    fi
+                  elif [ "$BRANCH" == "canary" ] || [ "$BRANCH" == "main" ]; then
                     if [ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]; then
                       CHANGED_FILES=$(git show --pretty='' --name-only "$AFTER_SHA" 2>/dev/null || true)
                     else
@@ -66,46 +84,35 @@ jobs:
                     fi
 
                     if ! echo "$CHANGED_FILES" | grep -qx '.release-meta.json'; then
-                      REASON="push to canary without release metadata change"
+                      REASON="push without release metadata change"
                     elif [ ! -f .release-meta.json ]; then
                       REASON="release metadata missing at branch head"
                     else
                       CHANNEL=$(node -p "const meta=require('./.release-meta.json'); meta.tag || ''")
-                      METADATA_VERSION=$(node -p "const meta=require('./.release-meta.json'); meta.version || ''")
-                      SHOULD_RUN=true
-                      PACKAGE_NAME="catalyst-core"
-                      DRY_RUN=false
-                      REASON="auto publish on push to canary via release metadata"
-                    fi
-                  elif [ "$BRANCH" == "main" ]; then
-                    if [ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]; then
-                      CHANGED_FILES=$(git show --pretty='' --name-only "$AFTER_SHA" 2>/dev/null || true)
-                    else
-                      CHANGED_FILES=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" 2>/dev/null || true)
-                    fi
+                      PUBLISH_CORE=$(node -p "const meta=require('./.release-meta.json'); String(Boolean(meta.packages?.['catalyst-core']?.publish))")
+                      PUBLISH_CCA=$(node -p "const meta=require('./.release-meta.json'); String(Boolean(meta.packages?.['create-catalyst-app']?.publish))")
+                      CORE_METADATA_VERSION=$(node -p "const meta=require('./.release-meta.json'); meta.packages?.['catalyst-core']?.version || ''")
+                      CCA_METADATA_VERSION=$(node -p "const meta=require('./.release-meta.json'); meta.packages?.['create-catalyst-app']?.version || ''")
+                      REASON="auto publish on push via release metadata"
 
-                    if ! echo "$CHANGED_FILES" | grep -qx '.release-meta.json'; then
-                      REASON="push to main without release metadata change"
-                    elif [ ! -f .release-meta.json ]; then
-                      REASON="release metadata missing at branch head"
-                    else
-                      CHANNEL=$(node -p "const meta=require('./.release-meta.json'); meta.tag || ''")
-                      METADATA_VERSION=$(node -p "const meta=require('./.release-meta.json'); meta.version || ''")
-                      SHOULD_RUN=true
-                      PACKAGE_NAME="catalyst-core"
-                      DRY_RUN=false
-                      REASON="auto publish on push to main via release metadata"
+                      if [ "$PUBLISH_CORE" == "true" ] || [ "$PUBLISH_CCA" == "true" ]; then
+                        SHOULD_RUN=true
+                      else
+                        REASON="release metadata selected no packages"
+                      fi
                     fi
                   else
                     REASON="unsupported trigger context"
                   fi
 
                   echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
-                  echo "package=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
                   echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
                   echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
                   echo "reason=$REASON" >> "$GITHUB_OUTPUT"
-                  echo "metadata_version=$METADATA_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "publish_core=$PUBLISH_CORE" >> "$GITHUB_OUTPUT"
+                  echo "publish_cca=$PUBLISH_CCA" >> "$GITHUB_OUTPUT"
+                  echo "core_metadata_version=$CORE_METADATA_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "cca_metadata_version=$CCA_METADATA_VERSION" >> "$GITHUB_OUTPUT"
 
             - name: Validate branch
               if: steps.context.outputs.should_run == 'true'
@@ -130,96 +137,143 @@ jobs:
                   node-version: "20"
                   registry-url: "https://registry.npmjs.org"
 
-            - name: Read current version
-              id: version
+            - name: Read workspace package versions
+              id: versions
               if: steps.context.outputs.should_run == 'true'
               run: |
-                  VERSION=$(node -p "require('./package.json').version")
-                  echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+                  CORE_VERSION=$(node -p "require('./packages/catalyst-core/package.json').version")
+                  CCA_VERSION=$(node -p "require('./packages/create-catalyst-app/package.json').version")
+                  echo "core=$CORE_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "cca=$CCA_VERSION" >> "$GITHUB_OUTPUT"
 
             - name: Validate release metadata
               if: steps.context.outputs.should_run == 'true' && github.event_name == 'push'
               run: |
-                  CHANNEL="${{ steps.context.outputs.channel }}"
-                  VERSION="${{ steps.version.outputs.value }}"
-                  METADATA_VERSION="${{ steps.context.outputs.metadata_version }}"
+                  if [ "${{ steps.context.outputs.publish_core }}" == "true" ]; then
+                    if [ -z "${{ steps.context.outputs.core_metadata_version }}" ]; then
+                      echo "::error::Release metadata is missing catalyst-core version"
+                      exit 1
+                    fi
 
-                  if [ -z "$CHANNEL" ]; then
-                    echo "::error::Release metadata is missing a tag"
-                    exit 1
+                    if [ "${{ steps.versions.outputs.core }}" != "${{ steps.context.outputs.core_metadata_version }}" ]; then
+                      echo "::error::Release metadata catalyst-core version '${{ steps.context.outputs.core_metadata_version }}' does not match package version '${{ steps.versions.outputs.core }}'"
+                      exit 1
+                    fi
                   fi
 
-                  if [ -z "$METADATA_VERSION" ]; then
-                    echo "::error::Release metadata is missing a version"
-                    exit 1
+                  if [ "${{ steps.context.outputs.publish_cca }}" == "true" ]; then
+                    if [ -z "${{ steps.context.outputs.cca_metadata_version }}" ]; then
+                      echo "::error::Release metadata is missing create-catalyst-app version"
+                      exit 1
+                    fi
+
+                    if [ "${{ steps.versions.outputs.cca }}" != "${{ steps.context.outputs.cca_metadata_version }}" ]; then
+                      echo "::error::Release metadata create-catalyst-app version '${{ steps.context.outputs.cca_metadata_version }}' does not match package version '${{ steps.versions.outputs.cca }}'"
+                      exit 1
+                    fi
                   fi
 
-                  if [ "$VERSION" != "$METADATA_VERSION" ]; then
-                    echo "::error::Release metadata version '$METADATA_VERSION' does not match package.json version '$VERSION'"
-                    exit 1
-                  fi
+            - name: Validate create-catalyst-app template versions
+              if: steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_cca == 'true'
+              run: |
+                  TEMPLATE_CORE_VERSION=$(node -p "require('./packages/create-catalyst-app/templates/none-js/package.json').dependencies['catalyst-core']")
+                  node scripts/release/sync-cca-templates.js --check --package-name="catalyst-core" --package-version="$TEMPLATE_CORE_VERSION"
 
-            - name: Validate version against channel
+            - name: Validate package versions against channel
               if: steps.context.outputs.should_run == 'true'
               run: |
-                  CHANNEL="${{ steps.context.outputs.channel }}"
-                  VERSION="${{ steps.version.outputs.value }}"
+                  validate_version() {
+                    PACKAGE_NAME="$1"
+                    VERSION="$2"
+                    CHANNEL="$3"
 
-                  if [ "$CHANNEL" == "beta" ] && ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$'; then
-                    echo "::error::Beta publishes require X.Y.Z-beta.N (current: $VERSION)"
-                    exit 1
+                    if [ "$CHANNEL" == "beta" ] && ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$'; then
+                      echo "::error::$PACKAGE_NAME beta publishes require X.Y.Z-beta.N (current: $VERSION)"
+                      exit 1
+                    fi
+
+                    if [ "$CHANNEL" == "latest" ] && ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$'; then
+                      echo "::error::$PACKAGE_NAME latest publishes require either X.Y.Z or X.Y.Z-beta.N (current: $VERSION)"
+                      exit 1
+                    fi
+
+                    if [ "$CHANNEL" == "canary" ] && ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-canary\.[0-9]+$'; then
+                      echo "::error::$PACKAGE_NAME canary publishes require X.Y.Z-canary.N (current: $VERSION)"
+                      exit 1
+                    fi
+                  }
+
+                  if [ "${{ steps.context.outputs.publish_core }}" == "true" ]; then
+                    validate_version "catalyst-core" "${{ steps.versions.outputs.core }}" "${{ steps.context.outputs.channel }}"
                   fi
 
-                  if [ "$CHANNEL" == "latest" ] && ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$'; then
-                    echo "::error::Latest publishes require either X.Y.Z or X.Y.Z-beta.N (current: $VERSION)"
-                    exit 1
-                  fi
-
-                  if [ "$CHANNEL" == "canary" ] && ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-canary\.[0-9]+$'; then
-                    echo "::error::Canary publishes require X.Y.Z-canary.N (current: $VERSION)"
-                    exit 1
+                  if [ "${{ steps.context.outputs.publish_cca }}" == "true" ]; then
+                    validate_version "create-catalyst-app" "${{ steps.versions.outputs.cca }}" "${{ steps.context.outputs.channel }}"
                   fi
 
             - name: Check release state
               id: release_state
               if: steps.context.outputs.should_run == 'true'
               run: |
-                  PACKAGE_NAME="${{ steps.context.outputs.package }}"
-                  VERSION="${{ steps.version.outputs.value }}"
-                  NPM_TAG="${{ steps.context.outputs.channel }}"
-                  VERSION_EXISTS=false
-                  TAG_EXISTS=false
-                  DIST_TAG_MATCHES=false
-                  DIST_TAG_VERSION=$(npm view "$PACKAGE_NAME@$NPM_TAG" version 2>/dev/null || true)
+                  check_package_state() {
+                    PACKAGE_NAME="$1"
+                    VERSION="$2"
+                    CHANNEL="$3"
+                    TAG_NAME="$4"
+                    PREFIX="$5"
 
-                  if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
-                    VERSION_EXISTS=true
+                    VERSION_EXISTS=false
+                    TAG_EXISTS=false
+                    DIST_TAG_MATCHES=false
+                    DIST_TAG_VERSION=$(npm view "$PACKAGE_NAME@$CHANNEL" version 2>/dev/null || true)
+
+                    if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
+                      VERSION_EXISTS=true
+                    fi
+
+                    if git ls-remote --exit-code --tags origin "refs/tags/$TAG_NAME" >/dev/null 2>&1; then
+                      TAG_EXISTS=true
+                    fi
+
+                    if [ "$DIST_TAG_VERSION" == "$VERSION" ]; then
+                      DIST_TAG_MATCHES=true
+                    fi
+
+                    echo "${PREFIX}_version_exists=$VERSION_EXISTS" >> "$GITHUB_OUTPUT"
+                    echo "${PREFIX}_tag_exists=$TAG_EXISTS" >> "$GITHUB_OUTPUT"
+                    echo "${PREFIX}_dist_tag_matches=$DIST_TAG_MATCHES" >> "$GITHUB_OUTPUT"
+                  }
+
+                  if [ "${{ steps.context.outputs.publish_core }}" == "true" ]; then
+                    check_package_state "catalyst-core" "${{ steps.versions.outputs.core }}" "${{ steps.context.outputs.channel }}" "catalyst-core@${{ steps.versions.outputs.core }}" "core"
                   fi
 
-                  if [ "$PACKAGE_NAME" == "catalyst-core" ] && git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
-                    TAG_EXISTS=true
+                  if [ "${{ steps.context.outputs.publish_cca }}" == "true" ]; then
+                    check_package_state "create-catalyst-app" "${{ steps.versions.outputs.cca }}" "${{ steps.context.outputs.channel }}" "create-catalyst-app@${{ steps.versions.outputs.cca }}" "cca"
                   fi
-
-                  if [ "$DIST_TAG_VERSION" == "$VERSION" ]; then
-                    DIST_TAG_MATCHES=true
-                  fi
-
-                  echo "version_exists=$VERSION_EXISTS" >> "$GITHUB_OUTPUT"
-                  echo "tag_exists=$TAG_EXISTS" >> "$GITHUB_OUTPUT"
-                  echo "dist_tag_matches=$DIST_TAG_MATCHES" >> "$GITHUB_OUTPUT"
 
             - name: Validate release state
               if: steps.context.outputs.should_run == 'true'
               run: |
-                  PACKAGE_NAME="${{ steps.context.outputs.package }}"
-                  VERSION="${{ steps.version.outputs.value }}"
-                  VERSION_EXISTS="${{ steps.release_state.outputs.version_exists }}"
-                  TAG_EXISTS="${{ steps.release_state.outputs.tag_exists }}"
-                  DIST_TAG_MATCHES="${{ steps.release_state.outputs.dist_tag_matches }}"
+                  validate_state() {
+                    PACKAGE_NAME="$1"
+                    VERSION="$2"
+                    VERSION_EXISTS="$3"
+                    TAG_EXISTS="$4"
+                    DIST_TAG_MATCHES="$5"
 
-                  if [ "$VERSION_EXISTS" == "true" ] && [ "$TAG_EXISTS" == "true" ] && [ "$DIST_TAG_MATCHES" == "true" ]; then
-                    echo "::error::Version $VERSION is already published and assigned to the requested dist-tag"
-                    exit 1
+                    if [ "$VERSION_EXISTS" == "true" ] && [ "$TAG_EXISTS" == "true" ] && [ "$DIST_TAG_MATCHES" == "true" ]; then
+                      echo "::error::Version $VERSION is already published and assigned to the requested dist-tag for $PACKAGE_NAME"
+                      exit 1
+                    fi
+                  }
+
+                  if [ "${{ steps.context.outputs.publish_core }}" == "true" ]; then
+                    validate_state "catalyst-core" "${{ steps.versions.outputs.core }}" "${{ steps.release_state.outputs.core_version_exists }}" "${{ steps.release_state.outputs.core_tag_exists }}" "${{ steps.release_state.outputs.core_dist_tag_matches }}"
+                  fi
+
+                  if [ "${{ steps.context.outputs.publish_cca }}" == "true" ]; then
+                    validate_state "create-catalyst-app" "${{ steps.versions.outputs.cca }}" "${{ steps.release_state.outputs.cca_version_exists }}" "${{ steps.release_state.outputs.cca_tag_exists }}" "${{ steps.release_state.outputs.cca_dist_tag_matches }}"
                   fi
 
             - name: Configure Git
@@ -229,55 +283,101 @@ jobs:
                   git config --global user.name "github-actions[bot]"
 
             - name: Install dependencies
-              if: steps.context.outputs.should_run == 'true' && steps.release_state.outputs.version_exists != 'true'
-              run: npm install
+              if: steps.context.outputs.should_run == 'true'
+              run: npm install --ignore-scripts
 
-            - name: Build package
-              if: steps.context.outputs.should_run == 'true' && steps.release_state.outputs.version_exists != 'true'
-              run: npm run prepare
+            - name: Build catalyst-core package
+              if: steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_core == 'true' && steps.release_state.outputs.core_version_exists != 'true'
+              run: npm run prepare --workspace packages/catalyst-core
 
             - name: Update npm for OIDC support
               if: steps.context.outputs.should_run == 'true' && steps.context.outputs.dry_run != 'true'
               run: npm install -g npm@latest
 
-            - name: Publish to npm
-              id: publish_npm
-              if: steps.context.outputs.should_run == 'true' && steps.release_state.outputs.version_exists != 'true' && steps.context.outputs.dry_run != 'true'
-              run: npm publish --tag ${{ steps.context.outputs.channel }} --access public
+            - name: Publish catalyst-core to npm
+              id: publish_core
+              if: steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_core == 'true' && steps.release_state.outputs.core_version_exists != 'true' && steps.context.outputs.dry_run != 'true'
+              run: npm publish --workspace packages/catalyst-core --tag ${{ steps.context.outputs.channel }} --access public
 
-            - name: Update dist-tag
-              id: update_dist_tag
-              if: steps.context.outputs.should_run == 'true' && steps.release_state.outputs.version_exists == 'true' && steps.release_state.outputs.dist_tag_matches != 'true' && steps.context.outputs.dry_run != 'true'
-              run: |
-                  PACKAGE_NAME="${{ steps.context.outputs.package }}"
-                  VERSION="${{ steps.version.outputs.value }}"
-                  NPM_TAG="${{ steps.context.outputs.channel }}"
-                  npm dist-tag add "$PACKAGE_NAME@$VERSION" "$NPM_TAG"
+            - name: Update catalyst-core dist-tag
+              id: retag_core
+              if: steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_core == 'true' && steps.release_state.outputs.core_version_exists == 'true' && steps.release_state.outputs.core_dist_tag_matches != 'true' && steps.context.outputs.dry_run != 'true'
+              run: npm dist-tag add "catalyst-core@${{ steps.versions.outputs.core }}" "${{ steps.context.outputs.channel }}"
 
-            - name: Create git tag
-              id: create_git_tag
-              if: steps.context.outputs.should_run == 'true' && steps.release_state.outputs.tag_exists != 'true' && steps.context.outputs.dry_run != 'true'
+            - name: Verify catalyst-core version for create-catalyst-app templates
+              if: steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_cca == 'true' && steps.context.outputs.dry_run != 'true'
               run: |
-                  VERSION="${{ steps.version.outputs.value }}"
-                  git tag "v$VERSION"
-                  git push origin "v$VERSION"
+                  TEMPLATE_CORE_VERSION=$(node -p "require('./packages/create-catalyst-app/templates/none-js/package.json').dependencies['catalyst-core']")
+
+                  if [ "${{ steps.context.outputs.channel }}" == "beta" ] && ! echo "$TEMPLATE_CORE_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$'; then
+                    echo "::error::create-catalyst-app beta publish requires catalyst-core template dependency X.Y.Z-beta.N (current: $TEMPLATE_CORE_VERSION)"
+                    exit 1
+                  fi
+
+                  if [ "${{ steps.context.outputs.channel }}" == "canary" ] && ! echo "$TEMPLATE_CORE_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-canary\.[0-9]+$'; then
+                    echo "::error::create-catalyst-app canary publish requires catalyst-core template dependency X.Y.Z-canary.N (current: $TEMPLATE_CORE_VERSION)"
+                    exit 1
+                  fi
+
+                  if [ "${{ steps.context.outputs.channel }}" == "latest" ] && ! echo "$TEMPLATE_CORE_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                    echo "::error::create-catalyst-app latest publish requires a stable catalyst-core template dependency (current: $TEMPLATE_CORE_VERSION)"
+                    exit 1
+                  fi
+
+                  if [ "${{ steps.context.outputs.publish_core }}" == "true" ] && [ "$TEMPLATE_CORE_VERSION" != "${{ steps.versions.outputs.core }}" ]; then
+                    echo "::error::create-catalyst-app templates depend on catalyst-core@$TEMPLATE_CORE_VERSION but this publish is releasing catalyst-core@${{ steps.versions.outputs.core }}"
+                    exit 1
+                  fi
+
+                  npm view "catalyst-core@$TEMPLATE_CORE_VERSION" version
+
+            - name: Publish create-catalyst-app to npm
+              id: publish_cca
+              if: steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_cca == 'true' && steps.release_state.outputs.cca_version_exists != 'true' && steps.context.outputs.dry_run != 'true'
+              run: npm publish --workspace packages/create-catalyst-app --tag ${{ steps.context.outputs.channel }} --access public
+
+            - name: Update create-catalyst-app dist-tag
+              id: retag_cca
+              if: steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_cca == 'true' && steps.release_state.outputs.cca_version_exists == 'true' && steps.release_state.outputs.cca_dist_tag_matches != 'true' && steps.context.outputs.dry_run != 'true'
+              run: npm dist-tag add "create-catalyst-app@${{ steps.versions.outputs.cca }}" "${{ steps.context.outputs.channel }}"
+
+            - name: Create catalyst-core git tag
+              id: tag_core
+              if: steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_core == 'true' && steps.release_state.outputs.core_tag_exists != 'true' && steps.context.outputs.dry_run != 'true'
+              run: |
+                  git tag "catalyst-core@${{ steps.versions.outputs.core }}"
+                  git push origin "catalyst-core@${{ steps.versions.outputs.core }}"
+
+            - name: Create create-catalyst-app git tag
+              id: tag_cca
+              if: steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_cca == 'true' && steps.release_state.outputs.cca_tag_exists != 'true' && steps.context.outputs.dry_run != 'true'
+              run: |
+                  git tag "create-catalyst-app@${{ steps.versions.outputs.cca }}"
+                  git push origin "create-catalyst-app@${{ steps.versions.outputs.cca }}"
 
             - name: Send Flock notification
               id: notify
               if: success() && steps.context.outputs.should_run == 'true' && steps.context.outputs.dry_run != 'true'
               run: |
-                  PACKAGE_NAME="${{ steps.context.outputs.package }}"
-                  VERSION="${{ steps.version.outputs.value }}"
-                  NPM_TAG="${{ steps.context.outputs.channel }}"
-                  NPM_URL="https://www.npmjs.com/package/$PACKAGE_NAME/v/$VERSION"
+                  SUMMARY_LINES=()
+
+                  if [ "${{ steps.context.outputs.publish_core }}" == "true" ]; then
+                    SUMMARY_LINES+=("catalyst-core@${{ steps.versions.outputs.core }} (${{ steps.context.outputs.channel }})")
+                  fi
+
+                  if [ "${{ steps.context.outputs.publish_cca }}" == "true" ]; then
+                    SUMMARY_LINES+=("create-catalyst-app@${{ steps.versions.outputs.cca }} (${{ steps.context.outputs.channel }})")
+                  fi
+
+                  SUMMARY=$(printf '%s\n' "${SUMMARY_LINES[@]}")
 
                   curl -X POST "${{ secrets.FLOCK_WEBHOOK_URL }}" \
                     -H "Content-Type: application/json" \
                     -d "{
-                      \"text\": \"✅ Package Published Successfully\",
+                      \"text\": \"✅ Package Publish Completed\",
                       \"attachments\": [{
-                        \"title\": \"$PACKAGE_NAME@$VERSION\",
-                        \"description\": \"NPM Tag: $NPM_TAG\n\nPublished by: ${{ github.actor }}\nBranch: ${{ github.ref_name }}\n\n📦 View on npm: $NPM_URL\",
+                        \"title\": \"${{ github.repository }}\",
+                        \"description\": \"$SUMMARY\n\nPublished by: ${{ github.actor }}\nBranch: ${{ github.ref_name }}\",
                         \"color\": \"#00C851\"
                       }]
                     }"
@@ -285,91 +385,17 @@ jobs:
             - name: Final summary
               if: always()
               run: |
-                  STATUS="${{ job.status }}"
-                  EVENT_NAME="${{ github.event_name }}"
-                  SHOULD_RUN="${{ steps.context.outputs.should_run }}"
-                  PACKAGE_NAME="${{ steps.context.outputs.package }}"
-                  CHANNEL="${{ steps.context.outputs.channel }}"
-                  DRY_RUN="${{ steps.context.outputs.dry_run }}"
-                  REASON="${{ steps.context.outputs.reason }}"
-                  VERSION="${{ steps.version.outputs.value }}"
-                  VERSION_EXISTS="${{ steps.release_state.outputs.version_exists }}"
-                  TAG_EXISTS="${{ steps.release_state.outputs.tag_exists }}"
-                  DIST_TAG_MATCHES="${{ steps.release_state.outputs.dist_tag_matches }}"
-                  PUBLISH_OUTCOME="${{ steps.publish_npm.outcome }}"
-                  DIST_TAG_OUTCOME="${{ steps.update_dist_tag.outcome }}"
-                  TAG_OUTCOME="${{ steps.create_git_tag.outcome }}"
-                  NOTIFY_OUTCOME="${{ steps.notify.outcome }}"
+                  echo "status=${{ job.status }}"
+                  echo "reason=${{ steps.context.outputs.reason }}"
+                  echo "channel=${{ steps.context.outputs.channel }}"
+                  echo "dry_run=${{ steps.context.outputs.dry_run }}"
+                  echo "publish_core=${{ steps.context.outputs.publish_core }}"
+                  echo "publish_cca=${{ steps.context.outputs.publish_cca }}"
 
-                  if [ "$SHOULD_RUN" != "true" ]; then
-                    NPM_ACTION="skipped"
-                    TAG_ACTION="skipped"
-                    NOTIFICATION_ACTION="skipped"
-                  elif [ "$VERSION_EXISTS" != "true" ]; then
-                    if [ "$DRY_RUN" == "true" ]; then
-                      NPM_ACTION="would publish $PACKAGE_NAME@$VERSION with dist-tag $CHANNEL"
-                    elif [ "$PUBLISH_OUTCOME" == "success" ]; then
-                      NPM_ACTION="published $PACKAGE_NAME@$VERSION with dist-tag $CHANNEL"
-                    elif [ "$PUBLISH_OUTCOME" == "failure" ]; then
-                      NPM_ACTION="publish failed"
-                    else
-                      NPM_ACTION="publish not run"
-                    fi
-                  elif [ "$DIST_TAG_MATCHES" != "true" ]; then
-                    if [ "$DRY_RUN" == "true" ]; then
-                      NPM_ACTION="would update dist-tag $CHANNEL -> $VERSION"
-                    elif [ "$DIST_TAG_OUTCOME" == "success" ]; then
-                      NPM_ACTION="updated dist-tag $CHANNEL -> $VERSION"
-                    elif [ "$DIST_TAG_OUTCOME" == "failure" ]; then
-                      NPM_ACTION="dist-tag update failed"
-                    else
-                      NPM_ACTION="dist-tag update not run"
-                    fi
-                  else
-                    NPM_ACTION="no npm write needed"
+                  if [ "${{ steps.context.outputs.publish_core }}" == "true" ]; then
+                    echo "catalyst-core=${{ steps.versions.outputs.core }}"
                   fi
 
-                  if [ "$SHOULD_RUN" != "true" ]; then
-                    TAG_ACTION="skipped"
-                  elif [ "$TAG_EXISTS" != "true" ]; then
-                    if [ "$DRY_RUN" == "true" ]; then
-                      TAG_ACTION="would create git tag v$VERSION"
-                    elif [ "$TAG_OUTCOME" == "success" ]; then
-                      TAG_ACTION="created git tag v$VERSION"
-                    elif [ "$TAG_OUTCOME" == "failure" ]; then
-                      TAG_ACTION="git tag creation failed"
-                    else
-                      TAG_ACTION="git tag step not run"
-                    fi
-                  else
-                    TAG_ACTION="git tag already present"
+                  if [ "${{ steps.context.outputs.publish_cca }}" == "true" ]; then
+                    echo "create-catalyst-app=${{ steps.versions.outputs.cca }}"
                   fi
-
-                  if [ "$SHOULD_RUN" != "true" ]; then
-                    NOTIFICATION_ACTION="skipped"
-                  elif [ "$DRY_RUN" == "true" ]; then
-                    NOTIFICATION_ACTION="skipped (dry_run=true)"
-                  elif [ "$NOTIFY_OUTCOME" == "success" ]; then
-                    NOTIFICATION_ACTION="sent"
-                  elif [ "$NOTIFY_OUTCOME" == "failure" ]; then
-                    NOTIFICATION_ACTION="failed"
-                  else
-                    NOTIFICATION_ACTION="skipped"
-                  fi
-
-                  {
-                    echo "publish summary"
-                    echo "- status: $STATUS"
-                    echo "- trigger: $EVENT_NAME"
-                    echo "- branch: ${{ github.ref_name }}"
-                    echo "- should_run: $SHOULD_RUN"
-                    echo "- reason: $REASON"
-                    echo "- package: $PACKAGE_NAME"
-                    echo "- channel: $CHANNEL"
-                    echo "- version: ${VERSION:-not read}"
-                    echo "- dry_run: $DRY_RUN"
-                    echo "- npm_state: version_exists=${VERSION_EXISTS:-unknown}, tag_matches=${DIST_TAG_MATCHES:-unknown}"
-                    echo "- npm_action: $NPM_ACTION"
-                    echo "- git_tag: $TAG_ACTION"
-                    echo "- notification: $NOTIFICATION_ACTION"
-                  } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,27 @@
 **/node_modules
+
+# Monorepo app local config and generated output
+apps/docs/config.json
+apps/docs/server/config.json
+apps/docs/login-page/src/config.json
+apps/docs/static/js/config.js
+apps/docs/build/
+apps/docs/.docusaurus/
+apps/docs/public-docs/
+apps/docs/docs/
+apps/docs/api/
+apps/docs/temp/
+apps/docs/server/collection-files/
+apps/docs/login-page/build/
+apps/docs/.claude/
+apps/docs/hyperframes/
+
 /webpack
 /router
 /scripts
+!/scripts/
+!/scripts/release/
+!/scripts/release/sync-cca-templates.js
 /server
 /types
 /dist
@@ -13,6 +33,10 @@ logger.js
 /logs
 /loadable-stats.json
 /index.js
+packages/*/dist
+packages/catalyst-core/template/logs/
+packages/catalyst-core/template/playwright-report/
+packages/catalyst-core/template/test-results/
 
 build/
 **/iosnativeWebView/build/

--- a/scripts/release/sync-cca-templates.js
+++ b/scripts/release/sync-cca-templates.js
@@ -1,0 +1,164 @@
+const fs = require("fs")
+const path = require("path")
+
+const repoRoot = path.resolve(__dirname, "..", "..")
+const corePackagePath = path.join(repoRoot, "packages", "catalyst-core", "package.json")
+const templatesDir = path.join(repoRoot, "packages", "create-catalyst-app", "templates")
+const shouldCheckOnly = process.argv.includes("--check")
+const supportedCatalystPackages = ["catalyst-core", "catalyst-core-internal"]
+
+function getArgValue(flagName) {
+    const arg = process.argv.find((item) => item.startsWith(`${flagName}=`))
+    return arg ? arg.slice(flagName.length + 1) : null
+}
+
+const corePackage = JSON.parse(fs.readFileSync(corePackagePath, "utf8"))
+const targetPackageName = getArgValue("--package-name") || corePackage.name
+const targetVersion = getArgValue("--package-version") || corePackage.version
+
+const templateDirs = fs
+    .readdirSync(templatesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+
+const updatedTemplates = []
+const invalidTemplates = []
+const invalidFiles = []
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function createPackageReferenceRegex(packageName, flags = "") {
+    return new RegExp(`(^|[^A-Za-z0-9_-])(${escapeRegExp(packageName)})(?=$|[^A-Za-z0-9_-])`, flags)
+}
+
+function hasPackageReference(content, packageName) {
+    return createPackageReferenceRegex(packageName).test(content)
+}
+
+function replacePackageReferences(content, packageName, replacement) {
+    return content.replace(createPackageReferenceRegex(packageName, "g"), `$1${replacement}`)
+}
+
+function walkTemplateFiles(currentDir) {
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true })
+    let files = []
+
+    for (const entry of entries) {
+        const entryPath = path.join(currentDir, entry.name)
+
+        if (entry.isDirectory()) {
+            files = files.concat(walkTemplateFiles(entryPath))
+            continue
+        }
+
+        if (!/\.(js|jsx|ts|tsx|json|md|cjs|mjs|scss)$/.test(entry.name)) {
+            continue
+        }
+
+        files.push(entryPath)
+    }
+
+    return files
+}
+
+function getConflictingPackageNames(content) {
+    return supportedCatalystPackages.filter(
+        (packageName) => packageName !== targetPackageName && hasPackageReference(content, packageName)
+    )
+}
+
+for (const templateDir of templateDirs) {
+    const packageJsonPath = path.join(templatesDir, templateDir, "package.json")
+
+    if (!fs.existsSync(packageJsonPath)) {
+        continue
+    }
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"))
+    const dependencyEntries = Object.entries(packageJson.dependencies || {})
+    const currentDependency = dependencyEntries.find(([name]) => supportedCatalystPackages.includes(name))
+    const currentPackageName = currentDependency?.[0]
+    const currentVersion = currentDependency?.[1]
+
+    if (!currentPackageName || !currentVersion) {
+        continue
+    }
+
+    if (currentPackageName !== targetPackageName || currentVersion !== targetVersion) {
+        if (shouldCheckOnly) {
+            invalidTemplates.push({
+                name: templateDir,
+                currentPackageName,
+                currentVersion,
+            })
+            continue
+        }
+
+        for (const packageName of supportedCatalystPackages) {
+            delete packageJson.dependencies[packageName]
+        }
+
+        packageJson.dependencies[targetPackageName] = targetVersion
+        fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 4)}\n`)
+        updatedTemplates.push(templateDir)
+    }
+}
+
+for (const filePath of walkTemplateFiles(templatesDir)) {
+    if (filePath.endsWith("package.json")) {
+        continue
+    }
+
+    const currentContent = fs.readFileSync(filePath, "utf8")
+    const conflictingPackages = getConflictingPackageNames(currentContent)
+
+    if (conflictingPackages.length === 0) {
+        continue
+    }
+
+    if (shouldCheckOnly) {
+        invalidFiles.push({
+            filePath: path.relative(repoRoot, filePath),
+            conflictingPackages,
+        })
+        continue
+    }
+
+    let nextContent = currentContent
+    for (const packageName of conflictingPackages) {
+        nextContent = replacePackageReferences(nextContent, packageName, targetPackageName)
+    }
+
+    fs.writeFileSync(filePath, nextContent)
+}
+
+if (shouldCheckOnly && invalidTemplates.length > 0) {
+    console.error("create-catalyst-app templates are out of sync with catalyst-core:")
+    for (const template of invalidTemplates) {
+        console.error(
+            `- ${template.name}: ${template.currentPackageName}@${template.currentVersion} -> ${targetPackageName}@${targetVersion}`
+        )
+    }
+}
+
+if (shouldCheckOnly && invalidFiles.length > 0) {
+    console.error("create-catalyst-app template source files reference the wrong catalyst package:")
+    for (const entry of invalidFiles) {
+        console.error(`- ${entry.filePath}: ${entry.conflictingPackages.join(", ")} -> ${targetPackageName}`)
+    }
+}
+
+if (shouldCheckOnly && (invalidTemplates.length > 0 || invalidFiles.length > 0)) {
+    process.exit(1)
+}
+
+if (!shouldCheckOnly) {
+    console.log(
+        updatedTemplates.length > 0
+            ? `Updated template ${targetPackageName} versions in: ${updatedTemplates.join(", ")}`
+            : `All create-catalyst-app templates already matched ${targetPackageName}`
+    )
+}


### PR DESCRIPTION
Summary
This PR updates the release automation on main to support the upcoming monorepo release flow.

Changes

Replaces existing prepare-release.yml with the monorepo-aware release preparation workflow.
Replaces existing publish.yml with the monorepo-aware publish workflow.
Adds scripts/release/sync-cca-templates.js to sync CCA template dependencies to the selected catalyst-core / catalyst-core-internal version.