### PR TITLE
fix: vite cve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "sanitize-html": "^2.13.1",
                 "sass": "^1.89.2",
                 "ua-parser-js": "^1.0.37",
-                "vite": "^6.3.5",
+                "vite": "^6.4.3",
                 "vite-plugin-svgr": "^5.0.0"
             },
             "bin": {
@@ -6464,9 +6464,10 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "sanitize-html": "^2.13.1",
         "sass": "^1.89.2",
         "ua-parser-js": "^1.0.37",
-        "vite": "^6.3.5",
+        "vite": "^6.4.3",
         "vite-plugin-svgr": "^5.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
upgrades vite from 6.3.5 to 6.4.3 for resolving "CVE-2026-53571" and "CVE-2026-53632"