### PR TITLE
Add Meta crawler bot in userAgentUtils

### DIFF
--- a/src/server/utils/userAgentUtil.js
+++ b/src/server/utils/userAgentUtil.js
@@ -37,6 +37,9 @@ const aiCrawlerBots = {
 
     // Microsoft Bing bot (also powers Bing Chat/Copilot)
     Bingbot: "bingbot",
+
+    // Meta Crawler bot
+    MetaBot: "meta-externalagent",
 }
 
 /**


### PR DESCRIPTION
This PR registers Meta's crawler bot (`meta-externalagent`) under the `aiCrawlerBots` dictionary inside `userAgentUtil.js`. This ensures that when requests from Meta platforms (WhatsApp, Facebook, Instagram, Messenger) hit our services, the crawler bot is correctly classified under the `aiBot` details return object.