### PR TITLE
fix(serve): hard-fail when build is stale vs current config

### DIFF
--- a/packages/catalyst-core/src/scripts/build.js
+++ b/packages/catalyst-core/src/scripts/build.js
@@ -1,8 +1,27 @@
+const fs = require("fs")
 const path = require("path")
 const { green, cyan, yellow } = require("picocolors")
 const { name } = require(`${process.cwd()}/package.json`)
-const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
+const appConfig = require(`${process.cwd()}/config/config.json`)
+const { BUILD_OUTPUT_PATH, PUBLIC_STATIC_ASSET_URL, PUBLIC_STATIC_ASSET_PATH } = appConfig
 const { arrayToObject, printBundleInformation, runBuildCommands } = require("./scriptUtils.js")
+
+const BUILD_META_FILENAME = "build-meta.json"
+
+/**
+ * @description - Persists the config values that webpack bakes into the bundle so
+ * that `serve` can detect when the build is stale relative to the current config.
+ * Only keys whose values get embedded into client assets at build time are tracked here.
+ */
+function writeBuildMeta() {
+    const meta = {
+        PUBLIC_STATIC_ASSET_URL,
+        PUBLIC_STATIC_ASSET_PATH,
+        builtAt: new Date().toISOString(),
+    }
+    const metaPath = path.join(process.cwd(), BUILD_OUTPUT_PATH, BUILD_META_FILENAME)
+    fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2))
+}
 
 /**
  * @description - creates a production build of the application.
@@ -36,6 +55,8 @@ function build() {
             ...argumentsObject,
         },
     })
+
+    writeBuildMeta()
 
     console.log(green("Compiled successfully."))
     console.log("\nFile sizes after gzip:\n")

--- a/packages/catalyst-core/src/scripts/serve.js
+++ b/packages/catalyst-core/src/scripts/serve.js
@@ -1,8 +1,64 @@
+const fs = require("fs")
 const path = require("path")
 const { spawnSync } = require("child_process")
+const { red, yellow, cyan } = require("picocolors")
 const { arrayToObject } = require("./scriptUtils")
 const { name } = require(`${process.cwd()}/package.json`)
-const { BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
+const appConfig = require(`${process.cwd()}/config/config.json`)
+const { BUILD_OUTPUT_PATH, PUBLIC_STATIC_ASSET_URL, PUBLIC_STATIC_ASSET_PATH } = appConfig
+
+const BUILD_META_FILENAME = "build-meta.json"
+const TRACKED_KEYS = ["PUBLIC_STATIC_ASSET_URL", "PUBLIC_STATIC_ASSET_PATH"]
+
+/**
+ * @description - Aborts when the current config.json disagrees with the values that
+ * webpack baked into the build. Without this check `serve` happily logs the new host
+ * while the HTML it serves still references chunks at the old host, which is hard to
+ * diagnose (e.g. when developing across a changing local IP).
+ */
+function assertBuildMatchesConfig() {
+    const metaPath = path.join(process.cwd(), BUILD_OUTPUT_PATH, BUILD_META_FILENAME)
+
+    if (!fs.existsSync(metaPath)) {
+        console.warn(
+            yellow(
+                `\n[serve] ${BUILD_META_FILENAME} not found in ${BUILD_OUTPUT_PATH}/. ` +
+                    `Skipping build/config consistency check — rebuild to enable it.\n`
+            )
+        )
+        return
+    }
+
+    let meta
+    try {
+        meta = JSON.parse(fs.readFileSync(metaPath, "utf8"))
+    } catch (err) {
+        console.warn(
+            yellow(`\n[serve] Failed to parse ${BUILD_META_FILENAME}: ${err.message}. Skipping check.\n`)
+        )
+        return
+    }
+
+    const current = { PUBLIC_STATIC_ASSET_URL, PUBLIC_STATIC_ASSET_PATH }
+    const mismatches = TRACKED_KEYS.filter((key) => meta[key] !== current[key])
+
+    if (mismatches.length === 0) return
+
+    console.error(red("\n[serve] Build is stale relative to config/config.json.\n"))
+    console.error(
+        "The following values were baked into the build but differ from the current config:\n"
+    )
+    mismatches.forEach((key) => {
+        console.error(`  ${cyan(key)}`)
+        console.error(`    built with: ${meta[key]}`)
+        console.error(`    config now: ${current[key]}`)
+    })
+    console.error(
+        `\nThese values are embedded into client assets at build time, so serving this build` +
+            `\nwould reference assets at the old host. Run ${cyan("npm run build")} to rebuild.\n`
+    )
+    process.exit(1)
+}
 
 /**
  * @description -  Serves production build of the application.
@@ -12,6 +68,8 @@ function serve() {
     const commandLineArguments = process.argv.slice(2)
     const argumentsObject = arrayToObject(commandLineArguments)
     const dirname = path.resolve(__dirname, "../../")
+
+    assertBuildMatchesConfig()
 
     const command = `cross-env APPLICATION=${name || "catalyst_app"} node -r ./dist/scripts/loadScriptsBeforeServerStarts.js ${process.cwd()}/${BUILD_OUTPUT_PATH}/startServer.js`
 


### PR DESCRIPTION
## Summary

- Tracks `PUBLIC_STATIC_ASSET_URL` and `PUBLIC_STATIC_ASSET_PATH` in `BUILD_OUTPUT_PATH/build-meta.json` at build time (the values webpack embeds into the client bundle via `publicPath` + `DefinePlugin`).
- On `catalyst serve` startup, compares the embedded values against the current `config/config.json` and exits with a clear diff message on mismatch.
- Missing `build-meta.json` (older builds) emits a warning and proceeds — no break for existing deployments.

Closes #251.

## Why

`catalyst serve` currently re-reads `config.json` for the boot log and `NODE_SERVER_HOSTNAME`/`PORT`, but the asset host that ends up in the served HTML was frozen at build time. When config changes between build and serve (common when local IP changes), serve logs `Local: http://<new-host>` while the HTML still references chunks at the old host. On a device this looks like "page loads, no JS/CSS" with no signal from the serve process.

## Behavior

Before (config changed from `A` to `B` after the build, then `npm run serve`):
```
Local: http://B:3005
```
…and the HTML embeds `http://A:3005/assets/runtime.*.js`. Silent stale serve.

After:
```
[serve] Build is stale relative to config/config.json.

The following values were baked into the build but differ from the current config:

  PUBLIC_STATIC_ASSET_URL
    built with: http://A:3005
    config now: http://B:3005

These values are embedded into client assets at build time, so serving this build
would reference assets at the old host. Run npm run build to rebuild.
```
Exit code 1.

## Test plan

- [ ] `npm run build` in a fixture app writes `build/build-meta.json` with current `PUBLIC_STATIC_ASSET_URL` / `PUBLIC_STATIC_ASSET_PATH`.
- [ ] `npm run serve` with matching config starts normally.
- [ ] Mutate `PUBLIC_STATIC_ASSET_URL` in `config/config.json` and re-run `npm run serve` — exits non-zero with the diff message above, no server process spawned.
- [ ] Delete `build/build-meta.json` and re-run `npm run serve` — emits the "skipping check" warning and proceeds (backwards-compat with builds from prior versions).

## Notes / open questions

- Hard-fail is intentional: the bug is precisely that the broken state was silent. Happy to convert to warn-and-continue or gate behind a `--allow-stale-build` flag if maintainers prefer.
- Currently only the two `PUBLIC_STATIC_ASSET_*` keys are tracked. `CLIENT_ENV_VARIABLES` values are also embedded via `DefinePlugin`; extending the check to those is a small follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)