### PR TITLE
Catalyst Docs Mismatches Fix

### DIFF
--- a/.github/workflows/docs-tag.yml
+++ b/.github/workflows/docs-tag.yml
@@ -1,0 +1,58 @@
+name: Tag Docs
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - "docs/**"
+
+permissions:
+    contents: write
+
+concurrency:
+    group: docs-tag-${{ github.ref_name }}
+    cancel-in-progress: false
+
+jobs:
+    tag-docs:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "18"
+
+            - name: Build docs
+              run: |
+                  npm --prefix docs ci
+                  cp docs/config_template.json docs/config.json
+                  npm run docs:build
+
+            - name: Create docs git tag
+              run: |
+                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                  git config --global user.name "github-actions[bot]"
+
+                  git fetch --tags origin
+
+                  LATEST_TAG=$(git tag --list "catalyst-docs@[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
+
+                  if [ -z "$LATEST_TAG" ]; then
+                    TAG_NAME="catalyst-docs@1.0.0"
+                  else
+                    VERSION="${LATEST_TAG#catalyst-docs@}"
+                    MAJOR="${VERSION%%.*}"
+                    REMAINDER="${VERSION#*.}"
+                    MINOR="${REMAINDER%%.*}"
+                    PATCH="${VERSION##*.}"
+                    NEXT_PATCH=$((PATCH + 1))
+                    TAG_NAME="catalyst-docs@${MAJOR}.${MINOR}.${NEXT_PATCH}"
+                  fi
+
+                  git tag "$TAG_NAME"
+                  git push origin "$TAG_NAME"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,61 @@
-# Catalyst Monorepo
+# Catalyst
 
-This repository contains the publishable Catalyst packages and supporting apps:
+<div align="center">
+ <picture>
+ <source media="(prefers-color-scheme: dark)" srcset="https://onemg.gumlet.io/staging/7ee66dfb-b5fb-4fbe-8dea-789685e45f7a.svg">
+ <img alt="Catalyst logo" src="https://onemg.gumlet.io/staging/2fdb0975-8f51-4fd1-bd7d-6375d793f581.svg" height="128">
+ </picture>
+</div>
 
-- `packages/catalyst-core`: the framework package
-- `packages/create-catalyst-app`: the CLI and scaffold templates used to generate new apps
+Catalyst is a React framework for building performant web apps and universal apps for Android and iOS. It provides server-side rendering, route-level data fetching, app shell primitives, styling conventions, and native WebView packaging tools.
+
+## Quick Start
+
+Create a new Catalyst app with:
+
+```sh
+npx create-catalyst-app@latest
+```
+
+Then start the generated app:
+
+```sh
+cd <your-app>
+npm run start
+```
+
+The development server starts at `http://localhost:3005`.
+
+## Documentation
+
+Read the full documentation at [catalyst.1mg.com](https://catalyst.1mg.com).
+
+Useful starting points:
+
+- [Getting Started](https://catalyst.1mg.com/content/Introduction/getting-started)
+- [First Catalyst App](https://catalyst.1mg.com/content/Guides%20and%20Tutorials/First%20Catalyst%20App/quick-start)
+- [Universal App Setup](https://catalyst.1mg.com/content/Guides%20and%20Tutorials/First%20Universal%20App/first-universal-app)
+
+## Packages
+
+- [`catalyst-core`](./packages/catalyst-core): the framework package used by Catalyst applications.
+- [`create-catalyst-app`](./packages/create-catalyst-app): the CLI for scaffolding new Catalyst apps.
+
+## Requirements
+
+- Node.js `20.4.0` or later for generated Catalyst apps.
+- macOS or Linux for local development.
+
+## Repository
+
+This repository is a monorepo containing the framework package, scaffolding CLI, docs app, and internal test fixture.
+
+- `packages/catalyst-core`: framework package
+- `packages/create-catalyst-app`: CLI and scaffold templates
 - `apps/catalyst-core-test`: standalone fixture app used to test `catalyst-core`
 - `docs`: Catalyst documentation app
 
-Release preparation and publishing are managed from the repository root.
-
-## Fresh Clone Setup
+## Contributing
 
 Install dependencies and create local docs config before running build/test commands:
 
@@ -17,7 +63,7 @@ Install dependencies and create local docs config before running build/test comm
 npm run setup
 ```
 
-Then run the project commands you need:
+Common development commands:
 
 ```sh
 npm run core:build
@@ -26,18 +72,10 @@ npm run cca:test
 npm run docs:build
 ```
 
-## Release Sandbox
-
-Create a real scaffolded app from the current branch packages
+To scaffold a real app from the current branch packages:
 
 ```sh
 npm run sandbox:create -- --name release-test
 ```
 
-For non-interactive default scaffolding:
-
-```sh
-npm run sandbox:create -- --name release-test --yes --force
-```
-
-The app is created under `.sandbox/<name>` and uses a local packed `catalyst-core` from the current branch.
+The sandbox app is created under `.sandbox/<name>` and uses a local packed `catalyst-core` from the current branch.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Read the full documentation at [catalyst.1mg.com](https://catalyst.1mg.com).
 
 Useful starting points:
 
-- [Getting Started](https://catalyst.1mg.com/content/Introduction/getting-started)
-- [First Catalyst App](https://catalyst.1mg.com/content/Guides%20and%20Tutorials/First%20Catalyst%20App/quick-start)
-- [Universal App Setup](https://catalyst.1mg.com/content/Guides%20and%20Tutorials/First%20Universal%20App/first-universal-app)
+- [Getting Started](https://catalyst.1mg.com/public_docs/content/Introduction/getting-started)
+- [First Catalyst App](https://catalyst.1mg.com/public_docs/content/Guides%20and%20Tutorials/First%20Catalyst%20App/quick-start)
+- [Universal App Setup](https://catalyst.1mg.com/public_docs/content/Guides%20and%20Tutorials/First%20Universal%20App/first-universal-app)
 
 ## Packages
 

--- a/docs/content/02-Guides and Tutorials/01-First Catalyst App/04-Configuration.md
+++ b/docs/content/02-Guides and Tutorials/01-First Catalyst App/04-Configuration.md
@@ -239,12 +239,22 @@ Here's a complete example configuration file:
   "CLIENT_ENV_VARIABLES": ["API_URL", "ANALYTICS_ID"],
 
   "WEBVIEW_CONFIG": {
+    "port": "3005",
+    "LOCAL_IP": "192.168.0.11",
+    "appInfo": "android-v2.1.0",
     "useHttps": true,
     "android": {
-      "appName": "My App"
+      "appName": "My App",
+      "packageName": "com.example.myapp",
+      "buildType": "debug",
+      "sdkPath": "/Users/yourname/Library/Android/sdk",
+      "emulatorName": "Pixel_5_API_30"
     },
     "ios": {
-      "appName": "My App"
+      "appName": "My App",
+      "appBundleId": "com.example.myapp",
+      "buildType": "Debug",
+      "simulatorName": "iPhone 17 Pro"
     },
     "accessControl": {
       "enabled": true,
@@ -252,7 +262,7 @@ Here's a complete example configuration file:
         "https://api.example.com/*",
         "*.cdn.example.com"
       ]
-    }
+    },
     "splashScreen": {
       "duration": 2000,
       "backgroundColor": "#ffffff",

--- a/docs/content/02-Guides and Tutorials/01-First Catalyst App/04-Configuration.md
+++ b/docs/content/02-Guides and Tutorials/01-First Catalyst App/04-Configuration.md
@@ -4,6 +4,8 @@ slug: configuration
 id: configuration
 ---
 
+import ConfigExample from '@site/src/components/ConfigExample'
+
 # Configuration
 
 Catalyst uses `config/config.json` for all application configuration. This file controls server settings, environment variables, universal app settings, and more.
@@ -224,55 +226,7 @@ Configure webview protocol settings for your universal app. Control whether the 
 
 Here's a complete example configuration file:
 
-```json title="config/config.json"
-{
-  "NODE_SERVER_HOSTNAME": "localhost",
-  "NODE_SERVER_PORT": 3005,
-  "WEBPACK_DEV_SERVER_HOSTNAME": "localhost",
-  "WEBPACK_DEV_SERVER_PORT": 3006,
-  "BUILD_OUTPUT_PATH": "build",
-  "PUBLIC_STATIC_ASSET_PATH": "/assets/",
-  "PUBLIC_STATIC_ASSET_URL": "http://localhost:3006",
-  "NODE_ENV": "development",
-  "API_URL": "https://api.example.com",
-  "ANALYTICS_ID": "UA-123456",
-  "CLIENT_ENV_VARIABLES": ["API_URL", "ANALYTICS_ID"],
-
-  "WEBVIEW_CONFIG": {
-    "port": "3005",
-    "LOCAL_IP": "192.168.0.11",
-    "appInfo": "android-v2.1.0",
-    "useHttps": true,
-    "android": {
-      "appName": "My App",
-      "packageName": "com.example.myapp",
-      "buildType": "debug",
-      "sdkPath": "/Users/yourname/Library/Android/sdk",
-      "emulatorName": "Pixel_5_API_30"
-    },
-    "ios": {
-      "appName": "My App",
-      "appBundleId": "com.example.myapp",
-      "buildType": "Debug",
-      "simulatorName": "iPhone 17 Pro"
-    },
-    "accessControl": {
-      "enabled": true,
-      "allowedUrls": [
-        "https://api.example.com/*",
-        "*.cdn.example.com"
-      ]
-    },
-    "splashScreen": {
-      "duration": 2000,
-      "backgroundColor": "#ffffff",
-      "imageWidth": 120,
-      "imageHeight": 120,
-      "cornerRadius": 20
-    }
-  }
-}
-```
+<ConfigExample type="appConfig" />
 
 ---
 

--- a/docs/content/02-Guides and Tutorials/02-First Universal App/03-Configuration.md
+++ b/docs/content/02-Guides and Tutorials/02-First Universal App/03-Configuration.md
@@ -401,13 +401,25 @@ Control whether the webview uses HTTP or HTTPS protocol.
 ```json title="config/config.json"
 {
   "WEBVIEW_CONFIG": {
+    "port": "3005",
+    "LOCAL_IP": "192.168.0.11",
+    "appInfo": "android-v2.1.0",
+    "useHttps": true,
     "android": {
-      "appName": "My Awesome App"
+      "appName": "My Awesome App",
+      "packageName": "com.example.myawesomeapp",
+      "buildType": "debug",
+      "sdkPath": "/Users/yourname/Library/Android/sdk",
+      "emulatorName": "Pixel_5_API_30",
+      "cachePattern": "*.css,*.js"
     },
     "ios": {
-      "appName": "My Awesome App"
+      "appName": "My Awesome App",
+      "appBundleId": "com.example.myawesomeapp",
+      "buildType": "Debug",
+      "simulatorName": "iPhone 17 Pro",
+      "cachePattern": "*.css,*.js"
     },
-    "useHttps": true,
     "accessControl": {
       "enabled": true,
       "allowedUrls": [

--- a/docs/content/02-Guides and Tutorials/02-First Universal App/03-Configuration.md
+++ b/docs/content/02-Guides and Tutorials/02-First Universal App/03-Configuration.md
@@ -5,6 +5,8 @@ id: universal-app-configuration
 sidebar_position: 11
 ---
 
+import ConfigExample from '@site/src/components/ConfigExample'
+
 # Universal App Configuration
 
 Configure your universal app's appearance, behavior, and security settings through `config/config.json`.
@@ -398,49 +400,7 @@ Control whether the webview uses HTTP or HTTPS protocol.
 
 ## Complete Configuration Example
 
-```json title="config/config.json"
-{
-  "WEBVIEW_CONFIG": {
-    "port": "3005",
-    "LOCAL_IP": "192.168.0.11",
-    "appInfo": "android-v2.1.0",
-    "useHttps": true,
-    "android": {
-      "appName": "My Awesome App",
-      "packageName": "com.example.myawesomeapp",
-      "buildType": "debug",
-      "sdkPath": "/Users/yourname/Library/Android/sdk",
-      "emulatorName": "Pixel_5_API_30",
-      "cachePattern": "*.css,*.js"
-    },
-    "ios": {
-      "appName": "My Awesome App",
-      "appBundleId": "com.example.myawesomeapp",
-      "buildType": "Debug",
-      "simulatorName": "iPhone 17 Pro",
-      "cachePattern": "*.css,*.js"
-    },
-    "accessControl": {
-      "enabled": true,
-      "allowedUrls": [
-        "https://api.myapp.com/*",
-        "https://cdn.myapp.com/*",
-        "*.cloudfront.net"
-      ]
-    },
-    "splashScreen": {
-      "duration": 2000,
-      "backgroundColor": "#ffffff",
-      "imageWidth": 120,
-      "imageHeight": 120,
-      "cornerRadius": 20
-    },
-    "notifications": {
-      "enabled": true
-    }
-  }
-}
-```
+<ConfigExample type="universalAppConfig" />
 
 ---
 

--- a/docs/content/02-Guides and Tutorials/02-First Universal App/04-Offline-Support.md
+++ b/docs/content/02-Guides and Tutorials/02-First Universal App/04-Offline-Support.md
@@ -20,7 +20,7 @@
 - Why use it: drive in-app banners, pause/resume live data, or disable actions while offline—while native still owns the full-screen offline fallback.
 - Example:
   ```jsx
-  import { useNetworkStatus } from "catalyst-core/native"
+  import { useNetworkStatus } from "catalyst-core/hooks"
 
   export function ConnectivityBanner() {
       const { online, type } = useNetworkStatus()

--- a/docs/content/02-Guides and Tutorials/02-First Universal App/05-Cache-Management.md
+++ b/docs/content/02-Guides and Tutorials/02-First Universal App/05-Cache-Management.md
@@ -24,16 +24,29 @@ Configuration options:
 - `cachePattern`: Comma-separated list of file patterns to cache (e.g., "*.css,*.js")
 
 ### iOS Configuration
-Configure caching by setting cache patterns in constants:
-- Define patterns for files to be cached (e.g., CSS and JS files)
-- Multiple patterns can be specified in an array
+Configure caching through `WEBVIEW_CONFIG.ios.cachePattern`:
+
+```json
+{
+  "WEBVIEW_CONFIG": {
+    "ios": {
+      "buildType": "Debug",
+      "cachePattern": "*.css,*.js"
+    }
+  }
+}
+```
+
+Configuration options:
+- `buildType`: Use `Debug` for development. Use `Release` for distribution builds.
+- `cachePattern`: Comma-separated list of file patterns to cache (e.g., "*.css,*.js")
 
 ## Cache Pattern Format
 
 Both platforms support wildcard patterns for cache matching:
 - `*.css`: Matches all CSS files
 - `*.js`: Matches all JavaScript files
-- Multiple patterns can be specified
+- Multiple patterns can be specified as a comma-separated string
 - File extensions are case-insensitive
 
 ## Internal Implementation

--- a/docs/content/02-Guides and Tutorials/10-Customising-Shell.md
+++ b/docs/content/02-Guides and Tutorials/10-Customising-Shell.md
@@ -14,7 +14,7 @@ Create or edit `server/document.js` to customize:
 
 ```jsx title="server/document.js"
 import React from "react";
-import { Head, Body } from "catalyst";
+import { Head, Body } from "catalyst-core";
 
 function Document(props) {
   return (
@@ -32,7 +32,7 @@ export default Document;
 
 ```jsx title="server/document.js"
 import React from "react";
-import { Head, Body } from "catalyst";
+import { Head, Body } from "catalyst-core";
 
 function Document(props) {
   return (
@@ -54,7 +54,7 @@ export default Document;
 
 ```jsx title="server/document.js"
 import React from "react";
-import { Head, Body } from "catalyst";
+import { Head, Body } from "catalyst-core";
 
 function Document(props) {
   return (
@@ -84,7 +84,7 @@ The `props` object includes the request, allowing server-side customization:
 
 ```jsx title="server/document.js"
 import React from "react";
-import { Head, Body } from "catalyst";
+import { Head, Body } from "catalyst-core";
 
 function Document(props) {
   const { req } = props;

--- a/docs/content/06-Fonts.md
+++ b/docs/content/06-Fonts.md
@@ -73,7 +73,7 @@ Third-party hosted fonts such as Google Fonts, Adobe Fonts, or any CDN-hosted fo
 For Google Fonts, add `preconnect` and the stylesheet link inside `Head`:
 
 ```jsx title="server/document.js"
-import { Head, Body } from "catalyst";
+import { Head, Body } from "catalyst-core";
 
 function Document(props) {
   return (

--- a/docs/content/11-API Reference/01-Hooks.md
+++ b/docs/content/11-API Reference/01-Hooks.md
@@ -13,10 +13,11 @@ Catalyst exposes two groups of hooks:
 
 ## Hooks Overview
 
-| Hook | Description | Web | iOS | Android |
-|------|-------------|-----|-----|---------|
+| Hook / API | Description | Web | iOS | Android |
+|------------|-------------|-----|-----|---------|
 | `useRouterData` | Access data for all matched routes | Yes | Yes | Yes |
 | `useCurrentRouteData` | Access current route fetcher state and data | Yes | Yes | Yes |
+| `getDeviceInfo` | Read device, screen, and app metadata from the bridge | Yes | Yes | Yes |
 | `useCamera` | Capture media via the bridge or web fallback | Partial | Yes | Yes |
 | `useFilePicker` | Select files and normalize results | Partial | Yes | Yes |
 | `useIntent` | Open files or URLs with external apps | No | Yes | Yes |
@@ -166,6 +167,44 @@ Most native hooks follow a common pattern:
 - `execute`
 - `clear`
 - `clearError`
+
+### `getDeviceInfo`
+
+Read device, screen, and app metadata from the native bridge. `getDeviceInfo` is exposed by `WebBridge.init()` and on `window.WebBridge`; it is not a React hook exported from `catalyst-core/hooks`.
+
+#### Import
+
+```javascript
+import WebBridge from "catalyst-core/WebBridge";
+```
+
+#### Returns
+
+Resolves to an object with normalized device metadata.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `model` | `string` | Device model, or the browser user agent on web |
+| `manufacturer` | `string` | Device manufacturer, or `browser` on web |
+| `platform` | `string` | `ios`, `android`, or `web` |
+| `screenWidth` | `number` | Screen width in pixels |
+| `screenHeight` | `number` | Screen height in pixels |
+| `screenDensity` | `number` | Screen scale or pixel density |
+| `appInfo` | `object \| string \| null` | App metadata provided by the native shell, when available |
+| `security` | `object` | Android security check state, when available |
+
+#### Usage
+
+```javascript
+const { getDeviceInfo } = WebBridge.init();
+
+async function logDeviceInfo() {
+  const deviceInfo = await getDeviceInfo();
+  console.log(deviceInfo.platform, deviceInfo.model);
+}
+```
+
+If the bridge is already initialized, you can also call `window.WebBridge.getDeviceInfo()`. On web, `getDeviceInfo()` resolves with browser and screen information instead of throwing.
 
 ### `useCamera`
 

--- a/docs/content/11-API Reference/01-Hooks.md
+++ b/docs/content/11-API Reference/01-Hooks.md
@@ -19,10 +19,15 @@ Catalyst exposes two groups of hooks:
 | `useCurrentRouteData` | Access current route fetcher state and data | Yes | Yes | Yes |
 | `useCamera` | Capture media via the bridge or web fallback | Partial | Yes | Yes |
 | `useFilePicker` | Select files and normalize results | Partial | Yes | Yes |
+| `useIntent` | Open files or URLs with external apps | No | Yes | Yes |
+| `useGoogleSignIn` | Trigger Google sign-in through the native shell | No | Yes | Yes |
+| `useCameraPermission` | Check and request camera permission | Partial | Yes | Yes |
+| `useNotificationPermission` | Check and request notification permission | No | Yes | Yes |
 | `useHapticFeedback` | Trigger haptic feedback with platform-aware behavior | No | Yes | Yes |
-| `useStorage` | Persist key-value data across platforms | Yes | Yes | Yes |
-| `useDeviceInfo` | Read platform and device details | Partial | Yes | Yes |
 | `useNotification` | Schedule local notifications and manage push setup | No | Yes | Yes |
+| `useNetworkStatus` | Read online status and network type | Yes | Yes | Yes |
+| `useDataProtection` | Use native data protection and encryption helpers | No | Yes | Yes |
+| `useSafeArea` | Read native safe-area insets | Yes | Yes | Yes |
 
 `Partial` means behavior depends on browser support or fallback behavior in the web environment.
 
@@ -138,10 +143,15 @@ Import universal hooks from `catalyst-core/hooks`:
 import {
   useCamera,
   useFilePicker,
+  useIntent,
+  useGoogleSignIn,
+  useCameraPermission,
+  useNotificationPermission,
   useHapticFeedback,
-  useStorage,
-  useDeviceInfo,
   useNotification,
+  useNetworkStatus,
+  useDataProtection,
+  useSafeArea,
 } from "catalyst-core/hooks";
 ```
 
@@ -258,63 +268,56 @@ function FeedbackButton() {
 }
 ```
 
-### `useStorage`
+### `useIntent`
 
-Cross-platform key-value storage for universal apps.
-
-#### Returns
-
-| Method | Type | Description |
-|--------|------|-------------|
-| `getItem` | `(key) => Promise<string>` | Get value by key |
-| `setItem` | `(key, value) => Promise<void>` | Store value |
-| `removeItem` | `(key) => Promise<void>` | Delete value |
-| `clear` | `() => Promise<void>` | Clear all storage |
-| `getAllKeys` | `() => Promise<string[]>` | List all keys |
-
-#### Usage
-
-```javascript
-function UserPreferences() {
-  const { getItem, setItem, removeItem } = useStorage();
-
-  const saveTheme = async (theme) => {
-    await setItem("theme", theme);
-  };
-
-  return <button onClick={() => saveTheme("dark")}>Set Dark Theme</button>;
-}
-```
-
-### `useDeviceInfo`
-
-Read platform and device information in a normalized format.
+Open a file or URL with an external native app.
 
 #### Returns
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `platform` | `"web" \| "ios" \| "android"` | Current platform |
-| `model` | `string` | Device model name |
-| `manufacturer` | `string` | Device manufacturer |
-| `screenWidth` | `number` | Screen width in pixels |
-| `screenHeight` | `number` | Screen height in pixels |
-| `screenDensity` | `number` | Screen pixel density |
+| `execute` | `function` | Open the target URL with the provided MIME type |
+| `loading` | `boolean` | Intent flow in progress |
+| `error` | `object \| null` | Standardized error object |
+| `isNative` | `boolean` | Running inside the native shell |
+| `clear` | `function` | Clear result state |
+| `clearError` | `function` | Clear error state only |
 
 #### Usage
 
 ```javascript
-function DeviceDetails() {
-  const { platform, model, manufacturer, screenWidth, screenHeight, screenDensity } = useDeviceInfo();
+function OpenInvoiceButton({ url }) {
+  const { execute, loading } = useIntent();
 
   return (
-    <div>
-      <p>Platform: {platform}</p>
-      <p>Model: {model}</p>
-      <p>Manufacturer: {manufacturer}</p>
-      <p>Screen: {screenWidth} x {screenHeight} ({screenDensity}x)</p>
-    </div>
+    <button onClick={() => execute(url, "application/pdf")} disabled={loading}>
+      Open Invoice
+    </button>
   );
+}
+```
+
+### `useCameraPermission`
+
+Check or request camera permission through the native bridge.
+
+```javascript
+function CameraPermissionButton() {
+  const { permission, isLoading } = useCameraPermission();
+
+  return <button disabled={isLoading}>Camera permission: {permission || "checking"}</button>;
+}
+```
+
+### `useNotificationPermission`
+
+Check or request notification permission before registering for push notifications.
+
+```javascript
+function NotificationPermissionButton() {
+  const { permission, isLoading } = useNotificationPermission();
+
+  return <button disabled={isLoading}>Notification permission: {permission || "checking"}</button>;
 }
 ```
 
@@ -360,3 +363,65 @@ function NotificationExample() {
 #### Requirements
 
 Push-related notification features require `WEBVIEW_CONFIG.notifications.enabled = true` and the relevant Firebase platform files in the native projects.
+
+### `useGoogleSignIn`
+
+Trigger Google sign-in through the native shell.
+
+```javascript
+function GoogleLoginButton() {
+  const { signIn, loading, error } = useGoogleSignIn();
+
+  return <button onClick={signIn} disabled={loading}>Continue with Google</button>;
+}
+```
+
+### `useNetworkStatus`
+
+Read connectivity state from the native bridge, with a browser fallback.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `online` | `boolean` | Current connectivity state |
+| `type` | `string \| null` | Network type such as `wifi` or `cellular` |
+| `error` | `string \| null` | Connectivity error, if any |
+
+```javascript
+function ConnectivityBanner() {
+  const { online, type } = useNetworkStatus();
+
+  if (online) return null;
+  return <div>Offline{type ? ` (${type})` : ""}</div>;
+}
+```
+
+### `useDataProtection`
+
+Use native data protection and encryption helpers exposed through the bridge.
+
+```javascript
+function ProtectedAction() {
+  const { setScreenSecure, loading } = useDataProtection();
+
+  return <button onClick={() => setScreenSecure(true)} disabled={loading}>Protect Screen</button>;
+}
+```
+
+### `useSafeArea`
+
+Read safe-area insets in pixels. On web and SSR, all values are `0`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `top` | `number` | Top inset |
+| `right` | `number` | Right inset |
+| `bottom` | `number` | Bottom inset |
+| `left` | `number` | Left inset |
+
+```javascript
+function ScreenShell({ children }) {
+  const safeArea = useSafeArea();
+
+  return <main style={{ paddingTop: safeArea.top }}>{children}</main>;
+}
+```

--- a/docs/content/11-API Reference/02-Configuration.md
+++ b/docs/content/11-API Reference/02-Configuration.md
@@ -4,6 +4,8 @@ slug: configuration-api
 id: configuration-api
 ---
 
+import ConfigExample from '@site/src/components/ConfigExample'
+
 # Configuration API
 
 Catalyst reads runtime and build configuration from `config/config.json`. This page covers the contract that the framework expects. For a guided walkthrough, see [Configuration](/content/02-Guides%20and%20Tutorials/01-First%20Catalyst%20App/04-Configuration.md).
@@ -51,40 +53,7 @@ Keep this list small. Any key included here becomes visible in the client bundle
 
 Universal app settings live under `WEBVIEW_CONFIG` inside the same file.
 
-```json title="config/config.json"
-{
-  "WEBVIEW_CONFIG": {
-    "port": "3005",
-    "LOCAL_IP": "192.168.0.11",
-    "appInfo": "android-5Feb2026-v2.1.0",
-    "useHttps": false,
-    "accessControl": {
-      "enabled": true,
-      "allowedUrls": ["*.yourdomain.com*", "http://localhost:*"]
-    },
-    "android": {
-      "appName": "My App",
-      "packageName": "com.example.myapp",
-      "buildType": "debug",
-      "sdkPath": "/Users/yourname/Library/Android/sdk",
-      "emulatorName": "Pixel_5_API_30"
-    },
-    "ios": {
-      "appName": "My App",
-      "appBundleId": "com.example.myapp",
-      "buildType": "Debug",
-      "simulatorName": "iPhone 17 Pro"
-    },
-    "splashScreen": {
-      "backgroundColor": "#ffffff",
-      "duration": 2000,
-      "imageWidth": 400,
-      "imageHeight": 200,
-      "cornerRadius": 20
-    }
-  }
-}
-```
+<ConfigExample type="webviewConfigApi" />
 
 ## Required Universal App Fields
 

--- a/docs/content/16-CLI.md
+++ b/docs/content/16-CLI.md
@@ -28,8 +28,8 @@ Most apps wrap the CLI in package scripts:
     "start": "catalyst start",
     "build": "catalyst build",
     "serve": "catalyst serve",
-    "devBuild": "BUILD_ENV=development catalyst build",
-    "devServe": "BUILD_ENV=development catalyst serve",
+    "devBuild": "catalyst devBuild",
+    "devServe": "catalyst devServe",
     "buildApp:android": "catalyst buildApp:android",
     "buildApp:ios": "catalyst buildApp:ios"
   }

--- a/docs/privateDocs.config.js
+++ b/docs/privateDocs.config.js
@@ -8,6 +8,8 @@ const config = require('./config.json')
 const basePrivateDocsUrl = config.server.private_docs_mount_url
     ? `/${config.server.private_docs_mount_url}/`
     : '/private_docs/'
+const socialPreviewImageUrl =
+    'https://onemg.gumlet.io/staging/2fdb0975-8f51-4fd1-bd7d-6375d793f581.svg'
 
 /** @type {import('@docusaurus/types').Config} */
 const configObject = {
@@ -19,6 +21,43 @@ const configObject = {
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.ico',
+    headTags: [
+        {
+            tagName: 'meta',
+            attributes: {
+                property: 'og:image',
+                content: socialPreviewImageUrl,
+            },
+        },
+        {
+            tagName: 'meta',
+            attributes: {
+                property: 'og:image:secure_url',
+                content: socialPreviewImageUrl,
+            },
+        },
+        {
+            tagName: 'meta',
+            attributes: {
+                property: 'og:image:type',
+                content: 'image/svg+xml',
+            },
+        },
+        {
+            tagName: 'meta',
+            attributes: {
+                name: 'twitter:card',
+                content: 'summary_large_image',
+            },
+        },
+        {
+            tagName: 'meta',
+            attributes: {
+                name: 'twitter:image',
+                content: socialPreviewImageUrl,
+            },
+        },
+    ],
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.

--- a/docs/publicDocs.config.js
+++ b/docs/publicDocs.config.js
@@ -8,6 +8,8 @@ const config = require('./config.json')
 const basePublicDocsUrl = config.server.public_docs_mount_url
     ? `/${config.server.public_docs_mount_url}/`
     : '/'
+const socialPreviewImageUrl =
+    'https://onemg.gumlet.io/staging/2fdb0975-8f51-4fd1-bd7d-6375d793f581.svg'
 
 /** @type {import('@docusaurus/types').Config} */
 const configObject = {
@@ -19,6 +21,43 @@ const configObject = {
     onBrokenLinks: 'warn',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.ico',
+    headTags: [
+        {
+            tagName: 'meta',
+            attributes: {
+                property: 'og:image',
+                content: socialPreviewImageUrl,
+            },
+        },
+        {
+            tagName: 'meta',
+            attributes: {
+                property: 'og:image:secure_url',
+                content: socialPreviewImageUrl,
+            },
+        },
+        {
+            tagName: 'meta',
+            attributes: {
+                property: 'og:image:type',
+                content: 'image/svg+xml',
+            },
+        },
+        {
+            tagName: 'meta',
+            attributes: {
+                name: 'twitter:card',
+                content: 'summary_large_image',
+            },
+        },
+        {
+            tagName: 'meta',
+            attributes: {
+                name: 'twitter:image',
+                content: socialPreviewImageUrl,
+            },
+        },
+    ],
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.

--- a/docs/src/components/ConfigExample/index.js
+++ b/docs/src/components/ConfigExample/index.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import CodeBlock from '@theme/CodeBlock'
+import { configExamples } from '@site/src/data/configExamples'
+
+export default function ConfigExample({
+    type = 'appConfig',
+    title = 'config/config.json',
+}) {
+    const example = configExamples[type]
+
+    if (!example) {
+        throw new Error(`Unknown config example: ${type}`)
+    }
+
+    return (
+        <CodeBlock language="json" title={title}>
+            {JSON.stringify(example, null, 2)}
+        </CodeBlock>
+    )
+}

--- a/docs/src/data/configExamples.js
+++ b/docs/src/data/configExamples.js
@@ -1,0 +1,97 @@
+const baseWebviewConfig = {
+    port: '3005',
+    LOCAL_IP: '192.168.XX.XX',
+    appInfo: 'android-v2.1.0',
+    useHttps: true,
+    android: {
+        appName: 'My App',
+        packageName: 'com.example.myapp',
+        buildType: 'debug',
+        sdkPath: '/Users/yourname/Library/Android/sdk',
+        emulatorName: 'Pixel_5_API_30',
+    },
+    ios: {
+        appName: 'My App',
+        appBundleId: 'com.example.myapp',
+        buildType: 'Debug',
+        simulatorName: 'iPhone 17 Pro',
+    },
+    accessControl: {
+        enabled: true,
+        allowedUrls: ['https://api.example.com/*', '*.cdn.example.com'],
+    },
+    splashScreen: {
+        duration: 2000,
+        backgroundColor: '#ffffff',
+        imageWidth: 120,
+        imageHeight: 120,
+        cornerRadius: 20,
+    },
+}
+
+const appConfig = {
+    NODE_SERVER_HOSTNAME: 'localhost',
+    NODE_SERVER_PORT: 3005,
+    WEBPACK_DEV_SERVER_HOSTNAME: 'localhost',
+    WEBPACK_DEV_SERVER_PORT: 3006,
+    BUILD_OUTPUT_PATH: 'build',
+    PUBLIC_STATIC_ASSET_PATH: '/assets/',
+    PUBLIC_STATIC_ASSET_URL: 'http://localhost:3006',
+    NODE_ENV: 'development',
+    API_URL: 'https://api.example.com',
+    ANALYTICS_ID: 'UA-123456',
+    CLIENT_ENV_VARIABLES: ['API_URL', 'ANALYTICS_ID'],
+    WEBVIEW_CONFIG: baseWebviewConfig,
+}
+
+const universalAppConfig = {
+    WEBVIEW_CONFIG: {
+        ...baseWebviewConfig,
+        android: {
+            ...baseWebviewConfig.android,
+            appName: 'My Awesome App',
+            packageName: 'com.example.myawesomeapp',
+            cachePattern: '*.css,*.js',
+        },
+        ios: {
+            ...baseWebviewConfig.ios,
+            appName: 'My Awesome App',
+            appBundleId: 'com.example.myawesomeapp',
+            cachePattern: '*.css,*.js',
+        },
+        accessControl: {
+            enabled: true,
+            allowedUrls: [
+                'https://api.myapp.com/*',
+                'https://cdn.myapp.com/*',
+                '*.cloudfront.net',
+            ],
+        },
+        notifications: {
+            enabled: true,
+        },
+    },
+}
+
+const webviewConfigApi = {
+    WEBVIEW_CONFIG: {
+        ...baseWebviewConfig,
+        appInfo: 'android-5Feb2026-v2.1.0',
+        useHttps: false,
+        accessControl: {
+            enabled: true,
+            allowedUrls: ['*.yourdomain.com*', 'http://localhost:*'],
+        },
+        splashScreen: {
+            ...baseWebviewConfig.splashScreen,
+            imageWidth: 400,
+            imageHeight: 200,
+        },
+    },
+}
+
+export const configExamples = {
+    appConfig,
+    universalAppConfig,
+    webviewConfigApi,
+}

--- a/packages/catalyst-core/README.md
+++ b/packages/catalyst-core/README.md
@@ -14,7 +14,7 @@
 
 Catalyst offers a comprehensive suite of features designed for modern web development. It includes isomorphic rendering for optimal performance, an extendable server with full-stack capabilities, and configurable state management. The framework employs smart prefetching of data and chunks, allows easy configuration of global styles and layouts, and provides SEO optimization at both global and page levels.
 
-This version adds support for Universal app for both Android and iOS. Please checkout [Universal App Documentaion](https://catalyst.1mg.com/public_docs/content/Universal%20App/RunUniversalApp)
+Catalyst also supports universal apps for Android and iOS. See the [Universal App guide](https://catalyst.1mg.com/content/Guides%20and%20Tutorials/First%20Universal%20App/first-universal-app) to get started.
 
 ## Installation
 

--- a/packages/catalyst-core/README.md
+++ b/packages/catalyst-core/README.md
@@ -14,7 +14,7 @@
 
 Catalyst offers a comprehensive suite of features designed for modern web development. It includes isomorphic rendering for optimal performance, an extendable server with full-stack capabilities, and configurable state management. The framework employs smart prefetching of data and chunks, allows easy configuration of global styles and layouts, and provides SEO optimization at both global and page levels.
 
-Catalyst also supports universal apps for Android and iOS. See the [Universal App guide](https://catalyst.1mg.com/content/Guides%20and%20Tutorials/First%20Universal%20App/first-universal-app) to get started.
+Catalyst also supports universal apps for Android and iOS. See the [Universal App guide](https://catalyst.1mg.com/public_docs/content/Guides%20and%20Tutorials/First%20Universal%20App/first-universal-app) to get started.
 
 ## Installation
 


### PR DESCRIPTION
Fix Catalyst documentation mismatches, including hook references, `WEBVIEW_CONFIG` examples, CLI scripts, cache configuration, offline hook imports, and Head/Body import paths.