### PR TITLE
feat: add GitHub feedback integration to Catalyst MCP v2

### DIFF
--- a/packages/catalyst-core/mcp_v2/lib/helpers.js
+++ b/packages/catalyst-core/mcp_v2/lib/helpers.js
@@ -38,7 +38,8 @@ function versionOlderThan(a, b) {
 }
 
 /**
- * Walk up the directory tree looking for a package.json that depends on Catalyst.
+ * Walk up the directory tree looking for a package.json that depends on Catalyst,
+ * or the catalyst-core package source itself when developing this repo.
  * Returns { dir, pkg, catalystPackageName, catalystVersion, installedVersion, versionMeta } or null.
  */
 function findCatalystRoot() {
@@ -54,6 +55,26 @@ function findCatalystRoot() {
             if (fs.existsSync(pkgPath)) {
                 try {
                     const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"))
+                    if (pkg.name === "catalyst-core") {
+                        const sourceVersion = pkg.version || null
+                        return {
+                            dir,
+                            pkg,
+                            catalystPackageName: "catalyst-core",
+                            catalystVersion: sourceVersion,
+                            version: sourceVersion,
+                            installedVersion: sourceVersion,
+                            notInstalled: false,
+                            isSourcePackage: true,
+                            versionMeta: {
+                                declaredRef: sourceVersion,
+                                isGithubRef: false,
+                                installedVersion: sourceVersion,
+                                parsed: parseVersion(sourceVersion),
+                            },
+                        }
+                    }
+
                     const deps = { ...pkg.dependencies, ...pkg.devDependencies }
                     const declaredRef = deps["catalyst-core"]
                     if (declaredRef) {
@@ -77,6 +98,7 @@ function findCatalystRoot() {
                             pkg,
                             catalystPackageName: "catalyst-core",
                             catalystVersion: declaredRef, // what package.json says (may be github ref)
+                            version: declaredRef,
                             installedVersion, // what's actually in node_modules e.g. "0.0.3-canary.3"
                             notInstalled: !installed,
                             versionMeta: {

--- a/packages/catalyst-core/mcp_v2/mcp.js
+++ b/packages/catalyst-core/mcp_v2/mcp.js
@@ -457,10 +457,8 @@ const TOOLS = [
                     description: "What happens today.",
                 },
                 steps_to_reproduce: {
-                    oneOf: [
-                        { type: "string" },
-                        { type: "array", items: { type: "string" } },
-                    ],
+                    type: "array",
+                    items: { type: "string" },
                     description: "Steps to reproduce the issue.",
                 },
                 expected_behavior: {
@@ -489,10 +487,8 @@ const TOOLS = [
                     description: "Additional context that does not fit the primary sections.",
                 },
                 related_issues: {
-                    oneOf: [
-                        { type: "string" },
-                        { type: "array", items: { type: "string" } },
-                    ],
+                    type: "array",
+                    items: { type: "string" },
                     description: "Related GitHub issues or links.",
                 },
                 root_cause: {
@@ -504,14 +500,12 @@ const TOOLS = [
                     description: "Concrete suggested fix.",
                 },
                 optional_followups: {
-                    oneOf: [
-                        { type: "string" },
-                        { type: "array", items: { type: "string" } },
-                    ],
+                    type: "array",
+                    items: { type: "string" },
                     description: "Follow-up cleanup, docs, or test suggestions.",
                 },
                 environment: {
-                    type: ["string", "object"],
+                    type: "object",
                     description: "Environment details such as platform, OS, browser, device, Node/npm versions.",
                 },
                 labels: {
@@ -522,7 +516,7 @@ const TOOLS = [
                 },
                 images: {
                     type: "array",
-                    items: { type: ["string", "object"] },
+                    items: { type: "object" },
                     description:
                         "Optional image URLs or local image paths. URLs are embedded directly; local paths are preserved for fallback/manual upload.",
                 },

--- a/packages/catalyst-core/mcp_v2/mcp.js
+++ b/packages/catalyst-core/mcp_v2/mcp.js
@@ -536,6 +536,11 @@ const TOOLS = [
                     description:
                         "Set true only after a dry_run:true preview or blocked publish returned duplicate candidates, those candidates were shown to the developer, and the developer explicitly confirmed this issue is distinct and should still be published.",
                 },
+                sensitive_data_confirmed: {
+                    type: "boolean",
+                    description:
+                        "Set true only after a dry_run:true preview or blocked publish returned sensitive_data_review.required_before_publish=true, the config/sensitive-looking data warning and rendered issue preview were shown to the developer, and the developer explicitly confirmed this data may be posted to GitHub.",
+                },
                 duplicate_review_note: {
                     type: "string",
                     description:

--- a/packages/catalyst-core/mcp_v2/mcp.js
+++ b/packages/catalyst-core/mcp_v2/mcp.js
@@ -114,7 +114,7 @@ const INTENT_NEXT_ACTION = {
     debug: "answer_only — provide debug guidance. Do NOT call create_task_plan.",
     build: "answer_only — explain build flow. Do NOT call create_task_plan.",
     sync: "answer_only — sync complete. Do NOT call create_task_plan.",
-    feedback: "answer_only — GitHub action completed. Show the created issue/discussion URL. Do NOT call create_task_plan.",
+    feedback: "answer_only — run the GitHub issue workflow and show the created issue URL or markdown fallback. Do NOT call create_task_plan.",
     unknown: "answer_only — unclear intent. Return what you found. Do NOT call create_task_plan.",
 }
 
@@ -418,44 +418,176 @@ const TOOLS = [
         },
     },
     {
+        name: "start_github_issue_flow",
+        description:
+            "ALWAYS call this FIRST when the developer explicitly wants to create, raise, report, or publish a GitHub issue for catalyst-core, OR when the LLM discovers during another task that the root cause is likely catalyst-core framework behavior. If inferred during another task, ask the developer whether they want to create an issue before proceeding. Returns the issue-agent workflow, approval gates, template suggestions, required details to collect, supported labels/tags, screenshot/image handling rules, duplicate-avoidance policy, and next tool calls. Intent: feedback.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                problem: {
+                    type: "string",
+                    description: "The developer's initial issue/problem statement, if already known.",
+                },
+                _query: {
+                    type: "string",
+                    description: "Original user query for intent classification.",
+                },
+            },
+        },
+    },
+    {
+        name: "gather_github_issue_context",
+        description:
+            "Use after start_github_issue_flow and before preview_github_feedback. Reads the current Catalyst app context for a stronger GitHub issue: package name, catalyst-core version, scripts, config, git branch/status, runtime versions, and relevant file snippets. Use this to gather evidence before selecting the final template/labels. Intent: feedback.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                project_path: {
+                    type: "string",
+                    description: "Path to the catalyst app root. Defaults to detected project root.",
+                },
+                title: {
+                    type: "string",
+                    description: "Issue title, if available.",
+                },
+                problem: {
+                    type: "string",
+                    description: "Issue/problem statement or symptoms.",
+                },
+                query: {
+                    type: "string",
+                    description: "Search text used to find relevant source snippets.",
+                },
+                files: {
+                    type: "array",
+                    items: { type: "string" },
+                    description: "Optional explicit project files to include as context snippets.",
+                },
+                _query: {
+                    type: "string",
+                    description: "Original user query for intent classification.",
+                },
+            },
+        },
+    },
+    {
         name: "preview_github_feedback",
         description:
-            "ALWAYS call this FIRST before create_github_issue or create_github_discussion. Use when the developer wants to report a bug, raise an issue, start a discussion, or share any feedback about catalyst-core. This tool drafts the full content with project context attached, searches for duplicate issues/discussions already on GitHub, and returns a preview for the developer to approve — WITHOUT publishing anything. After the developer approves: if type was 'issue', you MUST call create_github_issue. If type was 'discussion', you MUST call create_github_discussion. Intent: feedback.",
+            "Use after start_github_issue_flow and gather_github_issue_context, before create_github_issue. Drafts the full GitHub issue with project context, suggested template, labels/tags, image URLs/paths, and duplicate search, then returns a preview for developer approval WITHOUT publishing anything. If duplicate candidates are returned, show them first and ask whether to cancel/use an existing issue, edit, or continue because this issue is distinct. Show this final rendered template to the developer and ask for edits or explicit publish approval. Intent: feedback.",
         inputSchema: {
             type: "object",
             properties: {
                 title: {
                     type: "string",
-                    description: "Proposed title for the issue or discussion.",
+                    description: "Proposed title for the issue.",
                 },
                 body: {
                     type: "string",
                     description:
-                        "Proposed body. For bugs: include steps to reproduce, expected vs actual behaviour, error messages. For discussions: the question or proposal.",
+                        "Proposed body. Plain text is upgraded into the catalyst-core issue style; already structured markdown is preserved.",
+                },
+                summary: {
+                    type: "string",
+                    description: "Structured issue summary if body is not already composed.",
+                },
+                issue_template: {
+                    type: "string",
+                    enum: ["bug", "enhancement", "documentation", "dependencies", "question"],
+                    description:
+                        "Optional template to force. Use bug for broken behavior, enhancement for feature requests, documentation for docs/examples, dependencies for package updates, question for clarification.",
+                },
+                current_behavior: {
+                    type: "string",
+                    description: "What happens today.",
+                },
+                steps_to_reproduce: {
+                    oneOf: [
+                        { type: "string" },
+                        { type: "array", items: { type: "string" } },
+                    ],
+                    description: "Steps to reproduce the issue.",
+                },
+                expected_behavior: {
+                    type: "string",
+                    description: "What should happen.",
+                },
+                actual_behavior: {
+                    type: "string",
+                    description: "What actually happens.",
+                },
+                error_logs: {
+                    type: "string",
+                    description: "Error logs or stack traces.",
+                },
+                preflight_checklist: {
+                    type: "array",
+                    items: { type: "string" },
+                    description: "Optional checklist items for bug reports. Defaults to searched issues, single issue, and included repro/environment/logs.",
+                },
+                what_i_tried: {
+                    type: "string",
+                    description: "Troubleshooting already attempted.",
+                },
+                additional_information: {
+                    type: "string",
+                    description: "Additional context that does not fit the primary sections.",
+                },
+                related_issues: {
+                    oneOf: [
+                        { type: "string" },
+                        { type: "array", items: { type: "string" } },
+                    ],
+                    description: "Related GitHub issues or links.",
+                },
+                root_cause: {
+                    type: "string",
+                    description: "Technical notes or suspected root cause.",
+                },
+                proposed_fix: {
+                    type: "string",
+                    description: "Concrete suggested fix.",
+                },
+                optional_followups: {
+                    oneOf: [
+                        { type: "string" },
+                        { type: "array", items: { type: "string" } },
+                    ],
+                    description: "Follow-up cleanup, docs, or test suggestions.",
+                },
+                environment: {
+                    type: ["string", "object"],
+                    description: "Environment details such as platform, OS, browser, device, Node/npm versions.",
+                },
+                context: {
+                    type: ["string", "object"],
+                    description: "Context returned by gather_github_issue_context.",
                 },
                 type: {
                     type: "string",
-                    enum: ["issue", "discussion"],
+                    enum: ["issue"],
                     description:
-                        "'issue' for bugs, regressions, and actionable feature requests. 'discussion' for questions, open-ended ideas, proposals, and general feedback.",
+                        "'issue' for bugs, regressions, and actionable feature requests.",
                 },
                 labels: {
                     type: "array",
                     items: { type: "string" },
-                    description: "Optional label names for issues. E.g. ['bug', 'native'].",
+                    description:
+                        "Optional labels. Valid catalyst-core labels: bug, dependencies, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. If omitted, the tool infers one primary label.",
                 },
-                category: {
-                    type: "string",
-                    description: "Optional discussion category. E.g. 'Q&A', 'Ideas', 'General'.",
+                images: {
+                    type: "array",
+                    items: { type: ["string", "object"] },
+                    description:
+                        "Optional image URLs or local image paths. URLs are embedded directly; local paths are preserved for fallback/manual upload.",
                 },
             },
-            required: ["title", "body", "type"],
+            required: ["title"],
         },
     },
     {
         name: "create_github_issue",
         description:
-            "Use ONLY when the developer wants to report a bug, request a feature, or raise any problem, AND the preview type was 'issue'. Do NOT call this tool if the preview type was 'discussion' (use create_github_discussion instead). Intent: feedback. Creates an issue on the catalyst-core GitHub repo. Automatically attaches the current catalyst-core version and project name to help triage.",
+            "Use ONLY after preview_github_feedback has been shown and the developer explicitly approved publishing. Creates an issue on the catalyst-core GitHub repo using the selected/suggested template and labels. Automatically attaches the current catalyst-core version and project name to help triage. Before publishing, this tool searches for duplicate candidates and blocks creation if matches are found unless duplicate_review_confirmed:true is passed after showing those candidates to the developer. If GitHub creation, auth, labels, network, or validation fails, return a manual markdown fallback via generate_issue_markdown/fallback. Intent: feedback.",
         inputSchema: {
             type: "object",
             properties: {
@@ -466,40 +598,214 @@ const TOOLS = [
                 body: {
                     type: "string",
                     description:
-                        "Full issue description: steps to reproduce, expected behaviour, actual behaviour, any error messages or stack traces. The more detail, the better.",
+                        "Full issue description. Plain text is upgraded into the catalyst-core issue style; already structured markdown is preserved.",
+                },
+                summary: {
+                    type: "string",
+                    description: "Structured issue summary if body is not already composed.",
+                },
+                issue_template: {
+                    type: "string",
+                    enum: ["bug", "enhancement", "documentation", "dependencies", "question"],
+                    description:
+                        "Optional template to force. Use bug for broken behavior, enhancement for feature requests, documentation for docs/examples, dependencies for package updates, question for clarification.",
+                },
+                current_behavior: {
+                    type: "string",
+                    description: "What happens today.",
+                },
+                steps_to_reproduce: {
+                    oneOf: [
+                        { type: "string" },
+                        { type: "array", items: { type: "string" } },
+                    ],
+                    description: "Steps to reproduce the issue.",
+                },
+                expected_behavior: {
+                    type: "string",
+                    description: "What should happen.",
+                },
+                actual_behavior: {
+                    type: "string",
+                    description: "What actually happens.",
+                },
+                error_logs: {
+                    type: "string",
+                    description: "Error logs or stack traces.",
+                },
+                preflight_checklist: {
+                    type: "array",
+                    items: { type: "string" },
+                    description: "Optional checklist items for bug reports. Defaults to searched issues, single issue, and included repro/environment/logs.",
+                },
+                what_i_tried: {
+                    type: "string",
+                    description: "Troubleshooting already attempted.",
+                },
+                additional_information: {
+                    type: "string",
+                    description: "Additional context that does not fit the primary sections.",
+                },
+                related_issues: {
+                    oneOf: [
+                        { type: "string" },
+                        { type: "array", items: { type: "string" } },
+                    ],
+                    description: "Related GitHub issues or links.",
+                },
+                root_cause: {
+                    type: "string",
+                    description: "Technical notes or suspected root cause.",
+                },
+                proposed_fix: {
+                    type: "string",
+                    description: "Concrete suggested fix.",
+                },
+                optional_followups: {
+                    oneOf: [
+                        { type: "string" },
+                        { type: "array", items: { type: "string" } },
+                    ],
+                    description: "Follow-up cleanup, docs, or test suggestions.",
+                },
+                environment: {
+                    type: ["string", "object"],
+                    description: "Environment details such as platform, OS, browser, device, Node/npm versions.",
+                },
+                context: {
+                    type: ["string", "object"],
+                    description: "Context returned by gather_github_issue_context.",
                 },
                 labels: {
                     type: "array",
                     items: { type: "string" },
                     description:
-                        "Optional label names to apply. Labels must already exist on the repo. E.g. ['bug', 'routing', 'native'].",
+                        "Optional labels. Valid catalyst-core labels: bug, dependencies, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. If omitted, the tool infers one primary label.",
+                },
+                images: {
+                    type: "array",
+                    items: { type: ["string", "object"] },
+                    description:
+                        "Optional image URLs or local image paths. URLs are embedded directly; local paths are preserved for fallback/manual upload.",
+                },
+                duplicate_review_confirmed: {
+                    type: "boolean",
+                    description:
+                        "Set true only after preview_github_feedback or create_github_issue returned duplicate candidates, those candidates were shown to the developer, and the developer explicitly confirmed this issue is distinct and should still be published.",
+                },
+                duplicate_review_note: {
+                    type: "string",
+                    description:
+                        "Optional short note explaining why the issue is not a duplicate, after the developer confirms publishing.",
                 },
             },
-            required: ["title", "body"],
+            required: ["title"],
         },
     },
     {
-        name: "create_github_discussion",
+        name: "generate_issue_markdown",
         description:
-            "Use ONLY when the developer wants to ask a question, propose an idea, or start a conversation, AND the preview type was 'discussion'. Do NOT call this tool if the preview type was 'issue' (use create_github_issue instead). Intent: feedback. Creates a GitHub Discussion on the catalyst-core repo. Auto-selects the best category (Q&A for questions, Ideas for proposals, General otherwise).",
+            "Use when create_github_issue fails due to auth, permissions, network, or validation problems, or when the developer explicitly wants a manual GitHub issue draft. Writes a local markdown file under .mcp_issues/ with title, labels, body, context, and image paths for manual copy/upload. Intent: feedback.",
         inputSchema: {
             type: "object",
             properties: {
+                project_path: {
+                    type: "string",
+                    description: "Path to the catalyst app root. Defaults to detected project root.",
+                },
                 title: {
                     type: "string",
-                    description: "Discussion title.",
+                    description: "Short, descriptive issue title.",
                 },
                 body: {
                     type: "string",
-                    description: "Full discussion body — the question, proposal, or topic to discuss.",
+                    description: "Full issue body. Plain text is upgraded into the catalyst-core issue style; already structured markdown is preserved.",
                 },
-                category: {
+                summary: {
                     type: "string",
+                    description: "Structured issue summary if body is not already composed.",
+                },
+                issue_template: {
+                    type: "string",
+                    enum: ["bug", "enhancement", "documentation", "dependencies", "question"],
                     description:
-                        "Optional discussion category name. E.g. 'Q&A', 'Ideas', 'General', 'Show and tell'. If omitted, auto-detected from the body content.",
+                        "Optional template to force. Use bug for broken behavior, enhancement for feature requests, documentation for docs/examples, dependencies for package updates, question for clarification.",
+                },
+                current_behavior: {
+                    type: "string",
+                    description: "What happens today.",
+                },
+                steps_to_reproduce: {
+                    oneOf: [
+                        { type: "string" },
+                        { type: "array", items: { type: "string" } },
+                    ],
+                    description: "Steps to reproduce the issue.",
+                },
+                expected_behavior: {
+                    type: "string",
+                    description: "What should happen.",
+                },
+                actual_behavior: {
+                    type: "string",
+                    description: "What actually happens.",
+                },
+                error_logs: {
+                    type: "string",
+                    description: "Error logs or stack traces.",
+                },
+                preflight_checklist: {
+                    type: "array",
+                    items: { type: "string" },
+                    description: "Optional checklist items for bug reports. Defaults to searched issues, single issue, and included repro/environment/logs.",
+                },
+                what_i_tried: {
+                    type: "string",
+                    description: "Troubleshooting already attempted.",
+                },
+                additional_information: {
+                    type: "string",
+                    description: "Additional context that does not fit the primary sections.",
+                },
+                related_issues: {
+                    oneOf: [
+                        { type: "string" },
+                        { type: "array", items: { type: "string" } },
+                    ],
+                    description: "Related GitHub issues or links.",
+                },
+                root_cause: {
+                    type: "string",
+                    description: "Technical notes or suspected root cause.",
+                },
+                proposed_fix: {
+                    type: "string",
+                    description: "Concrete suggested fix.",
+                },
+                optional_followups: {
+                    oneOf: [
+                        { type: "string" },
+                        { type: "array", items: { type: "string" } },
+                    ],
+                    description: "Follow-up cleanup, docs, or test suggestions.",
+                },
+                labels: {
+                    type: "array",
+                    items: { type: "string" },
+                    description:
+                        "Optional labels. Valid catalyst-core labels: bug, dependencies, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. If omitted, the tool infers one primary label.",
+                },
+                context: {
+                    type: ["string", "object"],
+                    description: "Context returned by gather_github_issue_context.",
+                },
+                images: {
+                    type: "array",
+                    items: { type: ["string", "object"] },
+                    description: "Optional image URLs or local image paths.",
                 },
             },
-            required: ["title", "body"],
+            required: ["title"],
         },
     },
 ]
@@ -519,9 +825,11 @@ const TOOL_HANDLERS = {
     close_task_plan: tasks.handle_close_task_plan,
     sync_catalyst_docs: sync.handle_sync_catalyst_docs,
     query_knowledge: knowledge.handle_query_knowledge,
+    start_github_issue_flow: github.handle_start_github_issue_flow,
+    gather_github_issue_context: github.handle_gather_github_issue_context,
     create_github_issue: github.handle_create_github_issue,
-    create_github_discussion: github.handle_create_github_discussion,
     preview_github_feedback: github.handle_preview_github_feedback,
+    generate_issue_markdown: github.handle_generate_issue_markdown,
 }
 
 // ── MCP JSON-RPC over stdio ───────────────────────────────────────────────────
@@ -589,7 +897,7 @@ rl.on("line", (line) => {
                                 text: JSON.stringify({
                                     error: "out_of_scope",
                                     message:
-                                        "This query is outside Catalyst MCP scope. MCP handles: conversion tracking, debugging, config validation, build flow, architecture, task planning, and doc sync.",
+                                        "This query is outside Catalyst MCP scope. MCP handles: conversion tracking, debugging, config validation, build flow, architecture, task planning, doc sync, and GitHub issue creation.",
                                 }),
                             },
                         ],

--- a/packages/catalyst-core/mcp_v2/mcp.js
+++ b/packages/catalyst-core/mcp_v2/mcp.js
@@ -99,11 +99,11 @@ const INTENT_PATTERNS = {
     guidance:
         /\b(what\s+is|what\s+are|how\s+does|how\s+do|explain|show\s+me|tell\s+me|hook|api|usage|example)\b/i,
     status: /status|done|complet|finish|check.*config|config.*check|what.*(left|remain|todo|next|pending)|how far|progress/i,
+    // feedback = wants to raise an issue or discussion on GitHub
+    feedback: /\b(issue|bug\s+report|report\s+(a\s+)?bug|open\s+(an?\s+)?issue|create\s+(an?\s+)?issue|raise\s+(an?\s+)?issue|discussion|discuss|feature\s+request|proposal|suggest)\b/i,
     debug: /error|fail|broken|not work|crash|issue|bug|why|wrong/i,
     build: /build|compile|webpack|bundle|android|ios|platform/i,
     sync: /sync|update.*doc|fetch.*doc|latest.*doc/i,
-    // feedback = wants to raise an issue or discussion on GitHub
-    feedback: /\b(issue|bug\s+report|report\s+(a\s+)?bug|open\s+(an?\s+)?issue|create\s+(an?\s+)?issue|raise\s+(an?\s+)?issue|discussion|discuss|feature\s+request|proposal|suggest)\b/i,
 }
 
 // next_action tells the LLM exactly what to do after getting this response
@@ -418,184 +418,21 @@ const TOOLS = [
         },
     },
     {
-        name: "start_github_issue_flow",
+        name: "create_github_issue",
         description:
-            "ALWAYS call this FIRST when the developer explicitly wants to create, raise, report, or publish a GitHub issue for catalyst-core, OR when the LLM discovers during another task that the root cause is likely catalyst-core framework behavior. If inferred during another task, ask the developer whether they want to create an issue before proceeding. Returns the issue-agent workflow, approval gates, template suggestions, required details to collect, supported labels/tags, screenshot/image handling rules, duplicate-avoidance policy, and next tool calls. Intent: feedback.",
+            "Use when the developer wants to create, raise, report, preview, or publish a GitHub issue for catalyst-core, or after the LLM discovers that a problem is likely caused by catalyst-core framework behavior and the developer agrees to raise an issue. This single tool first asks the developer to select labels when labels are omitted. After labels are supplied, it gathers project context, renders the issue using the selected/suggested template, searches duplicates using duplicate_search_query when provided, supports preview with dry_run:true, publishes only when dry_run:false is explicitly passed, and falls back to a markdown draft on auth/network/API failure. Default to dry_run:true first; if label_selection_required is returned, ask the developer to select labels before collecting/rendering the rest of the issue. Intent: feedback.",
         inputSchema: {
             type: "object",
             properties: {
-                problem: {
-                    type: "string",
-                    description: "The developer's initial issue/problem statement, if already known.",
+                dry_run: {
+                    type: "boolean",
+                    description:
+                        "Defaults to true. When true, returns rendered preview, labels, duplicate candidates, and gathered context without publishing. Pass false only after explicit developer approval.",
                 },
-                _query: {
-                    type: "string",
-                    description: "Original user query for intent classification.",
-                },
-            },
-        },
-    },
-    {
-        name: "gather_github_issue_context",
-        description:
-            "Use after start_github_issue_flow and before preview_github_feedback. Reads the current Catalyst app context for a stronger GitHub issue: package name, catalyst-core version, scripts, config, git branch/status, runtime versions, and relevant file snippets. Use this to gather evidence before selecting the final template/labels. Intent: feedback.",
-        inputSchema: {
-            type: "object",
-            properties: {
                 project_path: {
                     type: "string",
                     description: "Path to the catalyst app root. Defaults to detected project root.",
                 },
-                title: {
-                    type: "string",
-                    description: "Issue title, if available.",
-                },
-                problem: {
-                    type: "string",
-                    description: "Issue/problem statement or symptoms.",
-                },
-                query: {
-                    type: "string",
-                    description: "Search text used to find relevant source snippets.",
-                },
-                files: {
-                    type: "array",
-                    items: { type: "string" },
-                    description: "Optional explicit project files to include as context snippets.",
-                },
-                _query: {
-                    type: "string",
-                    description: "Original user query for intent classification.",
-                },
-            },
-        },
-    },
-    {
-        name: "preview_github_feedback",
-        description:
-            "Use after start_github_issue_flow and gather_github_issue_context, before create_github_issue. Drafts the full GitHub issue with project context, suggested template, labels/tags, image URLs/paths, and duplicate search, then returns a preview for developer approval WITHOUT publishing anything. Prefer passing duplicate_search_query from the LLM context instead of relying on automatic keyword extraction. If duplicate candidates are returned, show them first and ask whether to cancel/use an existing issue, edit, or continue because this issue is distinct. Show this final rendered template to the developer and ask for edits or explicit publish approval. Intent: feedback.",
-        inputSchema: {
-            type: "object",
-            properties: {
-                title: {
-                    type: "string",
-                    description: "Proposed title for the issue.",
-                },
-                body: {
-                    type: "string",
-                    description:
-                        "Proposed body. Plain text is upgraded into the catalyst-core issue style; already structured markdown is preserved.",
-                },
-                summary: {
-                    type: "string",
-                    description: "Structured issue summary if body is not already composed.",
-                },
-                issue_template: {
-                    type: "string",
-                    enum: ["bug", "enhancement", "documentation", "dependencies", "question"],
-                    description:
-                        "Optional template to force. Use bug for broken behavior, enhancement for feature requests, documentation for docs/examples, dependencies for package updates, question for clarification.",
-                },
-                current_behavior: {
-                    type: "string",
-                    description: "What happens today.",
-                },
-                steps_to_reproduce: {
-                    oneOf: [
-                        { type: "string" },
-                        { type: "array", items: { type: "string" } },
-                    ],
-                    description: "Steps to reproduce the issue.",
-                },
-                expected_behavior: {
-                    type: "string",
-                    description: "What should happen.",
-                },
-                actual_behavior: {
-                    type: "string",
-                    description: "What actually happens.",
-                },
-                error_logs: {
-                    type: "string",
-                    description: "Error logs or stack traces.",
-                },
-                preflight_checklist: {
-                    type: "array",
-                    items: { type: "string" },
-                    description: "Optional checklist items for bug reports. Defaults to searched issues, single issue, and included repro/environment/logs.",
-                },
-                what_i_tried: {
-                    type: "string",
-                    description: "Troubleshooting already attempted.",
-                },
-                additional_information: {
-                    type: "string",
-                    description: "Additional context that does not fit the primary sections.",
-                },
-                related_issues: {
-                    oneOf: [
-                        { type: "string" },
-                        { type: "array", items: { type: "string" } },
-                    ],
-                    description: "Related GitHub issues or links.",
-                },
-                root_cause: {
-                    type: "string",
-                    description: "Technical notes or suspected root cause.",
-                },
-                proposed_fix: {
-                    type: "string",
-                    description: "Concrete suggested fix.",
-                },
-                optional_followups: {
-                    oneOf: [
-                        { type: "string" },
-                        { type: "array", items: { type: "string" } },
-                    ],
-                    description: "Follow-up cleanup, docs, or test suggestions.",
-                },
-                environment: {
-                    type: ["string", "object"],
-                    description: "Environment details such as platform, OS, browser, device, Node/npm versions.",
-                },
-                context: {
-                    type: ["string", "object"],
-                    description: "Context returned by gather_github_issue_context.",
-                },
-                type: {
-                    type: "string",
-                    enum: ["issue"],
-                    description:
-                        "'issue' for bugs, regressions, and actionable feature requests.",
-                },
-                labels: {
-                    type: "array",
-                    items: { type: "string" },
-                    description:
-                        "Optional labels. Valid catalyst-core labels: bug, dependencies, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. If omitted, the tool infers one primary label.",
-                },
-                images: {
-                    type: "array",
-                    items: { type: ["string", "object"] },
-                    description:
-                        "Optional image URLs or local image paths. URLs are embedded directly; local paths are preserved for fallback/manual upload.",
-                },
-                duplicate_search_query: {
-                    type: "string",
-                    description:
-                        "Optional focused search query for duplicate detection, supplied by the LLM from the issue context. Example: 'android webview error.html fallback'.",
-                },
-            },
-            required: ["title"],
-        },
-    },
-    {
-        name: "create_github_issue",
-        description:
-            "Use ONLY after preview_github_feedback has been shown and the developer explicitly approved publishing. Creates an issue on the catalyst-core GitHub repo using the selected/suggested template and labels. Automatically attaches the current catalyst-core version and project name to help triage. Before publishing, this tool searches for duplicate candidates using duplicate_search_query when provided and blocks creation if matches are found unless duplicate_review_confirmed:true is passed after showing those candidates to the developer. If GitHub creation, auth, labels, network, or validation fails, return a manual markdown fallback via generate_issue_markdown/fallback. Intent: feedback.",
-        inputSchema: {
-            type: "object",
-            properties: {
                 title: {
                     type: "string",
                     description: "Short, descriptive issue title. E.g. 'RouterDataProvider fails on nested dynamic routes'.",
@@ -677,15 +514,11 @@ const TOOLS = [
                     type: ["string", "object"],
                     description: "Environment details such as platform, OS, browser, device, Node/npm versions.",
                 },
-                context: {
-                    type: ["string", "object"],
-                    description: "Context returned by gather_github_issue_context.",
-                },
                 labels: {
                     type: "array",
                     items: { type: "string" },
                     description:
-                        "Optional labels. Valid catalyst-core labels: bug, dependencies, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. If omitted, the tool infers one primary label.",
+                        "Required after the initial label-selection step. Valid catalyst-core labels: bug, dependencies, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. If omitted, the tool returns label_selection_required and does not gather context, render a full preview, search duplicates, or publish.",
                 },
                 images: {
                     type: "array",
@@ -696,126 +529,28 @@ const TOOLS = [
                 duplicate_search_query: {
                     type: "string",
                     description:
-                        "Optional focused search query for duplicate detection, supplied by the LLM from the issue context. Use the same query reviewed in preview_github_feedback.",
+                        "Optional focused search query for duplicate detection, supplied by the LLM from the issue context. Use the same query reviewed in the dry_run:true preview.",
                 },
                 duplicate_review_confirmed: {
                     type: "boolean",
                     description:
-                        "Set true only after preview_github_feedback or create_github_issue returned duplicate candidates, those candidates were shown to the developer, and the developer explicitly confirmed this issue is distinct and should still be published.",
+                        "Set true only after a dry_run:true preview or blocked publish returned duplicate candidates, those candidates were shown to the developer, and the developer explicitly confirmed this issue is distinct and should still be published.",
                 },
                 duplicate_review_note: {
                     type: "string",
                     description:
                         "Optional short note explaining why the issue is not a duplicate, after the developer confirms publishing.",
                 },
-            },
-            required: ["title"],
-        },
-    },
-    {
-        name: "generate_issue_markdown",
-        description:
-            "Use when create_github_issue fails due to auth, permissions, network, or validation problems, or when the developer explicitly wants a manual GitHub issue draft. Writes a local markdown file under .mcp_issues/ with title, labels, body, context, and image paths for manual copy/upload. Intent: feedback.",
-        inputSchema: {
-            type: "object",
-            properties: {
-                project_path: {
-                    type: "string",
-                    description: "Path to the catalyst app root. Defaults to detected project root.",
-                },
-                title: {
-                    type: "string",
-                    description: "Short, descriptive issue title.",
-                },
-                body: {
-                    type: "string",
-                    description: "Full issue body. Plain text is upgraded into the catalyst-core issue style; already structured markdown is preserved.",
-                },
-                summary: {
-                    type: "string",
-                    description: "Structured issue summary if body is not already composed.",
-                },
-                issue_template: {
-                    type: "string",
-                    enum: ["bug", "enhancement", "documentation", "dependencies", "question"],
-                    description:
-                        "Optional template to force. Use bug for broken behavior, enhancement for feature requests, documentation for docs/examples, dependencies for package updates, question for clarification.",
-                },
-                current_behavior: {
-                    type: "string",
-                    description: "What happens today.",
-                },
-                steps_to_reproduce: {
-                    oneOf: [
-                        { type: "string" },
-                        { type: "array", items: { type: "string" } },
-                    ],
-                    description: "Steps to reproduce the issue.",
-                },
-                expected_behavior: {
-                    type: "string",
-                    description: "What should happen.",
-                },
-                actual_behavior: {
-                    type: "string",
-                    description: "What actually happens.",
-                },
-                error_logs: {
-                    type: "string",
-                    description: "Error logs or stack traces.",
-                },
-                preflight_checklist: {
+                files: {
                     type: "array",
                     items: { type: "string" },
-                    description: "Optional checklist items for bug reports. Defaults to searched issues, single issue, and included repro/environment/logs.",
+                    description: "Optional explicit project files to include as context snippets.",
                 },
-                what_i_tried: {
+                _query: {
                     type: "string",
-                    description: "Troubleshooting already attempted.",
-                },
-                additional_information: {
-                    type: "string",
-                    description: "Additional context that does not fit the primary sections.",
-                },
-                related_issues: {
-                    oneOf: [
-                        { type: "string" },
-                        { type: "array", items: { type: "string" } },
-                    ],
-                    description: "Related GitHub issues or links.",
-                },
-                root_cause: {
-                    type: "string",
-                    description: "Technical notes or suspected root cause.",
-                },
-                proposed_fix: {
-                    type: "string",
-                    description: "Concrete suggested fix.",
-                },
-                optional_followups: {
-                    oneOf: [
-                        { type: "string" },
-                        { type: "array", items: { type: "string" } },
-                    ],
-                    description: "Follow-up cleanup, docs, or test suggestions.",
-                },
-                labels: {
-                    type: "array",
-                    items: { type: "string" },
-                    description:
-                        "Optional labels. Valid catalyst-core labels: bug, dependencies, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. If omitted, the tool infers one primary label.",
-                },
-                context: {
-                    type: ["string", "object"],
-                    description: "Context returned by gather_github_issue_context.",
-                },
-                images: {
-                    type: "array",
-                    items: { type: ["string", "object"] },
-                    description: "Optional image URLs or local image paths.",
+                    description: "Original user query for intent classification.",
                 },
             },
-            required: ["title"],
         },
     },
 ]
@@ -835,11 +570,7 @@ const TOOL_HANDLERS = {
     close_task_plan: tasks.handle_close_task_plan,
     sync_catalyst_docs: sync.handle_sync_catalyst_docs,
     query_knowledge: knowledge.handle_query_knowledge,
-    start_github_issue_flow: github.handle_start_github_issue_flow,
-    gather_github_issue_context: github.handle_gather_github_issue_context,
     create_github_issue: github.handle_create_github_issue,
-    preview_github_feedback: github.handle_preview_github_feedback,
-    generate_issue_markdown: github.handle_generate_issue_markdown,
 }
 
 // ── MCP JSON-RPC over stdio ───────────────────────────────────────────────────

--- a/packages/catalyst-core/mcp_v2/mcp.js
+++ b/packages/catalyst-core/mcp_v2/mcp.js
@@ -25,6 +25,7 @@ const build = require("./tools/build")
 const tasks = require("./tools/tasks")
 const sync = require("./tools/sync")
 const knowledge = require("./tools/knowledge")
+const github = require("./tools/github")
 
 const MCP_DIR = __dirname
 const DB_PATH = path.join(MCP_DIR, "context.db")
@@ -87,6 +88,7 @@ build.init(db)
 tasks.init(db)
 sync.init(db)
 knowledge.init(db)
+github.init(projectInfo)
 
 // ── Intent classification (internal, not exposed as tool) ─────────────────────
 
@@ -100,6 +102,8 @@ const INTENT_PATTERNS = {
     debug: /error|fail|broken|not work|crash|issue|bug|why|wrong/i,
     build: /build|compile|webpack|bundle|android|ios|platform/i,
     sync: /sync|update.*doc|fetch.*doc|latest.*doc/i,
+    // feedback = wants to raise an issue or discussion on GitHub
+    feedback: /\b(issue|bug\s+report|report\s+(a\s+)?bug|open\s+(an?\s+)?issue|create\s+(an?\s+)?issue|raise\s+(an?\s+)?issue|discussion|discuss|feature\s+request|proposal|suggest)\b/i,
 }
 
 // next_action tells the LLM exactly what to do after getting this response
@@ -110,6 +114,7 @@ const INTENT_NEXT_ACTION = {
     debug: "answer_only — provide debug guidance. Do NOT call create_task_plan.",
     build: "answer_only — explain build flow. Do NOT call create_task_plan.",
     sync: "answer_only — sync complete. Do NOT call create_task_plan.",
+    feedback: "answer_only — GitHub action completed. Show the created issue/discussion URL. Do NOT call create_task_plan.",
     unknown: "answer_only — unclear intent. Return what you found. Do NOT call create_task_plan.",
 }
 
@@ -412,6 +417,91 @@ const TOOLS = [
             },
         },
     },
+    {
+        name: "preview_github_feedback",
+        description:
+            "ALWAYS call this FIRST before create_github_issue or create_github_discussion. Use when the developer wants to report a bug, raise an issue, start a discussion, or share any feedback about catalyst-core. This tool drafts the full content with project context attached, searches for duplicate issues/discussions already on GitHub, and returns a preview for the developer to approve — WITHOUT publishing anything. After the developer approves: if type was 'issue', you MUST call create_github_issue. If type was 'discussion', you MUST call create_github_discussion. Intent: feedback.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string",
+                    description: "Proposed title for the issue or discussion.",
+                },
+                body: {
+                    type: "string",
+                    description:
+                        "Proposed body. For bugs: include steps to reproduce, expected vs actual behaviour, error messages. For discussions: the question or proposal.",
+                },
+                type: {
+                    type: "string",
+                    enum: ["issue", "discussion"],
+                    description:
+                        "'issue' for bugs, regressions, and actionable feature requests. 'discussion' for questions, open-ended ideas, proposals, and general feedback.",
+                },
+                labels: {
+                    type: "array",
+                    items: { type: "string" },
+                    description: "Optional label names for issues. E.g. ['bug', 'native'].",
+                },
+                category: {
+                    type: "string",
+                    description: "Optional discussion category. E.g. 'Q&A', 'Ideas', 'General'.",
+                },
+            },
+            required: ["title", "body", "type"],
+        },
+    },
+    {
+        name: "create_github_issue",
+        description:
+            "Use ONLY when the developer wants to report a bug, request a feature, or raise any problem, AND the preview type was 'issue'. Do NOT call this tool if the preview type was 'discussion' (use create_github_discussion instead). Intent: feedback. Creates an issue on the catalyst-core GitHub repo. Automatically attaches the current catalyst-core version and project name to help triage.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string",
+                    description: "Short, descriptive issue title. E.g. 'RouterDataProvider fails on nested dynamic routes'.",
+                },
+                body: {
+                    type: "string",
+                    description:
+                        "Full issue description: steps to reproduce, expected behaviour, actual behaviour, any error messages or stack traces. The more detail, the better.",
+                },
+                labels: {
+                    type: "array",
+                    items: { type: "string" },
+                    description:
+                        "Optional label names to apply. Labels must already exist on the repo. E.g. ['bug', 'routing', 'native'].",
+                },
+            },
+            required: ["title", "body"],
+        },
+    },
+    {
+        name: "create_github_discussion",
+        description:
+            "Use ONLY when the developer wants to ask a question, propose an idea, or start a conversation, AND the preview type was 'discussion'. Do NOT call this tool if the preview type was 'issue' (use create_github_issue instead). Intent: feedback. Creates a GitHub Discussion on the catalyst-core repo. Auto-selects the best category (Q&A for questions, Ideas for proposals, General otherwise).",
+        inputSchema: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string",
+                    description: "Discussion title.",
+                },
+                body: {
+                    type: "string",
+                    description: "Full discussion body — the question, proposal, or topic to discuss.",
+                },
+                category: {
+                    type: "string",
+                    description:
+                        "Optional discussion category name. E.g. 'Q&A', 'Ideas', 'General', 'Show and tell'. If omitted, auto-detected from the body content.",
+                },
+            },
+            required: ["title", "body"],
+        },
+    },
 ]
 
 // ── Tool handler dispatch ─────────────────────────────────────────────────────
@@ -429,6 +519,9 @@ const TOOL_HANDLERS = {
     close_task_plan: tasks.handle_close_task_plan,
     sync_catalyst_docs: sync.handle_sync_catalyst_docs,
     query_knowledge: knowledge.handle_query_knowledge,
+    create_github_issue: github.handle_create_github_issue,
+    create_github_discussion: github.handle_create_github_discussion,
+    preview_github_feedback: github.handle_preview_github_feedback,
 }
 
 // ── MCP JSON-RPC over stdio ───────────────────────────────────────────────────

--- a/packages/catalyst-core/mcp_v2/mcp.js
+++ b/packages/catalyst-core/mcp_v2/mcp.js
@@ -473,7 +473,7 @@ const TOOLS = [
     {
         name: "preview_github_feedback",
         description:
-            "Use after start_github_issue_flow and gather_github_issue_context, before create_github_issue. Drafts the full GitHub issue with project context, suggested template, labels/tags, image URLs/paths, and duplicate search, then returns a preview for developer approval WITHOUT publishing anything. If duplicate candidates are returned, show them first and ask whether to cancel/use an existing issue, edit, or continue because this issue is distinct. Show this final rendered template to the developer and ask for edits or explicit publish approval. Intent: feedback.",
+            "Use after start_github_issue_flow and gather_github_issue_context, before create_github_issue. Drafts the full GitHub issue with project context, suggested template, labels/tags, image URLs/paths, and duplicate search, then returns a preview for developer approval WITHOUT publishing anything. Prefer passing duplicate_search_query from the LLM context instead of relying on automatic keyword extraction. If duplicate candidates are returned, show them first and ask whether to cancel/use an existing issue, edit, or continue because this issue is distinct. Show this final rendered template to the developer and ask for edits or explicit publish approval. Intent: feedback.",
         inputSchema: {
             type: "object",
             properties: {
@@ -580,6 +580,11 @@ const TOOLS = [
                     description:
                         "Optional image URLs or local image paths. URLs are embedded directly; local paths are preserved for fallback/manual upload.",
                 },
+                duplicate_search_query: {
+                    type: "string",
+                    description:
+                        "Optional focused search query for duplicate detection, supplied by the LLM from the issue context. Example: 'android webview error.html fallback'.",
+                },
             },
             required: ["title"],
         },
@@ -587,7 +592,7 @@ const TOOLS = [
     {
         name: "create_github_issue",
         description:
-            "Use ONLY after preview_github_feedback has been shown and the developer explicitly approved publishing. Creates an issue on the catalyst-core GitHub repo using the selected/suggested template and labels. Automatically attaches the current catalyst-core version and project name to help triage. Before publishing, this tool searches for duplicate candidates and blocks creation if matches are found unless duplicate_review_confirmed:true is passed after showing those candidates to the developer. If GitHub creation, auth, labels, network, or validation fails, return a manual markdown fallback via generate_issue_markdown/fallback. Intent: feedback.",
+            "Use ONLY after preview_github_feedback has been shown and the developer explicitly approved publishing. Creates an issue on the catalyst-core GitHub repo using the selected/suggested template and labels. Automatically attaches the current catalyst-core version and project name to help triage. Before publishing, this tool searches for duplicate candidates using duplicate_search_query when provided and blocks creation if matches are found unless duplicate_review_confirmed:true is passed after showing those candidates to the developer. If GitHub creation, auth, labels, network, or validation fails, return a manual markdown fallback via generate_issue_markdown/fallback. Intent: feedback.",
         inputSchema: {
             type: "object",
             properties: {
@@ -687,6 +692,11 @@ const TOOLS = [
                     items: { type: ["string", "object"] },
                     description:
                         "Optional image URLs or local image paths. URLs are embedded directly; local paths are preserved for fallback/manual upload.",
+                },
+                duplicate_search_query: {
+                    type: "string",
+                    description:
+                        "Optional focused search query for duplicate detection, supplied by the LLM from the issue context. Use the same query reviewed in preview_github_feedback.",
                 },
                 duplicate_review_confirmed: {
                     type: "boolean",

--- a/packages/catalyst-core/mcp_v2/setup.js
+++ b/packages/catalyst-core/mcp_v2/setup.js
@@ -16,30 +16,13 @@ const path = require("path")
 const Database = require("better-sqlite3")
 const https = require("https")
 const crypto = require("crypto")
+const { findCatalystRoot } = require("./lib/helpers")
 
 const MCP_DIR = __dirname
 const DB_PATH = path.join(MCP_DIR, "context.db")
 const SCHEMA_PATH = path.join(MCP_DIR, "schema.sql")
 const KB_PATH = path.join(MCP_DIR, "knowledge-base.json")
 const SITEMAP_URL = "https://catalyst.1mg.com/public_docs/sitemap.xml"
-
-// ── 1. Find & validate catalyst project ──────────────────────────────────────
-
-function findCatalystRoot() {
-    let dir = process.cwd()
-    while (dir !== path.parse(dir).root) {
-        const pkgPath = path.join(dir, "package.json")
-        if (fs.existsSync(pkgPath)) {
-            const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"))
-            const deps = { ...pkg.dependencies, ...pkg.devDependencies }
-            if (deps["catalyst-core"]) {
-                return { dir, pkg, catalystPackageName: "catalyst-core", version: deps["catalyst-core"] }
-            }
-        }
-        dir = path.dirname(dir)
-    }
-    return null
-}
 
 // ── 2. DB init ────────────────────────────────────────────────────────────────
 

--- a/packages/catalyst-core/mcp_v2/tools/github.js
+++ b/packages/catalyst-core/mcp_v2/tools/github.js
@@ -4,11 +4,10 @@
  * tools/github.js - Catalyst MCP v2
  *
  * GitHub issue workflow for AI agents:
- *   1. start_github_issue_flow      - tells the LLM what details to collect
- *   2. gather_github_issue_context  - reads project/framework context for triage
- *   3. preview_github_feedback      - formats the issue and checks duplicate candidates
- *   4. create_github_issue          - publishes after duplicate review, with markdown fallback
- *   5. generate_issue_markdown      - manual fallback when auth/API is unavailable
+ *   create_github_issue({ dry_run: true })  - first asks the developer to select labels
+ *   create_github_issue({ dry_run: true, labels }) - gathers context, templates, and duplicate candidates
+ *   create_github_issue({ dry_run: false }) - publishes after explicit developer approval
+ *   markdown fallback is generated internally when auth/API publishing fails
  *
  * Authentication:
  *   1. Direct GitHub API token from GITHUB_TOKEN, GITHUB_PAT, or CATALYST_GITHUB_TOKEN
@@ -228,6 +227,9 @@ function githubRequest(method, urlPath, token, body) {
         })
 
         req.on("error", reject)
+        req.setTimeout(30000, () => {
+            req.destroy(new Error("GitHub API request timed out after 30 seconds"))
+        })
         if (payload) req.write(payload)
         req.end()
     })
@@ -282,6 +284,38 @@ function resolveIssueLabels(args, body) {
     if (labels.length > 0) return labels
 
     return [resolveIssueTemplate(args, body)]
+}
+
+function hasLabelsInput(args) {
+    return Object.prototype.hasOwnProperty.call(args, "labels")
+}
+
+function buildLabelSelectionResponse(args = {}) {
+    const textForSuggestion = [
+        args.title,
+        args.body,
+        args.summary,
+        args.current_behavior,
+        args.actual_behavior,
+        args.expected_behavior,
+        args.error_logs,
+    ]
+        .filter((value) => typeof value === "string" && value.trim())
+        .join("\n")
+    const suggestedLabel = textForSuggestion ? inferPrimaryLabel(args.title, textForSuggestion) : null
+
+    return {
+        ok: true,
+        dry_run: true,
+        label_selection_required: true,
+        repo: `${GITHUB_OWNER}/${GITHUB_REPO}`,
+        possible_labels: DEFAULT_LABELS,
+        label_guidance: LABEL_GUIDANCE,
+        suggested_label: suggestedLabel,
+        instructions:
+            "Ask the developer to select one or more labels before gathering context, rendering the issue preview, checking duplicates, or publishing. Call create_github_issue again with labels set to the selected labels.",
+        next_action: "Wait for developer label selection, then call create_github_issue with labels.",
+    }
 }
 
 function stripExistingFooter(body) {
@@ -582,66 +616,6 @@ async function commentOnIssue(token, issueNumber, body) {
     }
 }
 
-function handle_start_issue_creation(args = {}) {
-    const initialBody = args.problem || args._query || ""
-    const suggestedTemplate = resolveIssueTemplate({ ...args, title: args.problem || args._query || "", body: initialBody }, initialBody)
-    const suggestedLabels = resolveIssueLabels({ ...args, title: args.problem || args._query || "", body: initialBody }, initialBody)
-
-    return {
-        ok: true,
-        mode: "github_issue_agent",
-        repo: `${GITHUB_OWNER}/${GITHUB_REPO}`,
-        when_to_use: [
-            "Use this flow when the developer explicitly asks to create/raise/report/publish a GitHub issue for catalyst-core.",
-            "Use this flow when, during another task, the LLM identifies that the failure is likely caused by catalyst-core framework behavior. In that case, ask the developer whether they want to create a GitHub issue before gathering/publishing.",
-        ],
-        approval_gates: [
-            "Ask the developer whether they want to create a GitHub issue if the issue was inferred during another task.",
-            "Suggest the best template and labels; ask whether the developer accepts them or wants changes.",
-            "Search existing GitHub issues for duplicate candidates and show any matches to the developer before publishing.",
-            "If duplicate candidates exist, ask whether to cancel, update/comment on the existing issue manually, or continue because this is distinct.",
-            "Show the final rendered issue preview, including screenshots/attachments and labels, before publishing.",
-            "Call create_github_issue only after explicit developer approval.",
-        ],
-        next_steps: [
-            "Ask the developer for a concise issue title and problem statement if not already known.",
-            "Collect steps to reproduce, expected behavior, actual behavior, error logs, environment, what was tried, related issues, and screenshot/image paths or URLs if available.",
-            "Ask the LLM to provide a concise duplicate_search_query with the framework area and failure symptom, e.g. `android webview error.html fallback`.",
-            "Call gather_github_issue_context with the title/problem so the issue includes catalyst-core version, package scripts, git state, and relevant file snippets.",
-            "Call preview_github_feedback to select/render the issue template, suggested labels, project context, screenshots/attachments, and duplicate candidates.",
-            "Show duplicate candidates first when present. If one is the same issue, stop and suggest using the existing issue instead of creating a duplicate.",
-            "Show the preview to the developer and ask for approval or edits. If duplicates were shown and the developer still wants to publish, pass duplicate_review_confirmed:true to create_github_issue.",
-            "After approval and duplicate review, call create_github_issue. If it returns ok:false with duplicate_candidates, show them and do not generate a new issue. If it fails due to auth/network/API, use the markdown_path fallback for manual GitHub creation.",
-        ],
-        supported_labels: DEFAULT_LABELS,
-        label_guidance: LABEL_GUIDANCE,
-        supported_templates: ISSUE_TEMPLATES,
-        template_selection_rules: [
-            "Use Bug report + bug for broken behavior, ignored config, crashes, regressions, incorrect output, or failed commands.",
-            "Use Feature request / enhancement + enhancement for new APIs, CLI improvements, universal hook behavior, or framework ergonomics.",
-            "Use Documentation improvement + documentation for missing/incorrect docs, examples, guides, README, migration notes, or typos.",
-            "Use Dependency update + dependencies for package updates, lockfile updates, npm audit/security updates, or dependency version changes.",
-            "Use Question / clarification + question when implementation is not yet clear and maintainer input is needed.",
-            "Add good first issue only when the change is small and well-scoped; add help wanted when extra maintainer/community attention is needed.",
-            "Use duplicate, invalid, or wontfix only after triage establishes that state.",
-        ],
-        suggested_template: ISSUE_TEMPLATES[suggestedTemplate],
-        suggested_labels: suggestedLabels,
-        image_support:
-            "Hosted image URLs are embedded in the issue body. Local image files are listed in the body and copied into the markdown fallback for manual upload, because GitHub's public Issues API does not upload local binaries.",
-        duplicate_policy:
-            "The preview step performs a best-effort duplicate search. Prefer passing duplicate_search_query from the LLM instead of relying on automatic keyword extraction. create_github_issue blocks publishing when matching issues are found unless duplicate_review_confirmed:true is provided after showing those candidates to the developer.",
-        auth_options: [
-            "Preferred: set a GitHub API token in the MCP server environment as GITHUB_TOKEN, GITHUB_PAT, or CATALYST_GITHUB_TOKEN.",
-            "Optional fallback: if GitHub CLI is installed and authenticated, the MCP can use `gh auth token`.",
-            "GitHub CLI is not required when an API token environment variable is configured.",
-        ],
-        manual_fallback:
-            "If GitHub auth, network, permission, or validation fails, call generate_issue_markdown or use the fallback returned by create_github_issue so the developer can raise the issue manually.",
-        initial_problem: args.problem || args._query || null,
-    }
-}
-
 function collectRelatedFiles(root, query, explicitFiles) {
     const files = []
     const candidates = Array.isArray(explicitFiles) ? explicitFiles : []
@@ -687,7 +661,7 @@ function collectRelatedFiles(root, query, explicitFiles) {
     return matches.slice(0, 5)
 }
 
-function handle_gather_github_issue_context(args = {}) {
+function gatherGithubIssueContext(args = {}) {
     const root = getProjectRoot(args)
     const pkg = safeReadJson(path.join(root, "package.json"))
     const configJson = safeReadJson(path.join(root, "config", "config.json"))
@@ -701,83 +675,24 @@ function handle_gather_github_issue_context(args = {}) {
     const dependencies = pkg ? { ...pkg.dependencies, ...pkg.devDependencies } : {}
 
     return {
-        ok: true,
-        context: {
-            project_path: root,
-            package_name: pkg && pkg.name,
-            catalyst_core_declared_version: dependencies["catalyst-core"] || null,
-            catalyst_core_installed_version: _projectInfo && _projectInfo.installedVersion,
-            scripts: pkg && pkg.scripts ? pkg.scripts : {},
-            config: configJson
-                ? {
-                      NODE_SERVER_PORT: configJson.NODE_SERVER_PORT,
-                      WEBVIEW_CONFIG: configJson.WEBVIEW_CONFIG,
-                  }
-                : null,
-            git: { branch, commit, dirty: Boolean(status), status },
-            runtime: { node: nodeVersion, npm: npmVersion },
-            related_files: relatedFiles,
-        },
-        instructions:
-            "Use this context to enrich the issue body. Include only relevant file snippets; do not include secrets or unrelated config.",
+        project_path: root,
+        package_name: pkg && pkg.name,
+        catalyst_core_declared_version: dependencies["catalyst-core"] || null,
+        catalyst_core_installed_version: _projectInfo && _projectInfo.installedVersion,
+        scripts: pkg && pkg.scripts ? pkg.scripts : {},
+        config: configJson
+            ? {
+                  NODE_SERVER_PORT: configJson.NODE_SERVER_PORT,
+                  WEBVIEW_CONFIG: configJson.WEBVIEW_CONFIG,
+              }
+            : null,
+        git: { branch, commit, dirty: Boolean(status), status },
+        runtime: { node: nodeVersion, npm: npmVersion },
+        related_files: relatedFiles,
     }
 }
 
-async function handle_preview_github_feedback(args = {}) {
-    const { title, type = "issue" } = args
-
-    if (!title || typeof title !== "string" || title.trim() === "") {
-        return { ok: false, error: "title is required." }
-    }
-    if (type !== "issue") {
-        return { ok: false, error: "Only GitHub issues are supported by this MCP tool." }
-    }
-
-    const built = buildIssueBody(args)
-    if (!built.body || built.body.trim() === "") {
-        return { ok: false, error: "body or structured issue fields are required." }
-    }
-
-    let duplicates = []
-    let tokenSource = "none"
-    const tokenResult = getToken()
-    if (tokenResult.ok) {
-        tokenSource = tokenResult.source
-        duplicates = await searchDuplicates(tokenResult.token, title, built.body, args.duplicate_search_query)
-    }
-
-    return {
-        ok: true,
-        preview: {
-            type: "issue",
-            repo: `${GITHUB_OWNER}/${GITHUB_REPO}`,
-            title: title.trim(),
-            body: built.body,
-            labels: resolveIssueLabels(args, built.body),
-            suggested_template: ISSUE_TEMPLATES[resolveIssueTemplate(args, built.body)],
-            possible_labels: DEFAULT_LABELS,
-            label_guidance: LABEL_GUIDANCE,
-            images: built.images,
-        },
-        duplicates,
-        duplicate_review: {
-            required_before_publish: duplicates.length > 0,
-            status: duplicates.length > 0 ? "needs_user_review" : "no_duplicate_candidates_found",
-            candidates: duplicates,
-            publish_override_field:
-                duplicates.length > 0
-                    ? "Pass duplicate_review_confirmed:true to create_github_issue only after the developer confirms this is not a duplicate."
-                    : null,
-        },
-        token_source: tokenSource,
-        instructions:
-            duplicates.length > 0
-                ? "Show the suggested template, labels, full issue body, attachments, and duplicate candidates to the developer. Ask whether to cancel/use an existing issue, edit, or publish because this is distinct. Call create_github_issue only after explicit approval, and include duplicate_review_confirmed:true if the developer chooses to publish."
-                : "Show the suggested template, labels, full issue body, and attachments to the developer. Ask whether to edit, cancel, or publish. Call create_github_issue only after explicit approval.",
-    }
-}
-
-function handle_generate_issue_markdown(args = {}) {
+function generateIssueMarkdown(args = {}) {
     const { title } = args
     if (!title || typeof title !== "string" || title.trim() === "") {
         return { ok: false, error: "title is required." }
@@ -817,19 +732,88 @@ function handle_generate_issue_markdown(args = {}) {
 }
 
 async function handle_create_github_issue(args = {}) {
+    const labels = normalizeLabels(args.labels)
+    if (!hasLabelsInput(args) || labels.length === 0) {
+        if (hasLabelsInput(args)) {
+            return {
+                ok: false,
+                error: "labels must include at least one valid Catalyst GitHub label.",
+                possible_labels: DEFAULT_LABELS,
+                label_guidance: LABEL_GUIDANCE,
+            }
+        }
+        return buildLabelSelectionResponse(args)
+    }
+
     const { title } = args
     if (!title || typeof title !== "string" || title.trim() === "") {
         return { ok: false, error: "title is required and must be a non-empty string." }
     }
 
-    const built = buildIssueBody(args)
+    const dryRun = args.dry_run !== false
+    const gatheredContext = gatherGithubIssueContext({
+        ...args,
+        query: args.query || args.duplicate_search_query || args.summary || args.body || args.title,
+    })
+    const issueArgs = {
+        ...args,
+        context: args.context || gatheredContext,
+    }
+    const built = buildIssueBody(issueArgs)
     if (!built.body || built.body.trim() === "") {
         return { ok: false, error: "body or structured issue fields are required." }
     }
 
+    let duplicates = []
+    let tokenSource = "none"
     const tokenResult = getToken()
+    if (tokenResult.ok) {
+        tokenSource = tokenResult.source
+        duplicates = await searchDuplicates(tokenResult.token, title, built.body, issueArgs.duplicate_search_query)
+    }
+
+    const preview = {
+        type: "issue",
+        repo: `${GITHUB_OWNER}/${GITHUB_REPO}`,
+        title: title.trim(),
+        body: built.body,
+        labels,
+        suggested_template: ISSUE_TEMPLATES[resolveIssueTemplate(issueArgs, built.body)],
+        possible_labels: DEFAULT_LABELS,
+        label_guidance: LABEL_GUIDANCE,
+        images: built.images,
+        context: gatheredContext,
+    }
+
+    const duplicateReview = {
+        required_before_publish: duplicates.length > 0,
+        status: duplicates.length > 0 ? "needs_user_review" : "no_duplicate_candidates_found",
+        candidates: duplicates,
+        publish_override_field:
+            duplicates.length > 0
+                ? "Pass duplicate_review_confirmed:true with dry_run:false only after the developer confirms this is not a duplicate."
+                : null,
+    }
+
+    if (dryRun) {
+        return {
+            ok: true,
+            dry_run: true,
+            preview,
+            duplicates,
+            duplicate_review: duplicateReview,
+            token_source: tokenSource,
+            auth_warning: tokenResult.ok ? null : tokenResult.error,
+            instructions:
+                duplicates.length > 0
+                    ? "Show the rendered issue preview, suggested template, labels, attachments, context, and duplicate candidates to the developer. Ask whether to cancel/use an existing issue, edit, or publish because this is distinct. Publish only after explicit approval with dry_run:false, and include duplicate_review_confirmed:true if duplicates were reviewed."
+                    : "Show the rendered issue preview, suggested template, labels, attachments, and context to the developer. Ask whether to edit, cancel, or publish. Publish only after explicit approval with dry_run:false.",
+            next_action: "Wait for explicit developer approval before calling create_github_issue with dry_run:false.",
+        }
+    }
+
     if (!tokenResult.ok) {
-        const fallback = handle_generate_issue_markdown(args)
+        const fallback = generateIssueMarkdown(issueArgs)
         return {
             ok: false,
             error: tokenResult.error,
@@ -837,7 +821,6 @@ async function handle_create_github_issue(args = {}) {
         }
     }
 
-    const labels = resolveIssueLabels(args, built.body)
     const payload = {
         title: title.trim(),
         body: built.body,
@@ -845,7 +828,6 @@ async function handle_create_github_issue(args = {}) {
     }
 
     try {
-        const duplicates = await searchDuplicates(tokenResult.token, title, built.body, args.duplicate_search_query)
         if (duplicates.length > 0 && args.duplicate_review_confirmed !== true) {
             return {
                 ok: false,
@@ -914,14 +896,14 @@ async function handle_create_github_issue(args = {}) {
         }
 
         const apiMessage = res.body && res.body.message ? res.body.message : JSON.stringify(res.body)
-        const fallback = handle_generate_issue_markdown(args)
+        const fallback = generateIssueMarkdown(issueArgs)
         return {
             ok: false,
             error: `GitHub API returned HTTP ${res.status}: ${apiMessage}`,
             fallback: fallback.ok ? fallback : null,
         }
     } catch (err) {
-        const fallback = handle_generate_issue_markdown(args)
+        const fallback = generateIssueMarkdown(issueArgs)
         return {
             ok: false,
             error: `Network error while calling GitHub API: ${err.message}`,
@@ -932,11 +914,5 @@ async function handle_create_github_issue(args = {}) {
 
 module.exports = {
     init,
-    handle_start_issue_creation,
-    handle_start_github_issue_flow: handle_start_issue_creation,
-    handle_gather_github_issue_context,
-    handle_preview_github_feedback,
-    handle_preview_github_issue: handle_preview_github_feedback,
     handle_create_github_issue,
-    handle_generate_issue_markdown,
 }

--- a/packages/catalyst-core/mcp_v2/tools/github.js
+++ b/packages/catalyst-core/mcp_v2/tools/github.js
@@ -544,6 +544,74 @@ function buildDuplicateSearchText(title, body, duplicateSearchQuery) {
     return normalizeSearchText(body).split(/\s+/).slice(0, 8).join(" ")
 }
 
+const SENSITIVE_FILE_PATTERN =
+    /(^|\/)(\.env|\.npmrc|\.pypirc|config\/config\.json|google-services\.json|googleservice-info\.plist|.*keystore.*|.*\.jks|.*\.p12|.*\.pem|.*\.key)$/i
+
+const SENSITIVE_TEXT_PATTERN =
+    /\b(api[_-]?key|auth[_-]?token|authorization|client[_-]?secret|cookie|firebase|google[_-]?services|password|private[_-]?key|secret|session[_-]?id|sentry[_-]?dsn|token)\b/i
+
+const SENSITIVE_BODY_PATTERN =
+    /\b(api[_-]?key|auth[_-]?token|authorization|client[_-]?secret|cookie|password|private[_-]?key|secret|session[_-]?id|sentry[_-]?dsn|token)\b\s*[:=]\s*\S+|\bbearer\s+[a-z0-9._-]+/i
+
+function addSensitiveFinding(findings, seen, finding) {
+    const key = `${finding.type}:${finding.path || ""}:${finding.reason}`
+    if (seen.has(key)) return
+    seen.add(key)
+    findings.push(finding)
+}
+
+function detectSensitiveIssueData({ body, context }) {
+    const findings = []
+    const seen = new Set()
+
+    if (context && context.config) {
+        addSensitiveFinding(findings, seen, {
+            type: "config",
+            path: "config/config.json",
+            reason: "Issue context includes Catalyst config fields.",
+        })
+    }
+
+    const relatedFiles = context && Array.isArray(context.related_files) ? context.related_files : []
+    for (const file of relatedFiles) {
+        if (!file || typeof file.path !== "string") continue
+
+        if (SENSITIVE_FILE_PATTERN.test(file.path)) {
+            addSensitiveFinding(findings, seen, {
+                type: "file",
+                path: file.path,
+                reason: "Related file path is a config or credential-looking file.",
+            })
+        }
+
+        if (typeof file.content === "string" && SENSITIVE_TEXT_PATTERN.test(file.content)) {
+            addSensitiveFinding(findings, seen, {
+                type: "content",
+                path: file.path,
+                reason: "Related file content contains secret-looking keys or values.",
+            })
+        }
+    }
+
+    if (typeof body === "string" && SENSITIVE_BODY_PATTERN.test(body)) {
+        addSensitiveFinding(findings, seen, {
+            type: "body",
+            path: null,
+            reason: "Rendered issue body contains sensitive-looking words or values.",
+        })
+    }
+
+    return {
+        required_before_publish: findings.length > 0,
+        status: findings.length > 0 ? "needs_user_review" : "no_sensitive_or_config_data_detected",
+        findings,
+        publish_override_field:
+            findings.length > 0
+                ? "Pass sensitive_data_confirmed:true with dry_run:false only after the developer reviews the preview and confirms the config/sensitive-looking data may be posted."
+                : null,
+    }
+}
+
 async function searchDuplicates(token, title, body, duplicateSearchQuery) {
     const searchText = buildDuplicateSearchText(title, body, duplicateSearchQuery)
     if (!searchText) return []
@@ -794,6 +862,10 @@ async function handle_create_github_issue(args = {}) {
                 ? "Pass duplicate_review_confirmed:true with dry_run:false only after the developer confirms this is not a duplicate."
                 : null,
     }
+    const sensitiveDataReview = detectSensitiveIssueData({
+        body: built.body,
+        context: gatheredContext,
+    })
 
     if (dryRun) {
         return {
@@ -802,13 +874,32 @@ async function handle_create_github_issue(args = {}) {
             preview,
             duplicates,
             duplicate_review: duplicateReview,
+            sensitive_data_review: sensitiveDataReview,
             token_source: tokenSource,
             auth_warning: tokenResult.ok ? null : tokenResult.error,
             instructions:
-                duplicates.length > 0
-                    ? "Show the rendered issue preview, suggested template, labels, attachments, context, and duplicate candidates to the developer. Ask whether to cancel/use an existing issue, edit, or publish because this is distinct. Publish only after explicit approval with dry_run:false, and include duplicate_review_confirmed:true if duplicates were reviewed."
+                duplicates.length > 0 || sensitiveDataReview.required_before_publish
+                    ? "Show the rendered issue preview, suggested template, labels, attachments, context, duplicate candidates if any, and sensitive/config data warning if present. Ask whether to edit, cancel, use an existing issue, or publish. Publish only after explicit approval with dry_run:false. Include duplicate_review_confirmed:true if duplicates were reviewed, and sensitive_data_confirmed:true if config or sensitive-looking data was detected and the developer confirms it may be posted."
                     : "Show the rendered issue preview, suggested template, labels, attachments, and context to the developer. Ask whether to edit, cancel, or publish. Publish only after explicit approval with dry_run:false.",
             next_action: "Wait for explicit developer approval before calling create_github_issue with dry_run:false.",
+        }
+    }
+
+    const payload = {
+        title: title.trim(),
+        body: built.body,
+        labels,
+    }
+
+    if (sensitiveDataReview.required_before_publish && args.sensitive_data_confirmed !== true) {
+        return {
+            ok: false,
+            blocked: true,
+            error:
+                "The rendered GitHub issue includes config or sensitive-looking data. Show the preview and warning to the developer, and publish only if they explicitly confirm this data may be posted.",
+            sensitive_data_review: sensitiveDataReview,
+            next_action:
+                "If the developer confirms the config/sensitive-looking data may be posted, call create_github_issue again with sensitive_data_confirmed:true and dry_run:false.",
         }
     }
 
@@ -819,12 +910,6 @@ async function handle_create_github_issue(args = {}) {
             error: tokenResult.error,
             fallback: fallback.ok ? fallback : null,
         }
-    }
-
-    const payload = {
-        title: title.trim(),
-        body: built.body,
-        labels,
     }
 
     try {

--- a/packages/catalyst-core/mcp_v2/tools/github.js
+++ b/packages/catalyst-core/mcp_v2/tools/github.js
@@ -136,11 +136,25 @@ function safeReadJson(filePath) {
 }
 
 function safeReadText(filePath, maxBytes = 8000) {
+    let fd
     try {
-        const content = fs.readFileSync(filePath, "utf8")
-        return content.length > maxBytes ? `${content.slice(0, maxBytes)}\n...[truncated]` : content
+        fd = fs.openSync(filePath, "r")
+        const stats = fs.fstatSync(fd)
+        const limit = Math.max(0, maxBytes)
+        const buffer = Buffer.alloc(limit)
+        const bytesRead = fs.readSync(fd, buffer, 0, limit, 0)
+        const content = buffer.subarray(0, bytesRead).toString("utf8")
+        return stats.size > bytesRead ? `${content}\n...[truncated]` : content
     } catch {
         return null
+    } finally {
+        if (typeof fd === "number") {
+            try {
+                fs.closeSync(fd)
+            } catch {
+                // Ignore close failures; callers treat unreadable files as absent.
+            }
+        }
     }
 }
 
@@ -320,7 +334,7 @@ function buildLabelSelectionResponse(args = {}) {
 
 function stripExistingFooter(body) {
     return String(body || "")
-        .replace(/\n---\n(?:\*\*(?:Project|catalyst-core version|Project path|Reported via):\*\*.*\n?)+$/m, "")
+        .replace(/\n---\n(?:\*\*(?:Project|catalyst-core version|Project path|Reported via):\*\*.*\n?)+$/, "")
         .trim()
 }
 
@@ -349,9 +363,49 @@ function firstNonEmpty(...values) {
     return ""
 }
 
+function hasContentValue(value) {
+    if (typeof value === "string") return Boolean(value.trim())
+    if (Array.isArray(value)) return value.some(hasContentValue)
+    if (value && typeof value === "object") return Object.keys(value).length > 0
+    return false
+}
+
+function hasUserIssueContent(args = {}) {
+    return [
+        "body",
+        "summary",
+        "current_behavior",
+        "actual_behavior",
+        "expected_behavior",
+        "error_logs",
+        "environment",
+        "what_i_tried",
+        "additional_information",
+        "related_issues",
+        "root_cause",
+        "proposed_fix",
+        "optional_followups",
+        "steps_to_reproduce",
+        "repro",
+        "notes",
+        "context",
+    ].some((key) => hasContentValue(args[key]))
+}
+
 function appendSection(sections, heading, content) {
-    const text = Array.isArray(content) ? toMarkdownList(content) : firstNonEmpty(content)
+    const text = Array.isArray(content)
+        ? toMarkdownList(content)
+        : content && typeof content === "object"
+          ? JSON.stringify(content, null, 2)
+          : firstNonEmpty(content)
     if (text) sections.push(`## ${heading}\n\n${text}`)
+}
+
+function isPathInside(root, candidate) {
+    const resolvedRoot = path.resolve(root)
+    const resolvedCandidate = path.resolve(candidate)
+    const relative = path.relative(resolvedRoot, resolvedCandidate)
+    return relative === "" || (relative && !relative.startsWith("..") && !path.isAbsolute(relative))
 }
 
 function buildPreflightChecklist(args) {
@@ -451,7 +505,12 @@ function normalizeImages(images, root) {
             continue
         }
 
-        const absolutePath = path.isAbsolute(raw) ? raw : path.resolve(root, raw)
+        const absolutePath = path.isAbsolute(raw) ? path.resolve(raw) : path.resolve(root, raw)
+        if (!isPathInside(root, absolutePath)) {
+            localFiles.push({ path: raw, exists: false, rejected: true, reason: "outside_project_root" })
+            lines.push(`- ${raw} (outside project root; not included)`)
+            continue
+        }
         const exists = fs.existsSync(absolutePath)
         localFiles.push({ path: absolutePath, exists })
         lines.push(`- ${absolutePath}${exists ? "" : " (not found)"}`)
@@ -518,9 +577,6 @@ function enrichBody(body) {
         }
         const version = _projectInfo.installedVersion || _projectInfo.catalystVersion || "unknown"
         lines.push(`**catalyst-core version:** \`${version}\``)
-        if (_projectInfo.dir) {
-            lines.push(`**Project path:** \`${_projectInfo.dir}\``)
-        }
     }
     lines.push("**Reported via:** Catalyst MCP v2")
     return lines.join("\n")
@@ -689,8 +745,8 @@ function collectRelatedFiles(root, query, explicitFiles) {
     const candidates = Array.isArray(explicitFiles) ? explicitFiles : []
     for (const file of candidates) {
         if (typeof file !== "string") continue
-        const absolute = path.isAbsolute(file) ? file : path.join(root, file)
-        if (!absolute.startsWith(root)) continue
+        const absolute = path.isAbsolute(file) ? path.resolve(file) : path.resolve(root, file)
+        if (!isPathInside(root, absolute)) continue
         const content = safeReadText(absolute, 12000)
         if (content) {
             files.push({ path: path.relative(root, absolute), content })
@@ -767,6 +823,10 @@ function generateIssueMarkdown(args = {}) {
     }
 
     const root = getProjectRoot(args)
+    if (!hasUserIssueContent(args)) {
+        return { ok: false, error: "body or structured issue fields are required." }
+    }
+
     const built = buildIssueBody(args, { enrich: true })
     const labels = resolveIssueLabels(args, built.body)
     const dir = ensureFallbackDir(root)
@@ -818,6 +878,10 @@ async function handle_create_github_issue(args = {}) {
         return { ok: false, error: "title is required and must be a non-empty string." }
     }
 
+    if (!hasUserIssueContent(args)) {
+        return { ok: false, error: "body or structured issue fields are required." }
+    }
+
     const dryRun = args.dry_run !== false
     const gatheredContext = gatherGithubIssueContext({
         ...args,
@@ -825,7 +889,7 @@ async function handle_create_github_issue(args = {}) {
     })
     const issueArgs = {
         ...args,
-        context: args.context || gatheredContext,
+        context: args.context,
     }
     const built = buildIssueBody(issueArgs)
     if (!built.body || built.body.trim() === "") {
@@ -864,7 +928,7 @@ async function handle_create_github_issue(args = {}) {
     }
     const sensitiveDataReview = detectSensitiveIssueData({
         body: built.body,
-        context: gatheredContext,
+        context: issueArgs.context,
     })
 
     if (dryRun) {

--- a/packages/catalyst-core/mcp_v2/tools/github.js
+++ b/packages/catalyst-core/mcp_v2/tools/github.js
@@ -1,55 +1,183 @@
 "use strict"
 
 /**
- * tools/github.js — Catalyst MCP v2
+ * tools/github.js - Catalyst MCP v2
  *
- * Exposes three tools:
- *   preview_github_feedback   → drafts content, searches duplicates, returns preview for approval
- *   create_github_issue       → GitHub REST API  (POST /repos/{owner}/{repo}/issues)
- *   create_github_discussion  → GitHub GraphQL API (createDiscussion mutation)
+ * GitHub issue workflow for AI agents:
+ *   1. start_github_issue_flow      - tells the LLM what details to collect
+ *   2. gather_github_issue_context  - reads project/framework context for triage
+ *   3. preview_github_feedback      - formats the issue and checks duplicate candidates
+ *   4. create_github_issue          - publishes after duplicate review, with markdown fallback
+ *   5. generate_issue_markdown      - manual fallback when auth/API is unavailable
  *
- * Authentication (in priority order):
- *   1. GITHUB_TOKEN environment variable (Personal Access Token)
- *   2. GitHub CLI session  — `gh auth login` (token read via `gh auth token`)
- *
- *   Required scopes:
- *     - repo              (for creating issues + searching)
- *     - write:discussion  (for creating discussions)
- *
- * Zero external dependencies — uses Node's built-in `https` and `child_process` modules only.
+ * Authentication:
+ *   1. GITHUB_TOKEN environment variable
+ *   2. GitHub CLI session (`gh auth token`)
  */
 
+const fs = require("fs")
+const path = require("path")
 const https = require("https")
 const { execSync } = require("child_process")
 
-// ── Module state ──────────────────────────────────────────────────────────────
-
 let _projectInfo = null
 
-// Parsed from catalyst-core package.json "repository.url"
 const GITHUB_OWNER = "tata1mg"
 const GITHUB_REPO = "catalyst-core"
+const FALLBACK_DIR = ".mcp_issues"
+
+const DEFAULT_LABELS = [
+    "bug",
+    "dependencies",
+    "documentation",
+    "duplicate",
+    "enhancement",
+    "good first issue",
+    "help wanted",
+    "invalid",
+    "question",
+    "wontfix",
+]
+
+const LABEL_GUIDANCE = {
+    bug: "Something is broken, regressed, ignored, crashes, or behaves differently from the documented/configured behavior.",
+    dependencies: "Dependency/package update work, package-lock changes, npm audit fixes, or vulnerability remediation.",
+    documentation: "Docs, README, examples, guides, migration notes, tutorials, or wording fixes.",
+    duplicate: "The same issue already exists.",
+    enhancement: "New capability, framework improvement, or actionable feature request.",
+    "good first issue": "Small, well-scoped change suitable for newcomers.",
+    "help wanted": "Needs extra maintainer/community attention or implementation help.",
+    invalid: "The report is not applicable or does not describe a valid Catalyst problem.",
+    question: "Needs clarification, usage guidance, or design direction before implementation.",
+    wontfix: "A consciously unsupported or not-planned request.",
+}
+
+const ISSUE_TEMPLATES = {
+    bug: {
+        label: "bug",
+        name: "Bug report",
+        use_when: "Something is not working, is ignored, crashes, regresses, or differs from expected Catalyst behavior.",
+        sections: [
+            "Preflight Checklist",
+            "What's Wrong?",
+            "Steps to Reproduce",
+            "Expected Behavior",
+            "Actual Behavior",
+            "Error Messages/Logs",
+            "Environment",
+            "What I Tried",
+            "Additional Information",
+            "Related Issues",
+        ],
+    },
+    enhancement: {
+        label: "enhancement",
+        name: "Feature request / enhancement",
+        use_when: "A new capability, universal hook behavior, CLI improvement, or framework ergonomics improvement is needed.",
+        sections: [
+            "Summary",
+            "Motivation",
+            "Proposed Behaviour",
+            "Example Usage / Output",
+            "Proposed Fix",
+            "Optional Follow-ups",
+        ],
+    },
+    documentation: {
+        label: "documentation",
+        name: "Documentation improvement",
+        use_when: "Docs, examples, README, guides, migration notes, or API reference need to be added or corrected.",
+        sections: [
+            "Summary",
+            "Current Documentation",
+            "Suggested Documentation",
+            "Affected Pages / Examples",
+            "Optional Follow-ups",
+        ],
+    },
+    dependencies: {
+        label: "dependencies",
+        name: "Dependency update",
+        use_when: "A dependency, lockfile, audit finding, package version, or security update needs attention.",
+        sections: [
+            "Summary",
+            "Current Dependency",
+            "Target Dependency",
+            "Reason / Impact",
+            "Validation Plan",
+        ],
+    },
+    question: {
+        label: "question",
+        name: "Question / clarification",
+        use_when: "The report primarily asks for usage guidance, clarification, or a decision before implementation.",
+        sections: [
+            "Question",
+            "Context",
+            "What I Tried",
+            "Expected Guidance",
+        ],
+    },
+}
 
 function init(projectInfo) {
     _projectInfo = projectInfo
 }
 
-// ── Internal helpers ──────────────────────────────────────────────────────────
+function getProjectRoot(args = {}) {
+    return args.project_path || (_projectInfo && _projectInfo.dir) || process.cwd()
+}
 
-/**
- * Read a GitHub token in priority order:
- *   1. GITHUB_TOKEN env var
- *   2. Active `gh` CLI session (gh auth token)
- * Returns { ok, token, source } or { ok: false, error }.
- */
+function safeReadJson(filePath) {
+    try {
+        return JSON.parse(fs.readFileSync(filePath, "utf8"))
+    } catch {
+        return null
+    }
+}
+
+function safeReadText(filePath, maxBytes = 8000) {
+    try {
+        const content = fs.readFileSync(filePath, "utf8")
+        return content.length > maxBytes ? `${content.slice(0, maxBytes)}\n...[truncated]` : content
+    } catch {
+        return null
+    }
+}
+
+function runGit(root, command) {
+    try {
+        return execSync(command, {
+            cwd: root,
+            encoding: "utf8",
+            timeout: 4000,
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim()
+    } catch {
+        return null
+    }
+}
+
+function slugify(input) {
+    return String(input || "github-issue")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 80) || "github-issue"
+}
+
+function ensureFallbackDir(root) {
+    const dir = path.join(root, FALLBACK_DIR)
+    fs.mkdirSync(dir, { recursive: true })
+    return dir
+}
+
 function getToken() {
-    // 1. Explicit env var
     const envToken = process.env.GITHUB_TOKEN
     if (envToken && envToken.trim()) {
-        return { ok: true, token: envToken.trim(), source: "env" }
+        return { ok: true, token: envToken.trim(), source: "env:GITHUB_TOKEN" }
     }
 
-    // 2. GitHub CLI session — no credentials stored by Catalyst
     try {
         const ghToken = execSync("gh auth token", {
             encoding: "utf8",
@@ -58,27 +186,16 @@ function getToken() {
         }).trim()
         if (ghToken) return { ok: true, token: ghToken, source: "gh-cli" }
     } catch {
-        // gh not installed or not logged in — fall through to error
+        // gh not installed or not logged in.
     }
 
     return {
         ok: false,
         error:
-            "No GitHub credentials found. Provide one of:\n\n" +
-            "Option A — GitHub CLI (recommended, no config needed):\n" +
-            "  gh auth login\n" +
-            "  Required scopes: repo, write:discussion\n\n" +
-            "Option B — Environment variable:\n" +
-            "  Create a PAT at https://github.com/settings/tokens/new\n" +
-            '  Claude Desktop → claude_desktop_config.json → "env": { "GITHUB_TOKEN": "ghp_xxx..." }\n' +
-            "  Cursor → .cursor/mcp.json → \"env\": { \"GITHUB_TOKEN\": \"ghp_xxx...\" }",
+            "No GitHub credentials found. Run `gh auth login` with repo scope, or pass GITHUB_TOKEN in the MCP server environment.",
     }
 }
 
-/**
- * Thin wrapper around Node's https for GitHub API calls.
- * Returns parsed JSON body and status code.
- */
 function githubRequest(method, urlPath, token, body) {
     return new Promise((resolve, reject) => {
         const payload = body ? JSON.stringify(body) : null
@@ -113,19 +230,251 @@ function githubRequest(method, urlPath, token, body) {
     })
 }
 
-/**
- * Execute a GitHub GraphQL query/mutation.
- */
-function graphql(token, query, variables = {}) {
-    return githubRequest("POST", "/graphql", token, { query, variables })
+function normalizeLabels(labels) {
+    if (!Array.isArray(labels)) return []
+    const seen = new Set()
+    return labels
+        .filter((label) => typeof label === "string")
+        .map((label) => label.trim().toLowerCase())
+        .filter((label) => {
+            if (!label || !DEFAULT_LABELS.includes(label) || seen.has(label)) return false
+            seen.add(label)
+            return true
+        })
 }
 
-/**
- * Append a standard footer to the body with project context.
- * Makes triage easy for the catalyst-core team.
- */
+function inferPrimaryLabel(title, body) {
+    const text = `${title || ""}\n${body || ""}`.toLowerCase()
+
+    if (/\b(dependenc|package-lock|package\.json|npm audit|vulnerab|upgrade package)\b/.test(text)) {
+        return "dependencies"
+    }
+    if (/\b(doc|docs|documentation|readme|guide|tutorial|typo)\b/.test(text)) {
+        return "documentation"
+    }
+    if (/\b(bug|broken|fail|error|exception|crash|incorrect|ignored|not working|regression)\b/.test(text)) {
+        return "bug"
+    }
+    if (/\b(question|how do|how to|clarify|doubt)\b/.test(text)) {
+        return "question"
+    }
+
+    return "enhancement"
+}
+
+function resolveIssueTemplate(args, body) {
+    const requested = typeof args.issue_template === "string" ? args.issue_template.trim().toLowerCase() : ""
+    if (ISSUE_TEMPLATES[requested]) return requested
+
+    const labels = normalizeLabels(args.labels)
+    const templateLabel = labels.find((label) => ISSUE_TEMPLATES[label])
+    if (templateLabel) return templateLabel
+
+    const inferred = inferPrimaryLabel(args.title, body)
+    return ISSUE_TEMPLATES[inferred] ? inferred : "enhancement"
+}
+
+function resolveIssueLabels(args, body) {
+    const labels = normalizeLabels(args.labels)
+    if (labels.length > 0) return labels
+
+    return [resolveIssueTemplate(args, body)]
+}
+
+function stripExistingFooter(body) {
+    return String(body || "")
+        .replace(/\n---\n(?:\*\*(?:Project|catalyst-core version|Project path|Reported via):\*\*.*\n?)+$/m, "")
+        .trim()
+}
+
+function hasMarkdownHeadings(body) {
+    return /^#{2,3}\s+\S/m.test(body || "")
+}
+
+function toMarkdownList(value) {
+    if (Array.isArray(value)) {
+        return value
+            .map((item) => (typeof item === "string" ? item.trim() : ""))
+            .filter(Boolean)
+            .map((item, index) => {
+                if (/^\d+\.\s/.test(item) || /^[-*]\s/.test(item)) return item
+                return `${index + 1}. ${item}`
+            })
+            .join("\n")
+    }
+    return typeof value === "string" ? value.trim() : ""
+}
+
+function firstNonEmpty(...values) {
+    for (const value of values) {
+        if (typeof value === "string" && value.trim()) return value.trim()
+    }
+    return ""
+}
+
+function appendSection(sections, heading, content) {
+    const text = Array.isArray(content) ? toMarkdownList(content) : firstNonEmpty(content)
+    if (text) sections.push(`## ${heading}\n\n${text}`)
+}
+
+function buildPreflightChecklist(args) {
+    const checklist = Array.isArray(args.preflight_checklist)
+        ? args.preflight_checklist
+        : [
+              "I have searched existing issues and this has not already been reported.",
+              "This is a single issue, not a bundle of unrelated issues.",
+              "I have included reproduction steps, environment details, and logs where available.",
+          ]
+
+    return checklist
+        .map((item) => (typeof item === "string" ? item.trim() : ""))
+        .filter(Boolean)
+        .map((item) => (item.startsWith("[") ? `- ${item}` : `- [x] ${item}`))
+        .join("\n")
+}
+
+function buildStyledIssueSections(args) {
+    const rawBody = stripExistingFooter(args.body)
+
+    if (rawBody && hasMarkdownHeadings(rawBody)) {
+        return rawBody
+    }
+
+    const sections = []
+    const template = resolveIssueTemplate(args, rawBody)
+
+    if (template === "documentation") {
+        appendSection(sections, "Summary", firstNonEmpty(args.summary, rawBody))
+        appendSection(sections, "Current Documentation", firstNonEmpty(args.current_behavior, args.actual_behavior))
+        appendSection(sections, "Suggested Documentation", firstNonEmpty(args.expected_behavior, args.proposed_fix, args.suggested_fix))
+        appendSection(sections, "Affected Pages / Examples", args.steps_to_reproduce || args.repro)
+        appendSection(sections, "Optional Follow-ups", args.optional_followups || args.follow_ups)
+        return sections.join("\n\n").trim()
+    }
+
+    if (template === "dependencies") {
+        appendSection(sections, "Summary", firstNonEmpty(args.summary, rawBody))
+        appendSection(sections, "Current Dependency", firstNonEmpty(args.current_behavior, args.actual_behavior))
+        appendSection(sections, "Target Dependency", args.expected_behavior)
+        appendSection(sections, "Reason / Impact", firstNonEmpty(args.root_cause, args.notes))
+        appendSection(sections, "Validation Plan", args.steps_to_reproduce || args.repro)
+        return sections.join("\n\n").trim()
+    }
+
+    if (template === "question") {
+        appendSection(sections, "Question", firstNonEmpty(args.summary, rawBody))
+        appendSection(sections, "Context", firstNonEmpty(args.current_behavior, args.actual_behavior, args.root_cause, args.notes))
+        appendSection(sections, "What I Tried", args.steps_to_reproduce || args.repro)
+        appendSection(sections, "Expected Guidance", args.expected_behavior)
+        return sections.join("\n\n").trim()
+    }
+
+    if (template === "enhancement") {
+        appendSection(sections, "Summary", firstNonEmpty(args.summary, rawBody))
+        appendSection(sections, "Motivation", firstNonEmpty(args.current_behavior, args.actual_behavior, args.root_cause, args.notes))
+        appendSection(sections, "Proposed Behaviour", args.expected_behavior)
+        appendSection(sections, "Example Usage / Output", args.steps_to_reproduce || args.repro)
+        appendSection(sections, "Proposed Fix", firstNonEmpty(args.proposed_fix, args.suggested_fix))
+        appendSection(sections, "Optional Follow-ups", args.optional_followups || args.follow_ups)
+        return sections.join("\n\n").trim()
+    }
+
+    appendSection(sections, "Preflight Checklist", buildPreflightChecklist(args))
+    appendSection(sections, "What's Wrong?", firstNonEmpty(args.summary, rawBody))
+    appendSection(sections, "Steps to Reproduce", args.steps_to_reproduce || args.repro)
+    appendSection(sections, "Expected Behavior", args.expected_behavior)
+    appendSection(sections, "Actual Behavior", firstNonEmpty(args.actual_behavior, args.current_behavior))
+    appendSection(sections, "Error Messages/Logs", args.error_logs ? `\`\`\`\n${args.error_logs}\n\`\`\`` : "")
+    appendSection(sections, "Environment", args.environment)
+    appendSection(sections, "What I Tried", args.what_i_tried || args.what_tried)
+    appendSection(sections, "Additional Information", firstNonEmpty(args.additional_information, args.root_cause, args.notes, args.proposed_fix, args.suggested_fix))
+    appendSection(sections, "Related Issues", args.related_issues)
+
+    return sections.join("\n\n").trim()
+}
+
+function normalizeImages(images, root) {
+    if (!Array.isArray(images)) return { markdown: "", local_files: [], remote_urls: [] }
+
+    const localFiles = []
+    const remoteUrls = []
+    const lines = []
+
+    for (const image of images) {
+        const value = typeof image === "string" ? { path: image } : image
+        if (!value || typeof value !== "object") continue
+
+        const raw = value.url || value.path || value.file
+        if (!raw || typeof raw !== "string") continue
+
+        const alt = typeof value.alt === "string" && value.alt.trim() ? value.alt.trim() : "attachment"
+        if (/^https?:\/\//i.test(raw)) {
+            remoteUrls.push(raw)
+            lines.push(`![${alt}](${raw})`)
+            continue
+        }
+
+        const absolutePath = path.isAbsolute(raw) ? raw : path.resolve(root, raw)
+        const exists = fs.existsSync(absolutePath)
+        localFiles.push({ path: absolutePath, exists })
+        lines.push(`- ${absolutePath}${exists ? "" : " (not found)"}`)
+    }
+
+    if (lines.length === 0) return { markdown: "", local_files: localFiles, remote_urls: remoteUrls }
+
+    return {
+        markdown: ["", "## Attachments", "", ...lines].join("\n"),
+        local_files: localFiles,
+        remote_urls: remoteUrls,
+    }
+}
+
+function buildIssueBody(args, options = {}) {
+    const root = getProjectRoot(args)
+    const images = normalizeImages(args.images, root)
+    const sections = []
+    const styledBody = buildStyledIssueSections(args)
+
+    if (styledBody) sections.push(styledBody)
+
+    const labels = resolveIssueLabels(args, styledBody)
+    if (labels.length > 0) {
+        sections.push(
+            [
+                "## Suggested Labels",
+                "",
+                labels.map((label) => `\`${label}\``).join(", "),
+                "",
+                "> These labels are included in the GitHub API request. If they are not visible on the issue, the token/user likely does not have permission to apply labels.",
+            ].join("\n")
+        )
+    }
+
+    if (args.context) {
+        const context = typeof args.context === "string" ? args.context : JSON.stringify(args.context, null, 2)
+        sections.push(`## Catalyst/Project Context\n\n\`\`\`json\n${context}\n\`\`\``)
+    }
+
+    if (args.environment && resolveIssueTemplate(args, styledBody) !== "bug") {
+        const environment = typeof args.environment === "string" ? args.environment : JSON.stringify(args.environment, null, 2)
+        sections.push(`## Environment\n\n${environment}`)
+    }
+
+    if (args.duplicate_review_note && typeof args.duplicate_review_note === "string") {
+        sections.push(`## Duplicate Review\n\n${args.duplicate_review_note.trim()}`)
+    }
+
+    if (images.markdown) sections.push(images.markdown.trim())
+
+    const body = sections.filter(Boolean).join("\n\n").trim()
+    return {
+        body: options.enrich === false ? body : enrichBody(body),
+        images,
+    }
+}
+
 function enrichBody(body) {
-    const lines = [body.trim(), "", "---"]
+    const lines = [stripExistingFooter(body), "", "---"]
     if (_projectInfo) {
         if (_projectInfo.pkg && _projectInfo.pkg.name) {
             lines.push(`**Project:** \`${_projectInfo.pkg.name}\``)
@@ -140,275 +489,388 @@ function enrichBody(body) {
     return lines.join("\n")
 }
 
-/**
- * Extract short search keywords from a title + body.
- * Returns a URL-encoded query string suitable for the GitHub search API.
- */
 function extractKeywords(title, body) {
-    // Take top words from title (most signal), pad with body words if needed
     const stopWords = new Set([
-        "a", "an", "the", "is", "in", "on", "at", "to", "for", "of", "and",
-        "or", "but", "not", "with", "this", "that", "it", "be", "are", "was",
-        "can", "how", "do", "does", "i", "my", "me", "we", "our",
+        "a",
+        "an",
+        "the",
+        "is",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "and",
+        "or",
+        "but",
+        "not",
+        "with",
+        "this",
+        "that",
+        "can",
+        "how",
+        "does",
+        "issue",
+        "bug",
     ])
     const tokenise = (str) =>
-        str
+        String(str || "")
             .toLowerCase()
             .replace(/[^a-z0-9\s]/g, " ")
             .split(/\s+/)
-            .filter((w) => w.length > 2 && !stopWords.has(w))
+            .filter((word) => word.length > 2 && !stopWords.has(word))
 
     const titleWords = tokenise(title).slice(0, 5)
     const bodyWords = tokenise(body)
-        .filter((w) => !titleWords.includes(w))
+        .filter((word) => !titleWords.includes(word))
         .slice(0, 3)
 
-    return [...titleWords, ...bodyWords].join("+")
+    return [...titleWords, ...bodyWords].join(" ")
 }
 
-/**
- * Search for existing issues or discussions that might be duplicates.
- * Returns array of { number, title, url, state? } — max 5 results.
- *
- * Issues   → GitHub REST Search API  (GET /search/issues)
- * Discussions → GitHub GraphQL search
- */
-async function searchDuplicates(token, title, body, type) {
+async function searchDuplicates(token, title, body) {
     const keywords = extractKeywords(title, body)
     if (!keywords) return []
 
     try {
-        if (type === "discussion") {
-            const query = `
-                query SearchDiscussions($q: String!) {
-                    search(query: $q, type: DISCUSSION, first: 5) {
-                        nodes {
-                            ... on Discussion {
-                                number
-                                title
-                                url
-                            }
-                        }
-                    }
-                }
-            `
-            const searchQ = `repo:${GITHUB_OWNER}/${GITHUB_REPO} ${keywords.replace(/\+/g, " ")}`
-            const res = await graphql(token, query, { q: searchQ })
-            if (res.status === 200 && !res.body.errors) {
-                return (res.body.data?.search?.nodes || []).filter(Boolean)
-            }
-            return []
-        } else {
-            // Issues via REST Search API
-            const q = encodeURIComponent(
-                `repo:${GITHUB_OWNER}/${GITHUB_REPO} ${keywords.replace(/\+/g, " ")} in:title,body`
-            )
-            const res = await githubRequest(
-                "GET",
-                `/search/issues?q=${q}&type=issue&per_page=5`,
-                token
-            )
-            if (res.status === 200 && Array.isArray(res.body.items)) {
-                return res.body.items.slice(0, 5).map((i) => ({
-                    number: i.number,
-                    title: i.title,
-                    url: i.html_url,
-                    state: i.state,
-                }))
-            }
-            return []
+        const q = encodeURIComponent(`repo:${GITHUB_OWNER}/${GITHUB_REPO} ${keywords} in:title,body is:issue`)
+        const res = await githubRequest("GET", `/search/issues?q=${q}&per_page=5`, token)
+        if (res.status === 200 && Array.isArray(res.body.items)) {
+            return res.body.items.slice(0, 5).map((issue) => ({
+                number: issue.number,
+                title: issue.title,
+                url: issue.html_url,
+                state: issue.state,
+            }))
         }
     } catch {
-        // Duplicate search is best-effort — never fail the main flow
-        return []
+        // Duplicate detection is best-effort.
     }
+    return []
 }
 
-/**
- * Fetch the GitHub repository node ID (needed for createDiscussion mutation).
- */
-async function getRepositoryId(token) {
-    const query = `
-        query GetRepoId($owner: String!, $name: String!) {
-            repository(owner: $owner, name: $name) {
-                id
-            }
+async function addLabelsToIssue(token, issueNumber, labels) {
+    if (!Array.isArray(labels) || labels.length === 0) {
+        return { ok: true, labels: [] }
+    }
+
+    const res = await githubRequest(
+        "POST",
+        `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues/${issueNumber}/labels`,
+        token,
+        { labels }
+    )
+
+    if (res.status === 200 && Array.isArray(res.body)) {
+        return {
+            ok: true,
+            labels: res.body.map((label) => label.name),
         }
-    `
-    const res = await graphql(token, query, { owner: GITHUB_OWNER, name: GITHUB_REPO })
-    if (res.status !== 200 || res.body.errors) {
-        const err = res.body.errors ? res.body.errors[0].message : `HTTP ${res.status}`
-        throw new Error(`Failed to fetch repository ID: ${err}`)
     }
-    return res.body.data.repository.id
+
+    const apiMessage = res.body && res.body.message ? res.body.message : JSON.stringify(res.body)
+    return {
+        ok: false,
+        status: res.status,
+        error: `GitHub API returned HTTP ${res.status}: ${apiMessage}`,
+    }
 }
 
-/**
- * Fetch all available Discussion categories for the repo.
- * Returns array of { id, name, emoji }.
- */
-async function getDiscussionCategories(token) {
-    const query = `
-        query GetCategories($owner: String!, $name: String!) {
-            repository(owner: $owner, name: $name) {
-                discussionCategories(first: 25) {
-                    nodes {
-                        id
-                        name
-                        emoji
-                    }
+async function commentOnIssue(token, issueNumber, body) {
+    if (!body || typeof body !== "string" || !body.trim()) {
+        return { ok: true }
+    }
+
+    const res = await githubRequest(
+        "POST",
+        `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues/${issueNumber}/comments`,
+        token,
+        { body: body.trim() }
+    )
+
+    if (res.status === 201) {
+        return { ok: true, url: res.body.html_url }
+    }
+
+    const apiMessage = res.body && res.body.message ? res.body.message : JSON.stringify(res.body)
+    return {
+        ok: false,
+        status: res.status,
+        error: `GitHub API returned HTTP ${res.status}: ${apiMessage}`,
+    }
+}
+
+function handle_start_issue_creation(args = {}) {
+    const initialBody = args.problem || args._query || ""
+    const suggestedTemplate = resolveIssueTemplate({ ...args, title: args.problem || args._query || "", body: initialBody }, initialBody)
+    const suggestedLabels = resolveIssueLabels({ ...args, title: args.problem || args._query || "", body: initialBody }, initialBody)
+
+    return {
+        ok: true,
+        mode: "github_issue_agent",
+        repo: `${GITHUB_OWNER}/${GITHUB_REPO}`,
+        when_to_use: [
+            "Use this flow when the developer explicitly asks to create/raise/report/publish a GitHub issue for catalyst-core.",
+            "Use this flow when, during another task, the LLM identifies that the failure is likely caused by catalyst-core framework behavior. In that case, ask the developer whether they want to create a GitHub issue before gathering/publishing.",
+        ],
+        approval_gates: [
+            "Ask the developer whether they want to create a GitHub issue if the issue was inferred during another task.",
+            "Suggest the best template and labels; ask whether the developer accepts them or wants changes.",
+            "Search existing GitHub issues for duplicate candidates and show any matches to the developer before publishing.",
+            "If duplicate candidates exist, ask whether to cancel, update/comment on the existing issue manually, or continue because this is distinct.",
+            "Show the final rendered issue preview, including screenshots/attachments and labels, before publishing.",
+            "Call create_github_issue only after explicit developer approval.",
+        ],
+        next_steps: [
+            "Ask the developer for a concise issue title and problem statement if not already known.",
+            "Collect steps to reproduce, expected behavior, actual behavior, error logs, environment, what was tried, related issues, and screenshot/image paths or URLs if available.",
+            "Call gather_github_issue_context with the title/problem so the issue includes catalyst-core version, package scripts, git state, and relevant file snippets.",
+            "Call preview_github_feedback to select/render the issue template, suggested labels, project context, screenshots/attachments, and duplicate candidates.",
+            "Show duplicate candidates first when present. If one is the same issue, stop and suggest using the existing issue instead of creating a duplicate.",
+            "Show the preview to the developer and ask for approval or edits. If duplicates were shown and the developer still wants to publish, pass duplicate_review_confirmed:true to create_github_issue.",
+            "After approval and duplicate review, call create_github_issue. If it returns ok:false with duplicate_candidates, show them and do not generate a new issue. If it fails due to auth/network/API, use the markdown_path fallback for manual GitHub creation.",
+        ],
+        supported_labels: DEFAULT_LABELS,
+        label_guidance: LABEL_GUIDANCE,
+        supported_templates: ISSUE_TEMPLATES,
+        template_selection_rules: [
+            "Use Bug report + bug for broken behavior, ignored config, crashes, regressions, incorrect output, or failed commands.",
+            "Use Feature request / enhancement + enhancement for new APIs, CLI improvements, universal hook behavior, or framework ergonomics.",
+            "Use Documentation improvement + documentation for missing/incorrect docs, examples, guides, README, migration notes, or typos.",
+            "Use Dependency update + dependencies for package updates, lockfile updates, npm audit/security updates, or dependency version changes.",
+            "Use Question / clarification + question when implementation is not yet clear and maintainer input is needed.",
+            "Add good first issue only when the change is small and well-scoped; add help wanted when extra maintainer/community attention is needed.",
+            "Use duplicate, invalid, or wontfix only after triage establishes that state.",
+        ],
+        suggested_template: ISSUE_TEMPLATES[suggestedTemplate],
+        suggested_labels: suggestedLabels,
+        image_support:
+            "Hosted image URLs are embedded in the issue body. Local image files are listed in the body and copied into the markdown fallback for manual upload, because GitHub's public Issues API does not upload local binaries.",
+        duplicate_policy:
+            "The preview step performs a best-effort duplicate search. create_github_issue blocks publishing when matching issues are found unless duplicate_review_confirmed:true is provided after showing those candidates to the developer.",
+        manual_fallback:
+            "If GitHub auth, network, permission, or validation fails, call generate_issue_markdown or use the fallback returned by create_github_issue so the developer can raise the issue manually.",
+        initial_problem: args.problem || args._query || null,
+    }
+}
+
+function collectRelatedFiles(root, query, explicitFiles) {
+    const files = []
+    const candidates = Array.isArray(explicitFiles) ? explicitFiles : []
+    for (const file of candidates) {
+        if (typeof file !== "string") continue
+        const absolute = path.isAbsolute(file) ? file : path.join(root, file)
+        if (!absolute.startsWith(root)) continue
+        const content = safeReadText(absolute, 12000)
+        if (content) {
+            files.push({ path: path.relative(root, absolute), content })
+        }
+    }
+
+    if (files.length > 0 || !query) return files
+
+    const words = extractKeywords(query, "").split(/\s+/).filter(Boolean).slice(0, 5)
+    if (words.length === 0) return files
+
+    const srcDir = path.join(root, "src")
+    const matches = []
+    function walk(dir) {
+        let entries
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true })
+        } catch {
+            return
+        }
+        for (const entry of entries) {
+            if (entry.name === "node_modules" || entry.name === ".git") continue
+            const full = path.join(dir, entry.name)
+            if (entry.isDirectory()) {
+                walk(full)
+            } else if (/\.(js|jsx|ts|tsx|json|scss|css|md|mdx)$/.test(entry.name)) {
+                const content = safeReadText(full, 4000)
+                if (content && words.some((word) => content.toLowerCase().includes(word))) {
+                    matches.push({ path: path.relative(root, full), content })
                 }
             }
+            if (matches.length >= 5) return
         }
-    `
-    const res = await graphql(token, query, { owner: GITHUB_OWNER, name: GITHUB_REPO })
-    if (res.status !== 200 || res.body.errors) {
-        const err = res.body.errors ? res.body.errors[0].message : `HTTP ${res.status}`
-        throw new Error(`Failed to fetch discussion categories: ${err}`)
     }
-    return res.body.data.repository.discussionCategories.nodes
+    walk(srcDir)
+    return matches.slice(0, 5)
 }
 
-/**
- * Pick the best matching category from available ones.
- * Falls back to smart auto-detection based on body content.
- */
-function resolveCategory(categories, requestedName, body) {
-    if (requestedName) {
-        // Exact match first (case-insensitive)
-        const exact = categories.find((c) => c.name.toLowerCase() === requestedName.toLowerCase())
-        if (exact) return exact
+function handle_gather_github_issue_context(args = {}) {
+    const root = getProjectRoot(args)
+    const pkg = safeReadJson(path.join(root, "package.json"))
+    const configJson = safeReadJson(path.join(root, "config", "config.json"))
+    const branch = runGit(root, "git rev-parse --abbrev-ref HEAD")
+    const commit = runGit(root, "git rev-parse --short HEAD")
+    const status = runGit(root, "git status --short")
+    const nodeVersion = runGit(root, "node --version")
+    const npmVersion = runGit(root, "npm --version")
+    const relatedFiles = collectRelatedFiles(root, args.query || args.problem || args.title || "", args.files)
 
-        // Partial match
-        const partial = categories.find((c) =>
-            c.name.toLowerCase().includes(requestedName.toLowerCase())
-        )
-        if (partial) return partial
+    const dependencies = pkg ? { ...pkg.dependencies, ...pkg.devDependencies } : {}
+
+    return {
+        ok: true,
+        context: {
+            project_path: root,
+            package_name: pkg && pkg.name,
+            catalyst_core_declared_version: dependencies["catalyst-core"] || null,
+            catalyst_core_installed_version: _projectInfo && _projectInfo.installedVersion,
+            scripts: pkg && pkg.scripts ? pkg.scripts : {},
+            config: configJson
+                ? {
+                      NODE_SERVER_PORT: configJson.NODE_SERVER_PORT,
+                      WEBVIEW_CONFIG: configJson.WEBVIEW_CONFIG,
+                  }
+                : null,
+            git: { branch, commit, dirty: Boolean(status), status },
+            runtime: { node: nodeVersion, npm: npmVersion },
+            related_files: relatedFiles,
+        },
+        instructions:
+            "Use this context to enrich the issue body. Include only relevant file snippets; do not include secrets or unrelated config.",
     }
-
-    // Auto-detect: if body has a question mark → Q&A, else Ideas or General
-    const isQuestion = body.includes("?")
-    const isFeatureRequest = /\b(feature|proposal|suggest|idea|would\s+be\s+nice|enhancement)\b/i.test(body)
-
-    if (isQuestion) {
-        const qa = categories.find((c) => /q.?a|question/i.test(c.name))
-        if (qa) return qa
-    }
-    if (isFeatureRequest) {
-        const ideas = categories.find((c) => /idea|feature|suggest/i.test(c.name))
-        if (ideas) return ideas
-    }
-
-    // Final fallback: General
-    const general = categories.find((c) => /general/i.test(c.name))
-    return general || categories[0]
 }
 
-// ── Tool: preview_github_feedback ────────────────────────────────────────────
-
-/**
- * Handle preview_github_feedback tool call.
- *
- * Drafts the enriched content, searches for potential duplicates,
- * and returns everything for developer review — WITHOUT publishing anything.
- * The developer then calls create_github_issue or create_github_discussion to confirm.
- *
- * Args:
- *   title    {string}   required — proposed title
- *   body     {string}   required — proposed body
- *   type     {string}   required — "issue" | "discussion"
- *   labels   {string[]} optional — for issues
- *   category {string}  optional — for discussions
- */
-async function handle_preview_github_feedback(args) {
-    const { title, body, type, labels, category } = args
+async function handle_preview_github_feedback(args = {}) {
+    const { title, type = "issue" } = args
 
     if (!title || typeof title !== "string" || title.trim() === "") {
         return { ok: false, error: "title is required." }
     }
-    if (!body || typeof body !== "string" || body.trim() === "") {
-        return { ok: false, error: "body is required." }
-    }
-    if (!type || ![ "issue", "discussion" ].includes(type)) {
-        return { ok: false, error: "type must be 'issue' or 'discussion'." }
+    if (type !== "issue") {
+        return { ok: false, error: "Only GitHub issues are supported by this MCP tool." }
     }
 
-    // Build enriched body (always works, no token needed)
-    const enrichedBody = enrichBody(body)
+    const built = buildIssueBody(args)
+    if (!built.body || built.body.trim() === "") {
+        return { ok: false, error: "body or structured issue fields are required." }
+    }
 
-    // Search duplicates (best-effort — requires token but won't fail without it)
     let duplicates = []
-    let tokenSource = null
+    let tokenSource = "none"
     const tokenResult = getToken()
     if (tokenResult.ok) {
         tokenSource = tokenResult.source
-        duplicates = await searchDuplicates(tokenResult.token, title, body, type)
+        duplicates = await searchDuplicates(tokenResult.token, title, built.body)
     }
-
-    // Build the preview object — exactly what will be published
-    const preview = {
-        type,
-        title: title.trim(),
-        body: enrichedBody,
-        ...(type === "issue" && Array.isArray(labels) && labels.length > 0 ? { labels } : {}),
-        ...(type === "discussion" && category ? { category } : {}),
-    }
-
-    const hasDuplicates = duplicates.length > 0
-    const nextStep =
-        type === "issue"
-            ? `Call create_github_issue with title and body above to publish.`
-            : `Call create_github_discussion with title and body above to publish.`
 
     return {
         ok: true,
-        preview,
+        preview: {
+            type: "issue",
+            repo: `${GITHUB_OWNER}/${GITHUB_REPO}`,
+            title: title.trim(),
+            body: built.body,
+            labels: resolveIssueLabels(args, built.body),
+            suggested_template: ISSUE_TEMPLATES[resolveIssueTemplate(args, built.body)],
+            possible_labels: DEFAULT_LABELS,
+            label_guidance: LABEL_GUIDANCE,
+            images: built.images,
+        },
         duplicates,
-        token_source: tokenSource || "none — duplicate search skipped",
-        instructions: [
-            hasDuplicates
-                ? `⚠️  Found ${duplicates.length} similar existing ${type}(s) listed above. Show them to the developer and ask if they still want to proceed.`
-                : `✅ No duplicates found.`,
-            `Show the preview to the developer for approval, then ${nextStep}`,
-        ].join(" "),
+        duplicate_review: {
+            required_before_publish: duplicates.length > 0,
+            status: duplicates.length > 0 ? "needs_user_review" : "no_duplicate_candidates_found",
+            candidates: duplicates,
+            publish_override_field:
+                duplicates.length > 0
+                    ? "Pass duplicate_review_confirmed:true to create_github_issue only after the developer confirms this is not a duplicate."
+                    : null,
+        },
+        token_source: tokenSource,
+        instructions:
+            duplicates.length > 0
+                ? "Show the suggested template, labels, full issue body, attachments, and duplicate candidates to the developer. Ask whether to cancel/use an existing issue, edit, or publish because this is distinct. Call create_github_issue only after explicit approval, and include duplicate_review_confirmed:true if the developer chooses to publish."
+                : "Show the suggested template, labels, full issue body, and attachments to the developer. Ask whether to edit, cancel, or publish. Call create_github_issue only after explicit approval.",
     }
 }
 
-// ── Tool: create_github_issue ─────────────────────────────────────────────────
+function handle_generate_issue_markdown(args = {}) {
+    const { title } = args
+    if (!title || typeof title !== "string" || title.trim() === "") {
+        return { ok: false, error: "title is required." }
+    }
 
-/**
- * Handle create_github_issue tool call.
- *
- * Args:
- *   title   {string}   required — short descriptive issue title
- *   body    {string}   required — full description
- *   labels  {string[]} optional — label names (must already exist on the repo)
- */
-async function handle_create_github_issue(args) {
-    const { title, body, labels } = args
+    const root = getProjectRoot(args)
+    const built = buildIssueBody(args, { enrich: true })
+    const labels = resolveIssueLabels(args, built.body)
+    const dir = ensureFallbackDir(root)
+    const filePath = path.join(dir, `${new Date().toISOString().replace(/[:.]/g, "-")}-${slugify(title)}.md`)
 
+    const markdown = [
+        `# ${title.trim()}`,
+        "",
+        labels.length ? `Labels: ${labels.join(", ")}` : "Labels: none",
+        "",
+        `Repository: https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/issues/new`,
+        "",
+        "Copy the title, labels, and body below into GitHub. Upload any local image files listed under Attachments manually.",
+        "",
+        "## Body",
+        "",
+        built.body,
+        "",
+    ].join("\n")
+
+    fs.writeFileSync(filePath, markdown, "utf8")
+
+    return {
+        ok: true,
+        markdown_path: filePath,
+        title: title.trim(),
+        labels,
+        local_images: built.images.local_files,
+        github_new_issue_url: `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/issues/new`,
+    }
+}
+
+async function handle_create_github_issue(args = {}) {
+    const { title } = args
     if (!title || typeof title !== "string" || title.trim() === "") {
         return { ok: false, error: "title is required and must be a non-empty string." }
     }
-    if (!body || typeof body !== "string" || body.trim() === "") {
-        return { ok: false, error: "body is required and must be a non-empty string." }
+
+    const built = buildIssueBody(args)
+    if (!built.body || built.body.trim() === "") {
+        return { ok: false, error: "body or structured issue fields are required." }
     }
 
     const tokenResult = getToken()
     if (!tokenResult.ok) {
-        return { ok: false, error: tokenResult.error }
+        const fallback = handle_generate_issue_markdown(args)
+        return {
+            ok: false,
+            error: tokenResult.error,
+            fallback: fallback.ok ? fallback : null,
+        }
     }
 
-    const enrichedBody = enrichBody(body)
+    const labels = resolveIssueLabels(args, built.body)
     const payload = {
         title: title.trim(),
-        body: enrichedBody,
-    }
-    if (Array.isArray(labels) && labels.length > 0) {
-        payload.labels = labels.filter((l) => typeof l === "string" && l.trim())
+        body: built.body,
+        labels,
     }
 
     try {
+        const duplicates = await searchDuplicates(tokenResult.token, title, built.body)
+        if (duplicates.length > 0 && args.duplicate_review_confirmed !== true) {
+            return {
+                ok: false,
+                blocked: true,
+                error:
+                    "Possible duplicate GitHub issues were found. Show these candidates to the developer and publish only if they confirm this report is distinct.",
+                duplicate_candidates: duplicates,
+                next_action:
+                    "If the developer confirms this is not a duplicate, call create_github_issue again with duplicate_review_confirmed:true and optionally duplicate_review_note.",
+            }
+        }
+
         const res = await githubRequest(
             "POST",
             `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues`,
@@ -417,186 +879,77 @@ async function handle_create_github_issue(args) {
         )
 
         if (res.status === 201) {
-            return {
-                ok: true,
-                message: `✅ Issue #${res.body.number} created successfully!`,
-                number: res.body.number,
-                title: res.body.title,
-                url: res.body.html_url,
-                labels: (res.body.labels || []).map((l) => l.name),
-                state: res.body.state,
-            }
-        }
+            const returnedLabels = (res.body.labels || []).map((label) => label.name)
+            const missingLabels = labels.filter((label) => !returnedLabels.includes(label))
+            let finalLabels = returnedLabels
+            let labelWarning = null
 
-        // Handle common errors with actionable messages
-        if (res.status === 401) {
-            return {
-                ok: false,
-                error:
-                    "GitHub authentication failed (401). Your GITHUB_TOKEN is invalid or expired.\n" +
-                    "Generate a new token at: https://github.com/settings/tokens/new (scope: repo)",
-            }
-        }
-        if (res.status === 403) {
-            return {
-                ok: false,
-                error:
-                    "GitHub permission denied (403). Your token may not have the `repo` scope, " +
-                    "or issues may be disabled on the repository.",
-            }
-        }
-        if (res.status === 404) {
-            return {
-                ok: false,
-                error: `Repository ${GITHUB_OWNER}/${GITHUB_REPO} not found or your token does not have access to it.`,
-            }
-        }
-        if (res.status === 422) {
-            const msg = res.body.errors ? res.body.errors.map((e) => e.message).join(", ") : res.body.message
-            return {
-                ok: false,
-                error: `Validation error (422): ${msg}. Check that all label names exist on the repo.`,
-            }
-        }
-
-        return {
-            ok: false,
-            error: `Unexpected GitHub API response: HTTP ${res.status} — ${JSON.stringify(res.body)}`,
-        }
-    } catch (err) {
-        return { ok: false, error: `Network error while calling GitHub API: ${err.message}` }
-    }
-}
-
-// ── Tool: create_github_discussion ───────────────────────────────────────────
-
-/**
- * Handle create_github_discussion tool call.
- *
- * Args:
- *   title    {string} required — discussion title
- *   body     {string} required — discussion body
- *   category {string} optional — category name ("Q&A", "Ideas", "General", etc.)
- */
-async function handle_create_github_discussion(args) {
-    const { title, body, category } = args
-
-    if (!title || typeof title !== "string" || title.trim() === "") {
-        return { ok: false, error: "title is required and must be a non-empty string." }
-    }
-    if (!body || typeof body !== "string" || body.trim() === "") {
-        return { ok: false, error: "body is required and must be a non-empty string." }
-    }
-
-    const tokenResult = getToken()
-    if (!tokenResult.ok) {
-        return { ok: false, error: tokenResult.error }
-    }
-
-    const token = tokenResult.token
-
-    try {
-        // Fetch repo ID and categories in parallel
-        const [repositoryId, categories] = await Promise.all([
-            getRepositoryId(token),
-            getDiscussionCategories(token),
-        ])
-
-        if (!categories || categories.length === 0) {
-            return {
-                ok: false,
-                error:
-                    "No discussion categories found on the repository. " +
-                    "Discussions may not be enabled on catalyst-core.",
-            }
-        }
-
-        const selectedCategory = resolveCategory(categories, category, body)
-        if (!selectedCategory) {
-            return {
-                ok: false,
-                error: `Could not find a matching discussion category. Available: ${categories.map((c) => c.name).join(", ")}`,
-            }
-        }
-
-        const enrichedBody = enrichBody(body)
-
-        const mutation = `
-            mutation CreateDiscussion($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
-                createDiscussion(input: {
-                    repositoryId: $repositoryId,
-                    categoryId: $categoryId,
-                    title: $title,
-                    body: $body
-                }) {
-                    discussion {
-                        number
-                        title
-                        url
-                        category {
-                            name
-                        }
+            if (missingLabels.length > 0) {
+                const labelResult = await addLabelsToIssue(tokenResult.token, res.body.number, missingLabels)
+                if (labelResult.ok) {
+                    finalLabels = labelResult.labels
+                } else {
+                    labelWarning =
+                        `Issue was created, but GitHub did not apply label(s): ${missingLabels.join(", ")}. ` +
+                        `This usually means the token/user can create issues but does not have triage/write permission to manage labels. ${labelResult.error}`
+                    const commentResult = await commentOnIssue(
+                        tokenResult.token,
+                        res.body.number,
+                        [
+                            "Catalyst MCP could not apply the requested GitHub label(s).",
+                            "",
+                            `Requested labels: ${missingLabels.map((label) => `\`${label}\``).join(", ")}`,
+                            "",
+                            "Please add these labels manually if appropriate. This usually means the token/user can create issues but does not have triage/write permission to manage labels.",
+                        ].join("\n")
+                    )
+                    if (!commentResult.ok) {
+                        labelWarning += ` MCP also could not add a label-warning comment. ${commentResult.error}`
                     }
                 }
             }
-        `
 
-        const res = await graphql(token, mutation, {
-            repositoryId,
-            categoryId: selectedCategory.id,
-            title: title.trim(),
-            body: enrichedBody,
-        })
-
-        if (res.status === 200 && !res.body.errors) {
-            const discussion = res.body.data.createDiscussion.discussion
             return {
                 ok: true,
-                message: `✅ Discussion #${discussion.number} created successfully!`,
-                number: discussion.number,
-                title: discussion.title,
-                url: discussion.url,
-                category: discussion.category.name,
+                message: labelWarning
+                    ? `Issue #${res.body.number} created successfully, but labels need manual review.`
+                    : `Issue #${res.body.number} created successfully.`,
+                number: res.body.number,
+                title: res.body.title,
+                url: res.body.html_url,
+                labels: finalLabels,
+                requested_labels: labels,
+                label_warning: labelWarning,
+                state: res.body.state,
+                token_source: tokenResult.source,
+                local_images_requiring_manual_upload: built.images.local_files.filter((image) => image.exists),
             }
         }
 
-        // Handle GraphQL-level errors
-        if (res.body.errors && res.body.errors.length > 0) {
-            const errMsg = res.body.errors[0].message
-            if (/not authorized|forbidden/i.test(errMsg)) {
-                return {
-                    ok: false,
-                    error:
-                        "GitHub authorization error: Your token may be missing the `write:discussion` scope.\n" +
-                        "Generate a new token at: https://github.com/settings/tokens/new",
-                }
-            }
-            return { ok: false, error: `GitHub GraphQL error: ${errMsg}` }
-        }
-
-        if (res.status === 401) {
-            return {
-                ok: false,
-                error:
-                    "GitHub authentication failed (401). Your GITHUB_TOKEN is invalid or expired.\n" +
-                    "Generate a new token at: https://github.com/settings/tokens/new",
-            }
-        }
-
+        const apiMessage = res.body && res.body.message ? res.body.message : JSON.stringify(res.body)
+        const fallback = handle_generate_issue_markdown(args)
         return {
             ok: false,
-            error: `Unexpected GitHub API response: HTTP ${res.status} — ${JSON.stringify(res.body)}`,
+            error: `GitHub API returned HTTP ${res.status}: ${apiMessage}`,
+            fallback: fallback.ok ? fallback : null,
         }
     } catch (err) {
-        return { ok: false, error: `Network error while calling GitHub API: ${err.message}` }
+        const fallback = handle_generate_issue_markdown(args)
+        return {
+            ok: false,
+            error: `Network error while calling GitHub API: ${err.message}`,
+            fallback: fallback.ok ? fallback : null,
+        }
     }
 }
 
-// ── Exports ───────────────────────────────────────────────────────────────────
-
 module.exports = {
     init,
+    handle_start_issue_creation,
+    handle_start_github_issue_flow: handle_start_issue_creation,
+    handle_gather_github_issue_context,
     handle_preview_github_feedback,
+    handle_preview_github_issue: handle_preview_github_feedback,
     handle_create_github_issue,
-    handle_create_github_discussion,
+    handle_generate_issue_markdown,
 }

--- a/packages/catalyst-core/mcp_v2/tools/github.js
+++ b/packages/catalyst-core/mcp_v2/tools/github.js
@@ -1,0 +1,602 @@
+"use strict"
+
+/**
+ * tools/github.js — Catalyst MCP v2
+ *
+ * Exposes three tools:
+ *   preview_github_feedback   → drafts content, searches duplicates, returns preview for approval
+ *   create_github_issue       → GitHub REST API  (POST /repos/{owner}/{repo}/issues)
+ *   create_github_discussion  → GitHub GraphQL API (createDiscussion mutation)
+ *
+ * Authentication (in priority order):
+ *   1. GITHUB_TOKEN environment variable (Personal Access Token)
+ *   2. GitHub CLI session  — `gh auth login` (token read via `gh auth token`)
+ *
+ *   Required scopes:
+ *     - repo              (for creating issues + searching)
+ *     - write:discussion  (for creating discussions)
+ *
+ * Zero external dependencies — uses Node's built-in `https` and `child_process` modules only.
+ */
+
+const https = require("https")
+const { execSync } = require("child_process")
+
+// ── Module state ──────────────────────────────────────────────────────────────
+
+let _projectInfo = null
+
+// Parsed from catalyst-core package.json "repository.url"
+const GITHUB_OWNER = "tata1mg"
+const GITHUB_REPO = "catalyst-core"
+
+function init(projectInfo) {
+    _projectInfo = projectInfo
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Read a GitHub token in priority order:
+ *   1. GITHUB_TOKEN env var
+ *   2. Active `gh` CLI session (gh auth token)
+ * Returns { ok, token, source } or { ok: false, error }.
+ */
+function getToken() {
+    // 1. Explicit env var
+    const envToken = process.env.GITHUB_TOKEN
+    if (envToken && envToken.trim()) {
+        return { ok: true, token: envToken.trim(), source: "env" }
+    }
+
+    // 2. GitHub CLI session — no credentials stored by Catalyst
+    try {
+        const ghToken = execSync("gh auth token", {
+            encoding: "utf8",
+            timeout: 4000,
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim()
+        if (ghToken) return { ok: true, token: ghToken, source: "gh-cli" }
+    } catch {
+        // gh not installed or not logged in — fall through to error
+    }
+
+    return {
+        ok: false,
+        error:
+            "No GitHub credentials found. Provide one of:\n\n" +
+            "Option A — GitHub CLI (recommended, no config needed):\n" +
+            "  gh auth login\n" +
+            "  Required scopes: repo, write:discussion\n\n" +
+            "Option B — Environment variable:\n" +
+            "  Create a PAT at https://github.com/settings/tokens/new\n" +
+            '  Claude Desktop → claude_desktop_config.json → "env": { "GITHUB_TOKEN": "ghp_xxx..." }\n' +
+            "  Cursor → .cursor/mcp.json → \"env\": { \"GITHUB_TOKEN\": \"ghp_xxx...\" }",
+    }
+}
+
+/**
+ * Thin wrapper around Node's https for GitHub API calls.
+ * Returns parsed JSON body and status code.
+ */
+function githubRequest(method, urlPath, token, body) {
+    return new Promise((resolve, reject) => {
+        const payload = body ? JSON.stringify(body) : null
+        const options = {
+            hostname: "api.github.com",
+            path: urlPath,
+            method,
+            headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: "application/vnd.github+json",
+                "User-Agent": "catalyst-mcp/2.0",
+                "X-GitHub-Api-Version": "2022-11-28",
+                ...(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {}),
+            },
+        }
+
+        const req = https.request(options, (res) => {
+            let data = ""
+            res.on("data", (chunk) => (data += chunk))
+            res.on("end", () => {
+                try {
+                    resolve({ status: res.statusCode, body: JSON.parse(data) })
+                } catch {
+                    resolve({ status: res.statusCode, body: data })
+                }
+            })
+        })
+
+        req.on("error", reject)
+        if (payload) req.write(payload)
+        req.end()
+    })
+}
+
+/**
+ * Execute a GitHub GraphQL query/mutation.
+ */
+function graphql(token, query, variables = {}) {
+    return githubRequest("POST", "/graphql", token, { query, variables })
+}
+
+/**
+ * Append a standard footer to the body with project context.
+ * Makes triage easy for the catalyst-core team.
+ */
+function enrichBody(body) {
+    const lines = [body.trim(), "", "---"]
+    if (_projectInfo) {
+        if (_projectInfo.pkg && _projectInfo.pkg.name) {
+            lines.push(`**Project:** \`${_projectInfo.pkg.name}\``)
+        }
+        const version = _projectInfo.installedVersion || _projectInfo.catalystVersion || "unknown"
+        lines.push(`**catalyst-core version:** \`${version}\``)
+        if (_projectInfo.dir) {
+            lines.push(`**Project path:** \`${_projectInfo.dir}\``)
+        }
+    }
+    lines.push("**Reported via:** Catalyst MCP v2")
+    return lines.join("\n")
+}
+
+/**
+ * Extract short search keywords from a title + body.
+ * Returns a URL-encoded query string suitable for the GitHub search API.
+ */
+function extractKeywords(title, body) {
+    // Take top words from title (most signal), pad with body words if needed
+    const stopWords = new Set([
+        "a", "an", "the", "is", "in", "on", "at", "to", "for", "of", "and",
+        "or", "but", "not", "with", "this", "that", "it", "be", "are", "was",
+        "can", "how", "do", "does", "i", "my", "me", "we", "our",
+    ])
+    const tokenise = (str) =>
+        str
+            .toLowerCase()
+            .replace(/[^a-z0-9\s]/g, " ")
+            .split(/\s+/)
+            .filter((w) => w.length > 2 && !stopWords.has(w))
+
+    const titleWords = tokenise(title).slice(0, 5)
+    const bodyWords = tokenise(body)
+        .filter((w) => !titleWords.includes(w))
+        .slice(0, 3)
+
+    return [...titleWords, ...bodyWords].join("+")
+}
+
+/**
+ * Search for existing issues or discussions that might be duplicates.
+ * Returns array of { number, title, url, state? } — max 5 results.
+ *
+ * Issues   → GitHub REST Search API  (GET /search/issues)
+ * Discussions → GitHub GraphQL search
+ */
+async function searchDuplicates(token, title, body, type) {
+    const keywords = extractKeywords(title, body)
+    if (!keywords) return []
+
+    try {
+        if (type === "discussion") {
+            const query = `
+                query SearchDiscussions($q: String!) {
+                    search(query: $q, type: DISCUSSION, first: 5) {
+                        nodes {
+                            ... on Discussion {
+                                number
+                                title
+                                url
+                            }
+                        }
+                    }
+                }
+            `
+            const searchQ = `repo:${GITHUB_OWNER}/${GITHUB_REPO} ${keywords.replace(/\+/g, " ")}`
+            const res = await graphql(token, query, { q: searchQ })
+            if (res.status === 200 && !res.body.errors) {
+                return (res.body.data?.search?.nodes || []).filter(Boolean)
+            }
+            return []
+        } else {
+            // Issues via REST Search API
+            const q = encodeURIComponent(
+                `repo:${GITHUB_OWNER}/${GITHUB_REPO} ${keywords.replace(/\+/g, " ")} in:title,body`
+            )
+            const res = await githubRequest(
+                "GET",
+                `/search/issues?q=${q}&type=issue&per_page=5`,
+                token
+            )
+            if (res.status === 200 && Array.isArray(res.body.items)) {
+                return res.body.items.slice(0, 5).map((i) => ({
+                    number: i.number,
+                    title: i.title,
+                    url: i.html_url,
+                    state: i.state,
+                }))
+            }
+            return []
+        }
+    } catch {
+        // Duplicate search is best-effort — never fail the main flow
+        return []
+    }
+}
+
+/**
+ * Fetch the GitHub repository node ID (needed for createDiscussion mutation).
+ */
+async function getRepositoryId(token) {
+    const query = `
+        query GetRepoId($owner: String!, $name: String!) {
+            repository(owner: $owner, name: $name) {
+                id
+            }
+        }
+    `
+    const res = await graphql(token, query, { owner: GITHUB_OWNER, name: GITHUB_REPO })
+    if (res.status !== 200 || res.body.errors) {
+        const err = res.body.errors ? res.body.errors[0].message : `HTTP ${res.status}`
+        throw new Error(`Failed to fetch repository ID: ${err}`)
+    }
+    return res.body.data.repository.id
+}
+
+/**
+ * Fetch all available Discussion categories for the repo.
+ * Returns array of { id, name, emoji }.
+ */
+async function getDiscussionCategories(token) {
+    const query = `
+        query GetCategories($owner: String!, $name: String!) {
+            repository(owner: $owner, name: $name) {
+                discussionCategories(first: 25) {
+                    nodes {
+                        id
+                        name
+                        emoji
+                    }
+                }
+            }
+        }
+    `
+    const res = await graphql(token, query, { owner: GITHUB_OWNER, name: GITHUB_REPO })
+    if (res.status !== 200 || res.body.errors) {
+        const err = res.body.errors ? res.body.errors[0].message : `HTTP ${res.status}`
+        throw new Error(`Failed to fetch discussion categories: ${err}`)
+    }
+    return res.body.data.repository.discussionCategories.nodes
+}
+
+/**
+ * Pick the best matching category from available ones.
+ * Falls back to smart auto-detection based on body content.
+ */
+function resolveCategory(categories, requestedName, body) {
+    if (requestedName) {
+        // Exact match first (case-insensitive)
+        const exact = categories.find((c) => c.name.toLowerCase() === requestedName.toLowerCase())
+        if (exact) return exact
+
+        // Partial match
+        const partial = categories.find((c) =>
+            c.name.toLowerCase().includes(requestedName.toLowerCase())
+        )
+        if (partial) return partial
+    }
+
+    // Auto-detect: if body has a question mark → Q&A, else Ideas or General
+    const isQuestion = body.includes("?")
+    const isFeatureRequest = /\b(feature|proposal|suggest|idea|would\s+be\s+nice|enhancement)\b/i.test(body)
+
+    if (isQuestion) {
+        const qa = categories.find((c) => /q.?a|question/i.test(c.name))
+        if (qa) return qa
+    }
+    if (isFeatureRequest) {
+        const ideas = categories.find((c) => /idea|feature|suggest/i.test(c.name))
+        if (ideas) return ideas
+    }
+
+    // Final fallback: General
+    const general = categories.find((c) => /general/i.test(c.name))
+    return general || categories[0]
+}
+
+// ── Tool: preview_github_feedback ────────────────────────────────────────────
+
+/**
+ * Handle preview_github_feedback tool call.
+ *
+ * Drafts the enriched content, searches for potential duplicates,
+ * and returns everything for developer review — WITHOUT publishing anything.
+ * The developer then calls create_github_issue or create_github_discussion to confirm.
+ *
+ * Args:
+ *   title    {string}   required — proposed title
+ *   body     {string}   required — proposed body
+ *   type     {string}   required — "issue" | "discussion"
+ *   labels   {string[]} optional — for issues
+ *   category {string}  optional — for discussions
+ */
+async function handle_preview_github_feedback(args) {
+    const { title, body, type, labels, category } = args
+
+    if (!title || typeof title !== "string" || title.trim() === "") {
+        return { ok: false, error: "title is required." }
+    }
+    if (!body || typeof body !== "string" || body.trim() === "") {
+        return { ok: false, error: "body is required." }
+    }
+    if (!type || ![ "issue", "discussion" ].includes(type)) {
+        return { ok: false, error: "type must be 'issue' or 'discussion'." }
+    }
+
+    // Build enriched body (always works, no token needed)
+    const enrichedBody = enrichBody(body)
+
+    // Search duplicates (best-effort — requires token but won't fail without it)
+    let duplicates = []
+    let tokenSource = null
+    const tokenResult = getToken()
+    if (tokenResult.ok) {
+        tokenSource = tokenResult.source
+        duplicates = await searchDuplicates(tokenResult.token, title, body, type)
+    }
+
+    // Build the preview object — exactly what will be published
+    const preview = {
+        type,
+        title: title.trim(),
+        body: enrichedBody,
+        ...(type === "issue" && Array.isArray(labels) && labels.length > 0 ? { labels } : {}),
+        ...(type === "discussion" && category ? { category } : {}),
+    }
+
+    const hasDuplicates = duplicates.length > 0
+    const nextStep =
+        type === "issue"
+            ? `Call create_github_issue with title and body above to publish.`
+            : `Call create_github_discussion with title and body above to publish.`
+
+    return {
+        ok: true,
+        preview,
+        duplicates,
+        token_source: tokenSource || "none — duplicate search skipped",
+        instructions: [
+            hasDuplicates
+                ? `⚠️  Found ${duplicates.length} similar existing ${type}(s) listed above. Show them to the developer and ask if they still want to proceed.`
+                : `✅ No duplicates found.`,
+            `Show the preview to the developer for approval, then ${nextStep}`,
+        ].join(" "),
+    }
+}
+
+// ── Tool: create_github_issue ─────────────────────────────────────────────────
+
+/**
+ * Handle create_github_issue tool call.
+ *
+ * Args:
+ *   title   {string}   required — short descriptive issue title
+ *   body    {string}   required — full description
+ *   labels  {string[]} optional — label names (must already exist on the repo)
+ */
+async function handle_create_github_issue(args) {
+    const { title, body, labels } = args
+
+    if (!title || typeof title !== "string" || title.trim() === "") {
+        return { ok: false, error: "title is required and must be a non-empty string." }
+    }
+    if (!body || typeof body !== "string" || body.trim() === "") {
+        return { ok: false, error: "body is required and must be a non-empty string." }
+    }
+
+    const tokenResult = getToken()
+    if (!tokenResult.ok) {
+        return { ok: false, error: tokenResult.error }
+    }
+
+    const enrichedBody = enrichBody(body)
+    const payload = {
+        title: title.trim(),
+        body: enrichedBody,
+    }
+    if (Array.isArray(labels) && labels.length > 0) {
+        payload.labels = labels.filter((l) => typeof l === "string" && l.trim())
+    }
+
+    try {
+        const res = await githubRequest(
+            "POST",
+            `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues`,
+            tokenResult.token,
+            payload
+        )
+
+        if (res.status === 201) {
+            return {
+                ok: true,
+                message: `✅ Issue #${res.body.number} created successfully!`,
+                number: res.body.number,
+                title: res.body.title,
+                url: res.body.html_url,
+                labels: (res.body.labels || []).map((l) => l.name),
+                state: res.body.state,
+            }
+        }
+
+        // Handle common errors with actionable messages
+        if (res.status === 401) {
+            return {
+                ok: false,
+                error:
+                    "GitHub authentication failed (401). Your GITHUB_TOKEN is invalid or expired.\n" +
+                    "Generate a new token at: https://github.com/settings/tokens/new (scope: repo)",
+            }
+        }
+        if (res.status === 403) {
+            return {
+                ok: false,
+                error:
+                    "GitHub permission denied (403). Your token may not have the `repo` scope, " +
+                    "or issues may be disabled on the repository.",
+            }
+        }
+        if (res.status === 404) {
+            return {
+                ok: false,
+                error: `Repository ${GITHUB_OWNER}/${GITHUB_REPO} not found or your token does not have access to it.`,
+            }
+        }
+        if (res.status === 422) {
+            const msg = res.body.errors ? res.body.errors.map((e) => e.message).join(", ") : res.body.message
+            return {
+                ok: false,
+                error: `Validation error (422): ${msg}. Check that all label names exist on the repo.`,
+            }
+        }
+
+        return {
+            ok: false,
+            error: `Unexpected GitHub API response: HTTP ${res.status} — ${JSON.stringify(res.body)}`,
+        }
+    } catch (err) {
+        return { ok: false, error: `Network error while calling GitHub API: ${err.message}` }
+    }
+}
+
+// ── Tool: create_github_discussion ───────────────────────────────────────────
+
+/**
+ * Handle create_github_discussion tool call.
+ *
+ * Args:
+ *   title    {string} required — discussion title
+ *   body     {string} required — discussion body
+ *   category {string} optional — category name ("Q&A", "Ideas", "General", etc.)
+ */
+async function handle_create_github_discussion(args) {
+    const { title, body, category } = args
+
+    if (!title || typeof title !== "string" || title.trim() === "") {
+        return { ok: false, error: "title is required and must be a non-empty string." }
+    }
+    if (!body || typeof body !== "string" || body.trim() === "") {
+        return { ok: false, error: "body is required and must be a non-empty string." }
+    }
+
+    const tokenResult = getToken()
+    if (!tokenResult.ok) {
+        return { ok: false, error: tokenResult.error }
+    }
+
+    const token = tokenResult.token
+
+    try {
+        // Fetch repo ID and categories in parallel
+        const [repositoryId, categories] = await Promise.all([
+            getRepositoryId(token),
+            getDiscussionCategories(token),
+        ])
+
+        if (!categories || categories.length === 0) {
+            return {
+                ok: false,
+                error:
+                    "No discussion categories found on the repository. " +
+                    "Discussions may not be enabled on catalyst-core.",
+            }
+        }
+
+        const selectedCategory = resolveCategory(categories, category, body)
+        if (!selectedCategory) {
+            return {
+                ok: false,
+                error: `Could not find a matching discussion category. Available: ${categories.map((c) => c.name).join(", ")}`,
+            }
+        }
+
+        const enrichedBody = enrichBody(body)
+
+        const mutation = `
+            mutation CreateDiscussion($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+                createDiscussion(input: {
+                    repositoryId: $repositoryId,
+                    categoryId: $categoryId,
+                    title: $title,
+                    body: $body
+                }) {
+                    discussion {
+                        number
+                        title
+                        url
+                        category {
+                            name
+                        }
+                    }
+                }
+            }
+        `
+
+        const res = await graphql(token, mutation, {
+            repositoryId,
+            categoryId: selectedCategory.id,
+            title: title.trim(),
+            body: enrichedBody,
+        })
+
+        if (res.status === 200 && !res.body.errors) {
+            const discussion = res.body.data.createDiscussion.discussion
+            return {
+                ok: true,
+                message: `✅ Discussion #${discussion.number} created successfully!`,
+                number: discussion.number,
+                title: discussion.title,
+                url: discussion.url,
+                category: discussion.category.name,
+            }
+        }
+
+        // Handle GraphQL-level errors
+        if (res.body.errors && res.body.errors.length > 0) {
+            const errMsg = res.body.errors[0].message
+            if (/not authorized|forbidden/i.test(errMsg)) {
+                return {
+                    ok: false,
+                    error:
+                        "GitHub authorization error: Your token may be missing the `write:discussion` scope.\n" +
+                        "Generate a new token at: https://github.com/settings/tokens/new",
+                }
+            }
+            return { ok: false, error: `GitHub GraphQL error: ${errMsg}` }
+        }
+
+        if (res.status === 401) {
+            return {
+                ok: false,
+                error:
+                    "GitHub authentication failed (401). Your GITHUB_TOKEN is invalid or expired.\n" +
+                    "Generate a new token at: https://github.com/settings/tokens/new",
+            }
+        }
+
+        return {
+            ok: false,
+            error: `Unexpected GitHub API response: HTTP ${res.status} — ${JSON.stringify(res.body)}`,
+        }
+    } catch (err) {
+        return { ok: false, error: `Network error while calling GitHub API: ${err.message}` }
+    }
+}
+
+// ── Exports ───────────────────────────────────────────────────────────────────
+
+module.exports = {
+    init,
+    handle_preview_github_feedback,
+    handle_create_github_issue,
+    handle_create_github_discussion,
+}

--- a/packages/catalyst-core/mcp_v2/tools/github.js
+++ b/packages/catalyst-core/mcp_v2/tools/github.js
@@ -11,8 +11,8 @@
  *   5. generate_issue_markdown      - manual fallback when auth/API is unavailable
  *
  * Authentication:
- *   1. GITHUB_TOKEN environment variable
- *   2. GitHub CLI session (`gh auth token`)
+ *   1. Direct GitHub API token from GITHUB_TOKEN, GITHUB_PAT, or CATALYST_GITHUB_TOKEN
+ *   2. Optional fallback to GitHub CLI session (`gh auth token`)
  */
 
 const fs = require("fs")
@@ -173,9 +173,12 @@ function ensureFallbackDir(root) {
 }
 
 function getToken() {
-    const envToken = process.env.GITHUB_TOKEN
-    if (envToken && envToken.trim()) {
-        return { ok: true, token: envToken.trim(), source: "env:GITHUB_TOKEN" }
+    const envTokenNames = ["GITHUB_TOKEN", "GITHUB_PAT", "CATALYST_GITHUB_TOKEN"]
+    for (const name of envTokenNames) {
+        const envToken = process.env[name]
+        if (envToken && envToken.trim()) {
+            return { ok: true, token: envToken.trim(), source: `env:${name}` }
+        }
     }
 
     try {
@@ -192,7 +195,7 @@ function getToken() {
     return {
         ok: false,
         error:
-            "No GitHub credentials found. Run `gh auth login` with repo scope, or pass GITHUB_TOKEN in the MCP server environment.",
+            "No GitHub credentials found. Set GITHUB_TOKEN, GITHUB_PAT, or CATALYST_GITHUB_TOKEN in the MCP server environment. As an optional fallback, you can also run `gh auth login` with repo scope.",
     }
 }
 
@@ -489,52 +492,30 @@ function enrichBody(body) {
     return lines.join("\n")
 }
 
-function extractKeywords(title, body) {
-    const stopWords = new Set([
-        "a",
-        "an",
-        "the",
-        "is",
-        "in",
-        "on",
-        "at",
-        "to",
-        "for",
-        "of",
-        "and",
-        "or",
-        "but",
-        "not",
-        "with",
-        "this",
-        "that",
-        "can",
-        "how",
-        "does",
-        "issue",
-        "bug",
-    ])
-    const tokenise = (str) =>
-        String(str || "")
-            .toLowerCase()
-            .replace(/[^a-z0-9\s]/g, " ")
-            .split(/\s+/)
-            .filter((word) => word.length > 2 && !stopWords.has(word))
-
-    const titleWords = tokenise(title).slice(0, 5)
-    const bodyWords = tokenise(body)
-        .filter((word) => !titleWords.includes(word))
-        .slice(0, 3)
-
-    return [...titleWords, ...bodyWords].join(" ")
+function normalizeSearchText(value) {
+    return String(value || "")
+        .toLowerCase()
+        .replace(/[^a-z0-9\s/_:-]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
 }
 
-async function searchDuplicates(token, title, body) {
-    const keywords = extractKeywords(title, body)
-    if (!keywords) return []
+function buildDuplicateSearchText(title, body, duplicateSearchQuery) {
+    const explicitQuery = normalizeSearchText(duplicateSearchQuery)
+    if (explicitQuery) return explicitQuery
+
+    const titleQuery = normalizeSearchText(title)
+    if (titleQuery) return titleQuery
+
+    return normalizeSearchText(body).split(/\s+/).slice(0, 8).join(" ")
+}
+
+async function searchDuplicates(token, title, body, duplicateSearchQuery) {
+    const searchText = buildDuplicateSearchText(title, body, duplicateSearchQuery)
+    if (!searchText) return []
 
     try {
-        const q = encodeURIComponent(`repo:${GITHUB_OWNER}/${GITHUB_REPO} ${keywords} in:title,body is:issue`)
+        const q = encodeURIComponent(`repo:${GITHUB_OWNER}/${GITHUB_REPO} ${searchText} in:title,body is:issue`)
         const res = await githubRequest("GET", `/search/issues?q=${q}&per_page=5`, token)
         if (res.status === 200 && Array.isArray(res.body.items)) {
             return res.body.items.slice(0, 5).map((issue) => ({
@@ -625,6 +606,7 @@ function handle_start_issue_creation(args = {}) {
         next_steps: [
             "Ask the developer for a concise issue title and problem statement if not already known.",
             "Collect steps to reproduce, expected behavior, actual behavior, error logs, environment, what was tried, related issues, and screenshot/image paths or URLs if available.",
+            "Ask the LLM to provide a concise duplicate_search_query with the framework area and failure symptom, e.g. `android webview error.html fallback`.",
             "Call gather_github_issue_context with the title/problem so the issue includes catalyst-core version, package scripts, git state, and relevant file snippets.",
             "Call preview_github_feedback to select/render the issue template, suggested labels, project context, screenshots/attachments, and duplicate candidates.",
             "Show duplicate candidates first when present. If one is the same issue, stop and suggest using the existing issue instead of creating a duplicate.",
@@ -648,7 +630,12 @@ function handle_start_issue_creation(args = {}) {
         image_support:
             "Hosted image URLs are embedded in the issue body. Local image files are listed in the body and copied into the markdown fallback for manual upload, because GitHub's public Issues API does not upload local binaries.",
         duplicate_policy:
-            "The preview step performs a best-effort duplicate search. create_github_issue blocks publishing when matching issues are found unless duplicate_review_confirmed:true is provided after showing those candidates to the developer.",
+            "The preview step performs a best-effort duplicate search. Prefer passing duplicate_search_query from the LLM instead of relying on automatic keyword extraction. create_github_issue blocks publishing when matching issues are found unless duplicate_review_confirmed:true is provided after showing those candidates to the developer.",
+        auth_options: [
+            "Preferred: set a GitHub API token in the MCP server environment as GITHUB_TOKEN, GITHUB_PAT, or CATALYST_GITHUB_TOKEN.",
+            "Optional fallback: if GitHub CLI is installed and authenticated, the MCP can use `gh auth token`.",
+            "GitHub CLI is not required when an API token environment variable is configured.",
+        ],
         manual_fallback:
             "If GitHub auth, network, permission, or validation fails, call generate_issue_markdown or use the fallback returned by create_github_issue so the developer can raise the issue manually.",
         initial_problem: args.problem || args._query || null,
@@ -670,7 +657,7 @@ function collectRelatedFiles(root, query, explicitFiles) {
 
     if (files.length > 0 || !query) return files
 
-    const words = extractKeywords(query, "").split(/\s+/).filter(Boolean).slice(0, 5)
+    const words = normalizeSearchText(query).split(/\s+/).filter(Boolean).slice(0, 5)
     if (words.length === 0) return files
 
     const srcDir = path.join(root, "src")
@@ -756,7 +743,7 @@ async function handle_preview_github_feedback(args = {}) {
     const tokenResult = getToken()
     if (tokenResult.ok) {
         tokenSource = tokenResult.source
-        duplicates = await searchDuplicates(tokenResult.token, title, built.body)
+        duplicates = await searchDuplicates(tokenResult.token, title, built.body, args.duplicate_search_query)
     }
 
     return {
@@ -858,7 +845,7 @@ async function handle_create_github_issue(args = {}) {
     }
 
     try {
-        const duplicates = await searchDuplicates(tokenResult.token, title, built.body)
+        const duplicates = await searchDuplicates(tokenResult.token, title, built.body, args.duplicate_search_query)
         if (duplicates.length > 0 && args.duplicate_review_confirmed !== true) {
             return {
                 ok: false,


### PR DESCRIPTION
## Description

### 📌 Overview
This PR introduces GitHub integration to the Catalyst MCP v2 server. It enables developers to submit bugs, feature requests, and general feedback directly to the `catalyst-core` repository from their AI assistant (Claude Desktop / DeputyDev). 

To ensure safety and quality, the implementation features a preview step and duplicate detection before anything is published.

---

### 🚀 What's New

#### 🛠️ New Tools Exposed:
1. **`preview_github_feedback`**: Drafts the issue/discussion content, automatically appends project metadata, searches GitHub for duplicates, and returns a preview for developer approval. *Must be called before publishing.*
2. **`create_github_issue`**: Creates a GitHub issue via the REST API (used for bugs and feature requests).
3. **`create_github_discussion`**: Creates a GitHub discussion via the GraphQL API (used for Q&A, proposals, and general discussion).

#### 🛡️ Key Features:
* **Zero External Dependencies**: Implemented using only native Node.js `https` and `child_process` modules (no package bloat).
* **Flexible Authentication**: Prioritizes local GitHub CLI (`gh auth token`) to prevent storing secrets, with a fallback to a `GITHUB_TOKEN` environment variable.
* **Smart Duplicate Detection**: Scans existing issues (REST) and discussions (GraphQL) before posting to prevent duplicate threads.
* **Automatic Metadata Triage**: Automatically appends the active project name, path, and `catalyst-core` package version to the footer of every submission.

---

### 🔑 Authentication Setup

The MCP server supports two authentication methods (evaluated in order):

1. **GitHub CLI (Recommended - Zero Config)**
   * Uses your active local session. Run `gh auth login` in your terminal.
   * *Required scopes:* `repo`, `write:discussion`.
2. **Environment Variable**
   * Pass `GITHUB_TOKEN` (Personal Access Token) in your MCP client environment configuration.
   * *Required scopes:* `repo`, `write:discussion`.

---

### 📂 Files Changed

* **[`mcp.js`](file:///Users/pallavjain/Documents/1mg_projects/catalyst-core/packages/catalyst-core/mcp_v2/mcp.js)**: Registered the new GitHub tools and wired them into the core MCP tool router with intent safeguards.
* **[`tools/github.js`](file:///Users/pallavjain/Documents/1mg_projects/catalyst-core/packages/catalyst-core/mcp_v2/tools/github.js)**: *(New)* Encapsulates the entire GitHub API integration (REST + GraphQL) and credentials handling.