### PR TITLE
Catalyst Docs Deployment Fix

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,26 +1,25 @@
-FROM --platform=linux/amd64 node:18-alpine as build
+FROM --platform=linux/amd64 node:16-alpine as build
 ARG env_name
 ARG env
 
 RUN apk add --no-cache \
     make \
     g++ \
-    python3 \
-    py3-pip \
-    openssh-client \
+    aws-cli \
     git \
     gcc \
     shared-mime-info \
     bash
-RUN pip3 install --no-cache-dir awscli
 
 WORKDIR /opt/1mg/web
+
 COPY docs/package.json docs/package-lock.json ./docs/
 COPY docs/server/package.json ./docs/server/
 COPY docs/login-page/package.json ./docs/login-page/
 RUN npm --prefix docs ci
 
 COPY docs ./docs
+
 WORKDIR /opt/1mg/web/docs
 
 ARG SERVICE_NAME


### PR DESCRIPTION
**PR Summary**

Fixes the docs Docker image build for Devtron deployment.

Changes vs `main`:
- Switches docs Docker base image from `node:18-alpine` to `node:16-alpine` to match the original docs runtime requirement.
- Replaces `pip3 install awscli` with Alpine package install via `apk add aws-cli`, fixing the PEP 668 externally-managed Python failure.
- Removes now-unneeded `python3`, `py3-pip`, and `openssh-client` packages from the image.