### PR TITLE
Add response.compress and response.flush spans to attribute post-res.end() time

### DIFF
--- a/src/otel.js
+++ b/src/otel.js
@@ -289,61 +289,98 @@ export function withObservability(serviceName, fn, name) {
 }
 
 /**
- * Express middleware that emits a span measuring the response body
- * flush/egress window: it STARTS when the app calls res.end() (the moment the
- * app stops writing) and ENDS on the response 'finish' event (all bytes handed
- * to the OS) or 'close' (connection torn down first).
+ * Express middleware that emits two spans describing what happens to the
+ * response body AFTER the app calls res.end() — the work that lives past the
+ * `handler` span and makes the HTTP server span run longer:
  *
- * The span's duration is therefore pure egress / TCP backpressure time — the
- * reason the HTTP server span runs longer than `handler` for large fully-SSR'd
- * bot responses (res.end() returns long before the bytes actually drain).
+ *   • response.compress — gzip/brotli of the body. Starts when the app calls
+ *     res.end() (which returns immediately, since compression is async) and
+ *     ends when the compressed bytes are handed to the real socket end.
+ *   • response.flush — network egress. Starts when those bytes hit the socket
+ *     and ends on 'finish' (all bytes handed to the OS) or 'close' (connection
+ *     torn down first).
  *
- * Register this BEFORE the SSR handler. It uses startSpan (not startActiveSpan),
- * so it becomes a sibling of `handler` under the same request span rather than
- * a parent of it. The 'finish'/'close' listeners are attached up front (so an
- * event is never missed), but the span itself is created only when res.end()
- * fires — if the app never writes (e.g. client aborts first), no span is emitted.
+ * Implementation: the gap is bounded by the *app's* res.end() call (outer) and
+ * the *real* socket end after compression (inner), so the middleware wraps
+ * res.end on BOTH sides of the compression middleware. It installs an inner
+ * hook before next() (which compression then wraps) to time the END of
+ * compression, and after next() — once compression has synchronously patched
+ * res.end — installs an outer hook on top to time the START.
+ *
+ * MOUNT THIS IMMEDIATELY BEFORE compression() so the post-next() outer hook
+ * reliably wraps compression's patch (no async middleware in between). If
+ * compression isn't present (or skips the response) only response.flush is
+ * emitted. Uses startSpan (not startActiveSpan), so the spans are siblings of
+ * `handler` under the same request span. No span is emitted if the app never
+ * writes (e.g. the client aborts first).
  *
  * @param {string} serviceName
- * @param {string} [name] - Span name
+ * @param {string} [flushName] - egress span name
+ * @param {string} [compressName] - compression span name
  * @returns {Function} Express middleware
  */
-export function responseFlushMiddleware(serviceName, name = "response.flush") {
+export function responseFlushMiddleware(
+    serviceName,
+    flushName = "response.flush",
+    compressName = "response.compress"
+) {
     const tracer = trace.getTracer(serviceName)
 
     return function (req, res, next) {
-        // Capture the active (request) context now, while it's guaranteed to be
-        // the in-flight request span. The span is created later — when res.end()
-        // is called — so it must be parented to this captured context.
+        // Captured while the request span is active; both spans parent to it.
         const parentContext = context.active()
 
-        let span = null
-        let ended = false
+        let compressSpan = null
+        let flushSpan = null
+        let finished = false
 
         const finalize = (endEvent) => {
-            if (ended) return
-            ended = true
-            if (span) {
-                span.setAttribute("http.response.end_event", endEvent) // "finish" | "close"
-                span.end()
+            if (finished) return
+            finished = true
+            // Whichever span is still open when the response ends gets tagged.
+            const open = flushSpan || compressSpan
+            if (open) {
+                open.setAttribute("http.response.end_event", endEvent) // "finish" | "close"
+                open.end()
             }
+            compressSpan = null
+            flushSpan = null
         }
 
-        // Start the span the moment the app finishes writing. Preserve all
-        // res.end call signatures. The `!ended` guard avoids creating a span
-        // after the response already closed (e.g. client aborted before end).
-        const originalEnd = res.end
-        res.end = function (...args) {
-            if (!span && !ended) {
-                span = tracer.startSpan(name, undefined, parentContext)
+        // Inner hook: wraps the real res.end (installed before compression), so
+        // it fires once compression has produced the final bytes → close the
+        // compression span and open the egress span.
+        const realEnd = res.end
+        const innerEnd = function (...args) {
+            if (!finished && !flushSpan) {
+                if (compressSpan) {
+                    compressSpan.end()
+                    compressSpan = null
+                }
+                flushSpan = tracer.startSpan(flushName, undefined, parentContext)
             }
-            return originalEnd.apply(this, args)
+            return realEnd.apply(this, args)
         }
+        res.end = innerEnd
 
         res.once("finish", () => finalize("finish"))
         res.once("close", () => finalize("close"))
 
         next()
+
+        // After next(): compression has synchronously wrapped innerEnd. Install
+        // an outer hook on top to catch the app's res.end() call → open the
+        // compression span. Skipped if nothing wrapped innerEnd (no compression),
+        // in which case innerEnd alone times the flush from the app's res.end().
+        if (res.end !== innerEnd) {
+            const chainEnd = res.end
+            res.end = function (...args) {
+                if (!finished && !compressSpan && !flushSpan) {
+                    compressSpan = tracer.startSpan(compressName, undefined, parentContext)
+                }
+                return chainEnd.apply(this, args)
+            }
+        }
     }
 }
 

--- a/src/otel.js
+++ b/src/otel.js
@@ -9,7 +9,7 @@ import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentation
 import { TraceIdRatioBasedSampler, ParentBasedSampler } from "@opentelemetry/sdk-trace-node"
 import { OTLPTraceExporter as OTLPTraceExporterHTTP } from "@opentelemetry/exporter-trace-otlp-http"
 import { OTLPMetricExporter as OTLPMetricExporterHTTP } from "@opentelemetry/exporter-metrics-otlp-http"
-import { trace } from "@opentelemetry/api"
+import { trace, context } from "@opentelemetry/api"
 
 import semanticConventions from "@opentelemetry/semantic-conventions"
 const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION, ATTR_DEPLOYMENT_ENVIRONMENT } = semanticConventions
@@ -289,45 +289,55 @@ export function withObservability(serviceName, fn, name) {
 }
 
 /**
- * Express middleware that emits a span covering the full server-side lifetime
- * of the response — INCLUDING the time spent flushing the body to the socket
- * after res.end() is called. Unlike the `handler` span (which ends as soon as
- * the render promise resolves), this span ends on the response 'finish' event
- * (all bytes handed to the OS) or 'close' (connection torn down first).
+ * Express middleware that emits a span measuring the response body
+ * flush/egress window: it STARTS when the app calls res.end() (the moment the
+ * app stops writing) and ENDS on the response 'finish' event (all bytes handed
+ * to the OS) or 'close' (connection torn down first).
  *
- * A "res.end" span event marks the moment the app stopped writing, so the gap
- * between that event and the span's end is pure egress / TCP backpressure time
- * — the reason the HTTP server span runs longer than `handler` for large
- * fully-SSR'd bot responses.
+ * The span's duration is therefore pure egress / TCP backpressure time — the
+ * reason the HTTP server span runs longer than `handler` for large fully-SSR'd
+ * bot responses (res.end() returns long before the bytes actually drain).
  *
  * Register this BEFORE the SSR handler. It uses startSpan (not startActiveSpan),
  * so it becomes a sibling of `handler` under the same request span rather than
- * a parent of it.
+ * a parent of it. The 'finish'/'close' listeners are attached up front (so an
+ * event is never missed), but the span itself is created only when res.end()
+ * fires — if the app never writes (e.g. client aborts first), no span is emitted.
  *
  * @param {string} serviceName
  * @param {string} [name] - Span name
  * @returns {Function} Express middleware
  */
-export function responseFlushMiddleware(serviceName, name = "response.send") {
+export function responseFlushMiddleware(serviceName, name = "response.flush") {
     const tracer = trace.getTracer(serviceName)
 
     return function (req, res, next) {
-        const span = tracer.startSpan(name)
+        // Capture the active (request) context now, while it's guaranteed to be
+        // the in-flight request span. The span is created later — when res.end()
+        // is called — so it must be parented to this captured context.
+        const parentContext = context.active()
 
-        // Mark when the app finished writing (res.end called) vs. when the
-        // bytes actually drained ('finish'). Preserve all call signatures.
-        const originalEnd = res.end
-        res.end = function (...args) {
-            span.addEvent("res.end")
-            return originalEnd.apply(this, args)
-        }
-
+        let span = null
         let ended = false
+
         const finalize = (endEvent) => {
             if (ended) return
             ended = true
-            span.setAttribute("http.response.end_event", endEvent) // "finish" | "close"
-            span.end()
+            if (span) {
+                span.setAttribute("http.response.end_event", endEvent) // "finish" | "close"
+                span.end()
+            }
+        }
+
+        // Start the span the moment the app finishes writing. Preserve all
+        // res.end call signatures. The `!ended` guard avoids creating a span
+        // after the response already closed (e.g. client aborted before end).
+        const originalEnd = res.end
+        res.end = function (...args) {
+            if (!span && !ended) {
+                span = tracer.startSpan(name, undefined, parentContext)
+            }
+            return originalEnd.apply(this, args)
         }
 
         res.once("finish", () => finalize("finish"))

--- a/src/otel.js
+++ b/src/otel.js
@@ -15,6 +15,14 @@ import semanticConventions from "@opentelemetry/semantic-conventions"
 const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION, ATTR_DEPLOYMENT_ENVIRONMENT } = semanticConventions
 
 function init(config = {}) {
+    // OpenTelemetry is opt-in — bail out unless explicitly enabled. Mirrors the
+    // OTEL_ENABLE guard in server/expressServer.js and server/renderer/handler.jsx
+    // so the SDK, exporters, instrumentations and signal handlers are never set
+    // up when tracing is off. Returns the same shape so callers can destructure.
+    if (process.env.OTEL_ENABLE !== true) {
+        return { sdk: null, meter: null }
+    }
+
     const {
         serviceName = "catalyst-server",
         serviceVersion = "1.0.0",
@@ -280,4 +288,53 @@ export function withObservability(serviceName, fn, name) {
     }
 }
 
-export default { init, withObservability, withSyncObservability }
+/**
+ * Express middleware that emits a span covering the full server-side lifetime
+ * of the response — INCLUDING the time spent flushing the body to the socket
+ * after res.end() is called. Unlike the `handler` span (which ends as soon as
+ * the render promise resolves), this span ends on the response 'finish' event
+ * (all bytes handed to the OS) or 'close' (connection torn down first).
+ *
+ * A "res.end" span event marks the moment the app stopped writing, so the gap
+ * between that event and the span's end is pure egress / TCP backpressure time
+ * — the reason the HTTP server span runs longer than `handler` for large
+ * fully-SSR'd bot responses.
+ *
+ * Register this BEFORE the SSR handler. It uses startSpan (not startActiveSpan),
+ * so it becomes a sibling of `handler` under the same request span rather than
+ * a parent of it.
+ *
+ * @param {string} serviceName
+ * @param {string} [name] - Span name
+ * @returns {Function} Express middleware
+ */
+export function responseFlushMiddleware(serviceName, name = "response.send") {
+    const tracer = trace.getTracer(serviceName)
+
+    return function (req, res, next) {
+        const span = tracer.startSpan(name)
+
+        // Mark when the app finished writing (res.end called) vs. when the
+        // bytes actually drained ('finish'). Preserve all call signatures.
+        const originalEnd = res.end
+        res.end = function (...args) {
+            span.addEvent("res.end")
+            return originalEnd.apply(this, args)
+        }
+
+        let ended = false
+        const finalize = (endEvent) => {
+            if (ended) return
+            ended = true
+            span.setAttribute("http.response.end_event", endEvent) // "finish" | "close"
+            span.end()
+        }
+
+        res.once("finish", () => finalize("finish"))
+        res.once("close", () => finalize("close"))
+
+        next()
+    }
+}
+
+export default { init, withObservability, withSyncObservability, responseFlushMiddleware }

--- a/src/server/expressServer.js
+++ b/src/server/expressServer.js
@@ -92,9 +92,9 @@ async function createServer() {
     // This middleware is being used to parse cookies!
     app.use(cookieParser())
 
-    // Span that ends on the response 'finish'/'close' event — captures the body
-    // flush/egress time that lives past the `handler` span (no-op when OTEL off).
-    app.use(responseFlushMiddleware(SSR_SERVICE, "response.send"))
+    // Span from res.end() to the response 'finish'/'close' event — captures the
+    // body flush/egress time that lives past the `handler` span (no-op when OTEL off).
+    app.use(responseFlushMiddleware(SSR_SERVICE, "response.flush"))
 
     // All the middlewares defined by the user will run here.
     if (validateMiddleware(addMiddlewares)) addMiddlewares(app)

--- a/src/server/expressServer.js
+++ b/src/server/expressServer.js
@@ -13,6 +13,20 @@ const { cyan, yellow, green } = pc
 import { validateMiddleware, safeCall } from "./utils/validator.js"
 const { addMiddlewares } = await import(path.join(process.env.src_path, "server/server.js"))
 
+// OpenTelemetry is opt-in (OTEL_ENABLE) — mirrors server/renderer/handler.jsx.
+// Passthrough no-op middleware when disabled or packages aren't installed.
+let responseFlushMiddleware = () => (_req, _res, next) => next()
+if (process.env.OTEL_ENABLE === true) {
+    try {
+        const otel = await import("../otel.js")
+        responseFlushMiddleware = otel.responseFlushMiddleware
+    } catch {
+        // otel packages not installed — continue without the flush span
+    }
+}
+
+const SSR_SERVICE = process.env.SERVICE_NAME || `pwa-${process.env.APPLICATION}-node-server`
+
 // ─── Load app-defined server lifecycle hooks ──────────────────────────────────
 let onServerError
 try {
@@ -77,6 +91,10 @@ async function createServer() {
 
     // This middleware is being used to parse cookies!
     app.use(cookieParser())
+
+    // Span that ends on the response 'finish'/'close' event — captures the body
+    // flush/egress time that lives past the `handler` span (no-op when OTEL off).
+    app.use(responseFlushMiddleware(SSR_SERVICE, "response.send"))
 
     // All the middlewares defined by the user will run here.
     if (validateMiddleware(addMiddlewares)) addMiddlewares(app)

--- a/src/server/expressServer.js
+++ b/src/server/expressServer.js
@@ -92,12 +92,14 @@ async function createServer() {
     // This middleware is being used to parse cookies!
     app.use(cookieParser())
 
-    // Span from res.end() to the response 'finish'/'close' event — captures the
-    // body flush/egress time that lives past the `handler` span (no-op when OTEL off).
-    app.use(responseFlushMiddleware(SSR_SERVICE, "response.flush"))
-
     // All the middlewares defined by the user will run here.
     if (validateMiddleware(addMiddlewares)) addMiddlewares(app)
+
+    // response.compress + response.flush spans straddle compression — they
+    // attribute the time past the `handler` span (gzip/brotli, then egress).
+    // MUST be mounted immediately before compression() so its outer res.end
+    // hook reliably wraps compression's patch (no-op when OTEL off).
+    app.use(responseFlushMiddleware(SSR_SERVICE, "response.flush", "response.compress"))
 
     // The middleware will attempt to compress response bodies for all request that traverse through the middleware
     app.use(compression())


### PR DESCRIPTION
## Problem

`res.end()` is non-blocking: it signals that the app has finished *producing* the response, not that the bytes have actually left the server. After the app calls `res.end()`, the response still has to be compressed (gzip/brotli) and then drained over the socket — work whose duration depends on payload size, compression cost, and how fast the client reads off the network.

Because of this, the HTTP server (request) span consistently ran noticeably longer than the `handler` span, even though `handler` is the last middleware in the chain and is the thing that calls `res.end()`. That trailing time — compression plus network egress — was previously unattributed, showing up as an unexplained gap at the tail of every trace. This is most visible for large responses and slow clients.

## What changed

- **`src/otel.js`** — Updated `responseFlushMiddleware` to emit **two** OpenTelemetry spans describing what happens to the response *after* the app calls `res.end()`:
  - `response.compress` — gzip/brotli compression of the response body.
  - `response.flush` — network egress, ending on the response `'finish'` event (all bytes handed to the OS) or `'close'` (connection torn down first), tagged with an `http.response.end_event` attribute recording which one fired.

  Both spans are created with `startSpan` against the captured active context (not `startActiveSpan`), so they are **siblings** of the existing `handler` span under the same request span rather than wrapping it.
- **`src/server/expressServer.js`** — Wired the middleware in, mounted **immediately before** `compression()`.

## How it works

The gap we want to measure is bounded by two different `res.end` calls that sit on opposite sides of the compression middleware:

- The **app's** `res.end()` (outer) — marks the START of the post-handler work.
- The **real** socket `res.end()` after compression has produced the final bytes (inner) — marks the boundary between compression and egress.

To capture both, the middleware wraps `res.end` on both sides of compression:

1. **Before `next()`** it installs an *inner* hook on the real `res.end`. Compression then wraps this hook with its own. When the inner hook eventually fires, compression has produced its output, so it closes the `response.compress` span and opens `response.flush`.
2. **After `next()`** — once compression has synchronously patched `res.end` — it installs an *outer* hook on top to catch the app's original `res.end()` call and open the `response.compress` span.

This ordering is why the middleware **must be mounted immediately before `compression()`**: the post-`next()` outer hook needs to reliably wrap compression's patch with no other async middleware in between.

Fallbacks:

- If `compression()` isn't present (or skips the response), `res.end` is unchanged after `next()`, and the inner hook alone emits a single `response.flush` span timed from the app's `res.end()`.
- No span is emitted if the app never writes a response (e.g. the client aborts first).
- When the OpenTelemetry SDK isn't started, the OTel API returns a no-op tracer, so the middleware is completely harmless and can be mounted unconditionally.

## Performance / risk

Negligible per-request overhead and **no added response latency** — the hooks call straight through to the underlying `res.end` and never buffer the body. The only cumulative cost is roughly one extra span per request in the export pipeline. Risk is low: with the SDK disabled the middleware is a no-op, and with no compression present it degrades gracefully to a single egress span.

## Testing

- Enable OpenTelemetry and send a request through the SSR path.
- Confirm `response.compress` and `response.flush` appear in the trace as **siblings of `handler`** under the same request span.
- Verify the request span no longer shows an unexplained trailing gap after `handler` — that time is now accounted for by the two new spans, with `response.flush` carrying the `http.response.end_event` attribute (`finish` or `close`).
- Verify the no-compression fallback: with `compression()` removed, only a single `response.flush` span is emitted.
- Verify that with the OTel SDK not started, requests behave exactly as before (no spans, no errors).
