### PR TITLE
fix: http-proxy-middleware cve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8232,39 +8232,29 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+            "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
             "license": "MIT",
             "dependencies": {
-                "@types/http-proxy": "^1.17.8",
+                "@types/http-proxy": "^1.17.15",
+                "debug": "^4.3.6",
                 "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.1",
-                "is-plain-obj": "^3.0.0",
-                "micromatch": "^4.0.2"
+                "is-glob": "^4.0.3",
+                "is-plain-object": "^5.0.0",
+                "micromatch": "^4.0.8"
             },
             "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "@types/express": "^4.17.13"
-            },
-            "peerDependenciesMeta": {
-                "@types/express": {
-                    "optional": true
-                }
+                "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+        "node_modules/http-proxy-middleware/node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
             "license": "MIT",
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/http-proxy/node_modules/eventemitter3": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,10 @@
         },
         "uuid": "11.1.1",
         "file-type": "22.0.1",
-        "imagemin": "9.0.1"
+        "imagemin": "9.0.1",
+        "webpack-dev-server": {
+            "http-proxy-middleware": "3.0.7"
+        }
     },
     "lint-staged": {
         "*.{js,jsx}": [


### PR DESCRIPTION
upgrades http-proxy-middleware from 2.0.9 to 3.0.7 for fixing "CVE-2026-55602"