### PR TITLE
N8N webhook trigger in publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ on:
 permissions:
     contents: write
     id-token: write
+    pull-requests: read
 
 concurrency:
     group: publish-${{ github.ref_name }}
@@ -349,6 +350,60 @@ jobs:
               run: |
                   git tag "catalyst-core@${{ steps.versions.outputs.core }}"
                   git push origin "catalyst-core@${{ steps.versions.outputs.core }}"
+
+            - name: Resolve catalyst-core publish PR
+              id: catalyst_core_pr
+              if: success() && steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_core == 'true' && steps.publish_core.outcome == 'success' && steps.context.outputs.dry_run != 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  PR_JSON=$(curl --fail-with-body -sS \
+                    -H "Authorization: Bearer $GH_TOKEN" \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls")
+
+                  PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number // empty')
+                  PR_URL=$(echo "$PR_JSON" | jq -r '.[0].html_url // empty')
+
+                  if [ -z "$PR_NUMBER" ]; then
+                    echo "::error::Could not resolve source PR for commit ${{ github.sha }}"
+                    exit 1
+                  fi
+
+                  echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+                  echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+            - name: Trigger catalyst release automation
+              if: success() && steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_core == 'true' && steps.publish_core.outcome == 'success' && steps.context.outputs.dry_run != 'true'
+              run: |
+                  if [ -z "${{ secrets.N8N_MASTER_WEBHOOK_URL }}" ]; then
+                    echo "::error::N8N_MASTER_WEBHOOK_URL secret is required"
+                    exit 1
+                  fi
+
+                  PAYLOAD=$(jq -n \
+                    --arg pr_id "${{ steps.catalyst_core_pr.outputs.number }}" \
+                    --arg pr_link "${{ steps.catalyst_core_pr.outputs.url }}" \
+                    --arg version "${{ steps.versions.outputs.core }}" \
+                    --arg channel "${{ steps.context.outputs.channel }}" \
+                    --arg repository "${{ github.repository }}" \
+                    --arg branch "${{ github.ref_name }}" \
+                    --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+                    '{
+                      pr_id: $pr_id,
+                      pr_link: $pr_link,
+                      version: $version,
+                      channel: $channel,
+                      repository: $repository,
+                      branch: $branch,
+                      run_url: $run_url,
+                      channels: { discord: true, flock: true, github: true }
+                    }')
+
+                  curl --fail-with-body -sS -X POST "${{ secrets.N8N_MASTER_WEBHOOK_URL }}" \
+                    -H "Content-Type: application/json" \
+                    -d "$PAYLOAD"
 
             - name: Create create-catalyst-app git tag
               id: tag_cca


### PR DESCRIPTION
Adds a post-publish hook to the Publish GitHub Actions workflow so successful catalyst-core publishes can trigger the Catalyst release automation in n8n.

### Changes
- Adds pull-requests: read permission so the workflow can resolve the merged PR associated with the publish commit.
- After a successful catalyst-core publish, calls GitHub’s commit PR API to resolve:
   - PR number
  - PR URL
- Sends a structured payload to secrets.N8N_MASTER_WEBHOOK_URL with:
  - pr_id
  - pr_link
  - version
  - channel
  - repository/branch/run metadata
  - enabled release channels