### PR TITLE
Docs versioning format change

### DIFF
--- a/.github/workflows/docs-tag.yml
+++ b/.github/workflows/docs-tag.yml
@@ -40,18 +40,18 @@ jobs:
 
                   git fetch --tags origin
 
-                  LATEST_TAG=$(git tag --list "catalyst-docs@[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
+                  LATEST_TAG=$(git tag --list "catalyst-docs-v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
 
                   if [ -z "$LATEST_TAG" ]; then
-                    TAG_NAME="catalyst-docs@1.0.0"
+                    TAG_NAME="catalyst-docs-v1.0.0"
                   else
-                    VERSION="${LATEST_TAG#catalyst-docs@}"
+                    VERSION="${LATEST_TAG#catalyst-docs-v}"
                     MAJOR="${VERSION%%.*}"
                     REMAINDER="${VERSION#*.}"
                     MINOR="${REMAINDER%%.*}"
                     PATCH="${VERSION##*.}"
                     NEXT_PATCH=$((PATCH + 1))
-                    TAG_NAME="catalyst-docs@${MAJOR}.${MINOR}.${NEXT_PATCH}"
+                    TAG_NAME="catalyst-docs-v${MAJOR}.${MINOR}.${NEXT_PATCH}"
                   fi
 
                   git tag "$TAG_NAME"


### PR DESCRIPTION
**PR Summary**

This fixes the Devtron docs deployment failure caused by docs Git tags using `@`, for example `catalyst-docs@1.0.0`. Devtron reuses the Git tag as a Docker image tag, and Docker treats `@` as a digest separator, which results in `Invalid reference format`.

The docs tagging workflow now creates Docker-safe tags using the format `catalyst-docs-vX.Y.Z`. 