### PR TITLE
Status Aware Error Sampling for OpenTelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Frontend framework with server rendering support for web applications.
     -   clientFetcher
     -   refetch (for data revalidation)
 -   State Management
+-   Observability
 
 ## Overview
 
@@ -141,6 +142,40 @@ const configureStore = (initialState, cookies, requestObj, customHeaders) => {
 
 export default configureStore
 ```
+
+## Observability
+
+Catalyst ships an opt-in OpenTelemetry integration (`src/otel.js`) for traces and metrics. It's off by default — set `OTEL_ENABLE` to `true` in your app config to turn it on, then call `init()` once at server startup:
+
+```js
+import otel from "catalyst-core/otel"
+
+otel.init({
+    serviceName: "my-app",
+    traceUrl: "http://otel-collector:4317",
+    samplingRate: 0.05, // 5% of normal traffic
+})
+```
+
+**Status-aware error sampling**
+
+Normal head sampling picks traces at random when a request *starts*, before anyone knows it's going to fail — so a low `samplingRate` means rare errors are unlikely to ever be captured. Setting `errorSampling.ENABLED` re-evaluates every trace when its request *ends*: traces that come back as an error get a second, independent chance to be exported, on top of (not instead of) the normal sampling rate.
+
+```js
+otel.init({
+    samplingRate: 0.05,
+    errorSampling: {
+        ENABLED: true,
+        RATE_5XX: 1.0, // promote (almost) every 5xx and OTEL-flagged error
+        RATE_4XX: 0.2, // promote a slice of 4xx roots
+        PROMOTE_HANDLED_ERRORS: false, // also promote 2xx roots whose children errored
+        SKIP_PROMOTION_CODES: [408, 504, 524, 598, 599], // treated as noise, not app bugs
+        PROMOTE_BOT_TRAFFIC: false, // exclude bot-attributed traffic from promotion
+    },
+})
+```
+
+All `errorSampling` keys are optional and default to the values shown above (`RATE_4XX` defaults to `samplingRate` if omitted). See the JSDoc on `init()` in `src/otel.js` for the full config reference.
 
 ## Documentation
 

--- a/src/otel.js
+++ b/src/otel.js
@@ -49,18 +49,18 @@ class StatusAwareSampler {
 
         if (parentSpanContext && isSpanContextValid(parentSpanContext)) {
             if (parentSpanContext.traceFlags & TraceFlags.SAMPLED) {
-                return { decision: SamplingDecision.RECORD_AND_SAMPLE }
+                return { decision: SamplingDecision.RECORD_AND_SAMPLED }
             } else {
-                return { decision: SamplingDecision.RECORD_ONLY }
+                return { decision: SamplingDecision.RECORD }
             }
         }
 
         // Head sampling using characters 0-12
         const isHeadSampled = getDecisionForBits(traceId, 0, 12, this.samplingRate)
         if (isHeadSampled) {
-            return { decision: SamplingDecision.RECORD_AND_SAMPLE }
+            return { decision: SamplingDecision.RECORD_AND_SAMPLED }
         } else {
-            return { decision: SamplingDecision.RECORD_ONLY }
+            return { decision: SamplingDecision.RECORD }
         }
     }
 

--- a/src/otel.js
+++ b/src/otel.js
@@ -1,29 +1,269 @@
-import { metrics } from "@opentelemetry/api"
 import { NodeSDK } from "@opentelemetry/sdk-node"
 import { resourceFromAttributes } from "@opentelemetry/resources"
-import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-node"
+import {
+    metrics,
+    trace,
+    TraceFlags,
+    SpanStatusCode,
+    context,
+    createContextKey,
+    isSpanContextValid,
+} from "@opentelemetry/api"
+import {
+    BatchSpanProcessor,
+    TraceIdRatioBasedSampler,
+    ParentBasedSampler,
+    SamplingDecision,
+} from "@opentelemetry/sdk-trace-node"
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics"
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc"
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-grpc"
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node"
-import { TraceIdRatioBasedSampler, ParentBasedSampler } from "@opentelemetry/sdk-trace-node"
 import { OTLPTraceExporter as OTLPTraceExporterHTTP } from "@opentelemetry/exporter-trace-otlp-http"
 import { OTLPMetricExporter as OTLPMetricExporterHTTP } from "@opentelemetry/exporter-metrics-otlp-http"
-import { trace, context, createContextKey } from "@opentelemetry/api"
 
 export const IS_BOT_KEY = createContextKey("catalyst.is_bot")
 
 import semanticConventions from "@opentelemetry/semantic-conventions"
 const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION, ATTR_DEPLOYMENT_ENVIRONMENT } = semanticConventions
 
+// Bit-range sampling decision helper
+function getDecisionForBits(traceId, start, end, rate) {
+    if (rate >= 1.0) return true
+    if (rate <= 0.0) return false
+    if (!traceId || traceId.length < end) return false
+    const hexPart = traceId.substring(start, end)
+    const value = parseInt(hexPart, 16)
+    const maxValue = Math.pow(16, end - start) - 1
+    return value / maxValue < rate
+}
+
+// Custom Status Aware Sampler
+class StatusAwareSampler {
+    constructor(samplingRate) {
+        this.samplingRate = samplingRate
+    }
+
+    shouldSample(context, traceId) {
+        const parentSpanContext = trace.getSpanContext(context)
+
+        if (parentSpanContext && isSpanContextValid(parentSpanContext)) {
+            if (parentSpanContext.traceFlags & TraceFlags.SAMPLED) {
+                return { decision: SamplingDecision.RECORD_AND_SAMPLE }
+            } else {
+                return { decision: SamplingDecision.RECORD_ONLY }
+            }
+        }
+
+        // Head sampling using characters 0-12
+        const isHeadSampled = getDecisionForBits(traceId, 0, 12, this.samplingRate)
+        if (isHeadSampled) {
+            return { decision: SamplingDecision.RECORD_AND_SAMPLE }
+        } else {
+            return { decision: SamplingDecision.RECORD_ONLY }
+        }
+    }
+
+    toString() {
+        return `StatusAwareSampler{samplingRate=${this.samplingRate}}`
+    }
+}
+
+// Custom Span Processor for Status Aware Error Sampling
+class PromotingSpanProcessor {
+    constructor(exporter, config) {
+        this.exporter = exporter
+        this.config = config
+        this.buffer = new Map()
+        this.promotedTraces = new Map()
+
+        // Delegating BatchSpanProcessor for head-sampled spans
+        this.batchProcessor = new BatchSpanProcessor(exporter, config.batchProcessorConfig)
+
+        this.cleanupInterval = setInterval(() => {
+            this._cleanupBuffers()
+        }, 30000)
+
+        if (this.cleanupInterval.unref) {
+            this.cleanupInterval.unref()
+        }
+    }
+
+    onStart(span, parentContext) {
+        const isSampled = (span.spanContext().traceFlags & TraceFlags.SAMPLED) !== 0
+        if (isSampled) {
+            this.batchProcessor.onStart(span, parentContext)
+        }
+    }
+
+    onEnd(span) {
+        const traceId = span.spanContext().traceId
+        const isSampled = (span.spanContext().traceFlags & TraceFlags.SAMPLED) !== 0
+
+        if (this.promotedTraces.has(traceId)) {
+            const promotionRate = this.promotedTraces.get(traceId).promotionRate
+            this._exportSpanImmediately(span, promotionRate)
+            return
+        }
+
+        if (isSampled) {
+            this.batchProcessor.onEnd(span)
+            return
+        }
+
+        // Buffer the RECORD_ONLY span
+        let record = this.buffer.get(traceId)
+        if (!record) {
+            record = {
+                spans: [],
+                rootSpan: null,
+                hasChildError: false,
+                timestamp: Date.now(),
+            }
+            this.buffer.set(traceId, record)
+        }
+
+        const isRoot = !span.parentSpanId
+        if (isRoot) {
+            record.rootSpan = span
+        } else {
+            record.spans.push(span)
+        }
+
+        if (span.status && span.status.code === SpanStatusCode.ERROR) {
+            record.hasChildError = true
+        }
+
+        if (isRoot) {
+            this._evaluateAndProcessPromotion(traceId, record)
+        }
+    }
+
+    _evaluateAndProcessPromotion(traceId, record) {
+        const rootSpan = record.rootSpan
+        if (!rootSpan) return
+
+        const statusCode = Number(
+            rootSpan.attributes["http.status_code"] || rootSpan.attributes["http.response.status_code"] || 0
+        )
+
+        const is5xx = statusCode >= 500 && statusCode < 600
+        const isRootError = rootSpan.status && rootSpan.status.code === SpanStatusCode.ERROR
+
+        let shouldPromote = false
+        let promotionRate = this.config.samplingRate
+
+        if (is5xx || isRootError) {
+            shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate5xx)
+            promotionRate = this.config.rate5xx
+        } else {
+            const is4xx = statusCode >= 400 && statusCode < 500
+            const isSkipped4xx = this.config.skipPromotionCodes.includes(statusCode)
+
+            if (is4xx && !isSkipped4xx) {
+                shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate4xx)
+                promotionRate = this.config.rate4xx
+            } else if (this.config.promoteHandledErrors && record.hasChildError) {
+                shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate5xx)
+                promotionRate = this.config.rate5xx
+            }
+        }
+
+        if (shouldPromote) {
+            this.promotedTraces.set(traceId, {
+                timestamp: Date.now(),
+                promotionRate,
+            })
+
+            let spansToExport = []
+            if (this.config.exportFullTraceOnError) {
+                spansToExport = [rootSpan, ...record.spans]
+            } else {
+                spansToExport = [rootSpan]
+                for (const s of record.spans) {
+                    if (s.status && s.status.code === SpanStatusCode.ERROR) {
+                        spansToExport.push(s)
+                    }
+                }
+            }
+
+            const finalSampleRate = this.config.reportActualPromotionRate
+                ? promotionRate
+                : this.config.samplingRate
+            for (const s of spansToExport) {
+                s.spanContext().traceFlags |= TraceFlags.SAMPLED
+                s.attributes["promoted"] = true
+                s.attributes["sample_rate"] = finalSampleRate
+            }
+
+            this.exporter.export(spansToExport, () => {})
+        }
+
+        this.buffer.delete(traceId)
+    }
+
+    _exportSpanImmediately(span, promotionRate) {
+        const finalSampleRate = this.config.reportActualPromotionRate
+            ? promotionRate
+            : this.config.samplingRate
+        span.spanContext().traceFlags |= TraceFlags.SAMPLED
+        span.attributes["promoted"] = true
+        span.attributes["sample_rate"] = finalSampleRate
+
+        this.exporter.export([span], () => {})
+    }
+
+    _cleanupBuffers() {
+        const now = Date.now()
+        const TTL = 5 * 60 * 1000
+
+        for (const [traceId, record] of this.buffer.entries()) {
+            if (now - record.timestamp > TTL) {
+                this.buffer.delete(traceId)
+            } else {
+                break
+            }
+        }
+
+        if (this.buffer.size > 1024) {
+            const toDelete = this.buffer.size - 1024
+            let count = 0
+            for (const traceId of this.buffer.keys()) {
+                this.buffer.delete(traceId)
+                count++
+                if (count >= toDelete) break
+            }
+        }
+
+        for (const [traceId, data] of this.promotedTraces.entries()) {
+            if (now - data.timestamp > TTL) {
+                this.promotedTraces.delete(traceId)
+            } else {
+                break
+            }
+        }
+    }
+
+    forceFlush() {
+        return this.batchProcessor.forceFlush()
+    }
+
+    shutdown() {
+        if (this.cleanupInterval) {
+            clearInterval(this.cleanupInterval)
+        }
+        return this.batchProcessor.shutdown()
+    }
+}
+
 function init(config = {}) {
     // OpenTelemetry is opt-in — bail out unless explicitly enabled. Mirrors the
     // OTEL_ENABLE guard in server/expressServer.js and server/renderer/handler.jsx
     // so the SDK, exporters, instrumentations and signal handlers are never set
     // up when tracing is off. Returns the same shape so callers can destructure.
-    if (process.env.OTEL_ENABLE !== true) {
-        return { sdk: null, meter: null }
-    }
+    // if (process.env.OTEL_ENABLE !== true) {
+    //     return { sdk: null, meter: null }
+    // }
 
     const {
         serviceName = "catalyst-server",
@@ -40,6 +280,7 @@ function init(config = {}) {
         instrumentations,
         samplingRate = 1.0,
         grpcCredentials,
+        errorSampling = {},
     } = config
 
     try {
@@ -61,9 +302,35 @@ function init(config = {}) {
             })
         }
 
-        const sampler = new ParentBasedSampler({
-            root: new TraceIdRatioBasedSampler(samplingRate),
-        })
+        let sampler
+        let spanProcessor
+
+        const isErrorSamplingEnabled = errorSampling && errorSampling.ENABLED === true
+
+        if (isErrorSamplingEnabled) {
+            logger.info("⚙️ OpenTelemetry initializing with Status Aware Error Sampling")
+            sampler = new StatusAwareSampler(samplingRate)
+
+            const errorSamplingConfig = {
+                samplingRate,
+                rate5xx: typeof errorSampling.RATE_5XX === "number" ? errorSampling.RATE_5XX : 1.0,
+                rate4xx: typeof errorSampling.RATE_4XX === "number" ? errorSampling.RATE_4XX : samplingRate,
+                exportFullTraceOnError: errorSampling.EXPORT_FULL_TRACE_ON_ERROR === true,
+                promoteHandledErrors: errorSampling.PROMOTE_HANDLED_ERRORS === true,
+                reportActualPromotionRate: errorSampling.REPORT_ACTUAL_PROMOTION_RATE === true,
+                skipPromotionCodes: Array.isArray(errorSampling.SKIP_PROMOTION_CODES)
+                    ? errorSampling.SKIP_PROMOTION_CODES
+                    : [408, 504, 524, 598, 599],
+                batchProcessorConfig,
+            }
+
+            spanProcessor = new PromotingSpanProcessor(otlpTraceExporter, errorSamplingConfig)
+        } else {
+            sampler = new ParentBasedSampler({
+                root: new TraceIdRatioBasedSampler(samplingRate),
+            })
+            spanProcessor = new BatchSpanProcessor(otlpTraceExporter, batchProcessorConfig)
+        }
 
         const sdkConfig = {
             resource: resourceFromAttributes({
@@ -71,7 +338,7 @@ function init(config = {}) {
                 [ATTR_SERVICE_VERSION]: serviceVersion,
                 [ATTR_DEPLOYMENT_ENVIRONMENT]: environment,
             }),
-            spanProcessor: new BatchSpanProcessor(otlpTraceExporter, batchProcessorConfig),
+            spanProcessor,
             instrumentations: instrumentations ?? [getNodeAutoInstrumentations()],
             sampler,
         }

--- a/src/otel.js
+++ b/src/otel.js
@@ -244,11 +244,9 @@ class PromotingSpanProcessor {
         const now = Date.now()
         const TTL = 5 * 60 * 1000
 
-        let bufferTtlEvicted = 0
         for (const [traceId, record] of this.buffer.entries()) {
             if (now - record.timestamp > TTL) {
                 this.buffer.delete(traceId)
-                bufferTtlEvicted++
             } else {
                 break
             }
@@ -264,25 +262,18 @@ class PromotingSpanProcessor {
             }
             // Buffer is filling faster than root spans resolve — unresolved traces
             // are being dropped before ever getting a promotion decision.
+            const { rss, heapUsed } = process.memoryUsage()
             logger.warn(
-                `⚠️ PromotingSpanProcessor: buffer overflow, dropped ${bufferOverflowEvicted} unresolved trace(s) (buffer size=${this.buffer.size})`
+                `⚠️ PromotingSpanProcessor: buffer overflow, dropped ${bufferOverflowEvicted} unresolved trace(s) (buffer size=${this.buffer.size}, rss=${(rss / 1024 / 1024).toFixed(1)}MB, heapUsed=${(heapUsed / 1024 / 1024).toFixed(1)}MB)`
             )
         }
 
-        let promotedTtlEvicted = 0
         for (const [traceId, data] of this.promotedTraces.entries()) {
             if (now - data.timestamp > TTL) {
                 this.promotedTraces.delete(traceId)
-                promotedTtlEvicted++
             } else {
                 break
             }
-        }
-
-        if (bufferTtlEvicted || promotedTtlEvicted) {
-            logger.debug(
-                `PromotingSpanProcessor cleanup: evicted ${bufferTtlEvicted} stale buffered trace(s) and ${promotedTtlEvicted} stale promoted trace(s) (buffer=${this.buffer.size}, promotedTraces=${this.promotedTraces.size})`
-            )
         }
     }
 
@@ -294,6 +285,9 @@ class PromotingSpanProcessor {
         if (this.cleanupInterval) {
             clearInterval(this.cleanupInterval)
         }
+        logger.info(
+            `📡 PromotingSpanProcessor: shutting down, discarding ${this.buffer.size} unresolved trace(s) and ${this.promotedTraces.size} promoted-trace record(s)`
+        )
         this.buffer.clear()
         this.promotedTraces.clear()
         return this.batchProcessor.shutdown()

--- a/src/otel.js
+++ b/src/otel.js
@@ -131,7 +131,7 @@ class PromotingSpanProcessor {
             record.spans.push(span)
         }
 
-        if (span.status && span.status.code === SpanStatusCode.ERROR) {
+        if (!isRoot && span.status && span.status.code === SpanStatusCode.ERROR) {
             record.hasChildError = true
         }
 
@@ -156,7 +156,7 @@ class PromotingSpanProcessor {
 
         const is5xx = statusCode >= 500 && statusCode < 600
         const is4xx = statusCode >= 400 && statusCode < 500
-        const isRootError = rootSpan.status && rootSpan.status.code === SpanStatusCode.ERROR
+        const isRootError = rootSpan.status && rootSpan.status.code === SpanStatusCode.ERROR && !is4xx
         const isSkipped = this.config.skipPromotionCodes.includes(statusCode)
 
         let shouldPromote = false
@@ -168,7 +168,13 @@ class PromotingSpanProcessor {
         } else if (is4xx && !isSkipped) {
             shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate4xx)
             promotionRate = this.config.rate4xx
-        } else if (this.config.promoteHandledErrors && record.hasChildError) {
+        } else if (
+            this.config.promoteHandledErrors &&
+            record.hasChildError &&
+            statusCode >= 200 &&
+            statusCode < 300 &&
+            !isSkipped
+        ) {
             shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate5xx)
             promotionRate = this.config.rate5xx
         }
@@ -238,30 +244,45 @@ class PromotingSpanProcessor {
         const now = Date.now()
         const TTL = 5 * 60 * 1000
 
+        let bufferTtlEvicted = 0
         for (const [traceId, record] of this.buffer.entries()) {
             if (now - record.timestamp > TTL) {
                 this.buffer.delete(traceId)
+                bufferTtlEvicted++
             } else {
                 break
             }
         }
 
+        let bufferOverflowEvicted = 0
         if (this.buffer.size > 1024) {
             const toDelete = this.buffer.size - 1024
-            let count = 0
             for (const traceId of this.buffer.keys()) {
                 this.buffer.delete(traceId)
-                count++
-                if (count >= toDelete) break
+                bufferOverflowEvicted++
+                if (bufferOverflowEvicted >= toDelete) break
             }
+            // Buffer is filling faster than root spans resolve — unresolved traces
+            // are being dropped before ever getting a promotion decision.
+            logger.warn(
+                `⚠️ PromotingSpanProcessor: buffer overflow, dropped ${bufferOverflowEvicted} unresolved trace(s) (buffer size=${this.buffer.size})`
+            )
         }
 
+        let promotedTtlEvicted = 0
         for (const [traceId, data] of this.promotedTraces.entries()) {
             if (now - data.timestamp > TTL) {
                 this.promotedTraces.delete(traceId)
+                promotedTtlEvicted++
             } else {
                 break
             }
+        }
+
+        if (bufferTtlEvicted || promotedTtlEvicted) {
+            logger.debug(
+                `PromotingSpanProcessor cleanup: evicted ${bufferTtlEvicted} stale buffered trace(s) and ${promotedTtlEvicted} stale promoted trace(s) (buffer=${this.buffer.size}, promotedTraces=${this.promotedTraces.size})`
+            )
         }
     }
 
@@ -273,6 +294,8 @@ class PromotingSpanProcessor {
         if (this.cleanupInterval) {
             clearInterval(this.cleanupInterval)
         }
+        this.buffer.clear()
+        this.promotedTraces.clear()
         return this.batchProcessor.shutdown()
     }
 }
@@ -300,7 +323,7 @@ class PromotingSpanProcessor {
  * @param {Function} [config.grpcCredentials]
  * @param {object} [config.errorSampling] - status-aware error sampling, off by default
  * @param {boolean} [config.errorSampling.ENABLED=false] - turns on StatusAwareSampler + PromotingSpanProcessor
- * @param {number} [config.errorSampling.RATE_5XX=1.0] - promotion rate for 5xx roots (and roots with OTEL ERROR status)
+ * @param {number} [config.errorSampling.RATE_5XX=1.0] - promotion rate for 5xx roots (and non-4xx roots with OTEL ERROR status)
  * @param {number} [config.errorSampling.RATE_4XX=samplingRate] - promotion rate for 4xx roots
  * @param {boolean} [config.errorSampling.EXPORT_FULL_TRACE_ON_ERROR=false] - export every buffered span on promotion, not just root + error spans
  * @param {boolean} [config.errorSampling.PROMOTE_HANDLED_ERRORS=false] - promote 2xx roots (at RATE_5XX) if any child span recorded an error

--- a/src/otel.js
+++ b/src/otel.js
@@ -15,6 +15,7 @@ import {
     ParentBasedSampler,
     SamplingDecision,
 } from "@opentelemetry/sdk-trace-node"
+import { setGlobalErrorHandler } from "@opentelemetry/core"
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics"
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc"
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-grpc"
@@ -143,30 +144,33 @@ class PromotingSpanProcessor {
         const rootSpan = record.rootSpan
         if (!rootSpan) return
 
+        const isBot = rootSpan.attributes["http.response.is_bot"] === true
+        if (isBot && !this.config.promoteBotTraffic) {
+            this.buffer.delete(traceId)
+            return
+        }
+
         const statusCode = Number(
             rootSpan.attributes["http.status_code"] || rootSpan.attributes["http.response.status_code"] || 0
         )
 
         const is5xx = statusCode >= 500 && statusCode < 600
+        const is4xx = statusCode >= 400 && statusCode < 500
         const isRootError = rootSpan.status && rootSpan.status.code === SpanStatusCode.ERROR
+        const isSkipped = this.config.skipPromotionCodes.includes(statusCode)
 
         let shouldPromote = false
         let promotionRate = this.config.samplingRate
 
-        if (is5xx || isRootError) {
+        if ((is5xx || isRootError) && !isSkipped) {
             shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate5xx)
             promotionRate = this.config.rate5xx
-        } else {
-            const is4xx = statusCode >= 400 && statusCode < 500
-            const isSkipped4xx = this.config.skipPromotionCodes.includes(statusCode)
-
-            if (is4xx && !isSkipped4xx) {
-                shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate4xx)
-                promotionRate = this.config.rate4xx
-            } else if (this.config.promoteHandledErrors && record.hasChildError) {
-                shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate5xx)
-                promotionRate = this.config.rate5xx
-            }
+        } else if (is4xx && !isSkipped) {
+            shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate4xx)
+            promotionRate = this.config.rate4xx
+        } else if (this.config.promoteHandledErrors && record.hasChildError) {
+            shouldPromote = getDecisionForBits(traceId, 12, 24, this.config.rate5xx)
+            promotionRate = this.config.rate5xx
         }
 
         if (shouldPromote) {
@@ -191,12 +195,14 @@ class PromotingSpanProcessor {
                 ? promotionRate
                 : this.config.samplingRate
             for (const s of spansToExport) {
+                // Required, not decorative: batchProcessor.onEnd() below silently
+                // drops any span whose traceFlags aren't SAMPLED.
                 s.spanContext().traceFlags |= TraceFlags.SAMPLED
                 s.attributes["promoted"] = true
                 s.attributes["sample_rate"] = finalSampleRate
             }
 
-            this.exporter.export(spansToExport, () => {})
+            this._export(spansToExport)
         }
 
         this.buffer.delete(traceId)
@@ -206,11 +212,26 @@ class PromotingSpanProcessor {
         const finalSampleRate = this.config.reportActualPromotionRate
             ? promotionRate
             : this.config.samplingRate
+        // Required, not decorative: batchProcessor.onEnd() below silently drops
+        // any span whose traceFlags aren't SAMPLED.
         span.spanContext().traceFlags |= TraceFlags.SAMPLED
         span.attributes["promoted"] = true
         span.attributes["sample_rate"] = finalSampleRate
 
-        this.exporter.export([span], () => {})
+        this._export([span])
+    }
+
+    // Hands promoted spans to the same BatchSpanProcessor used for normal
+    // head-sampled traffic, instead of exporting them directly. Reuses its
+    // queueing/backpressure (maxQueueSize, scheduledDelayMillis, ...) so a burst
+    // of promotions during an incident can't flood the collector with concurrent
+    // export calls. Trade-off: promoted spans export on the next batch flush
+    // instead of instantly. onStart() is a no-op on BatchSpanProcessorBase, so
+    // handing a span straight to onEnd() without a prior onStart() is safe.
+    _export(spans) {
+        for (const s of spans) {
+            this.batchProcessor.onEnd(s)
+        }
     }
 
     _cleanupBuffers() {
@@ -256,14 +277,50 @@ class PromotingSpanProcessor {
     }
 }
 
+/**
+ * Initializes the OpenTelemetry Node SDK — traces, optional metrics, and (when
+ * errorSampling.ENABLED is set) status-aware error sampling. No-op unless
+ * OTEL_ENABLE is set (see server/expressServer.js and server/renderer/handler.jsx
+ * for the same guard on the call sites that import this module).
+ *
+ * @param {object} [config]
+ * @param {string} [config.serviceName="catalyst-server"]
+ * @param {string} [config.serviceVersion="1.0.0"]
+ * @param {string} [config.environment="development"]
+ * @param {string} [config.traceUrl="http://localhost:4317"] - OTLP trace collector endpoint
+ * @param {string} [config.metricUrl="http://localhost:4317"] - OTLP metric collector endpoint
+ * @param {string} [config.traceProtocol="grpc"] - "grpc" or "http"
+ * @param {string} [config.metricProtocol] - "grpc" or "http"; metrics stay disabled if omitted
+ * @param {object} [config.traceHeaders]
+ * @param {object} [config.metricHeaders]
+ * @param {object} [config.batchProcessorConfig] - passed to BatchSpanProcessor (maxQueueSize, scheduledDelayMillis, ...)
+ * @param {number} [config.exportIntervalMillis=10000]
+ * @param {Array} [config.instrumentations] - defaults to getNodeAutoInstrumentations()
+ * @param {number} [config.samplingRate=1.0] - head-sampling rate in [0, 1] for non-error traffic
+ * @param {Function} [config.grpcCredentials]
+ * @param {object} [config.errorSampling] - status-aware error sampling, off by default
+ * @param {boolean} [config.errorSampling.ENABLED=false] - turns on StatusAwareSampler + PromotingSpanProcessor
+ * @param {number} [config.errorSampling.RATE_5XX=1.0] - promotion rate for 5xx roots (and roots with OTEL ERROR status)
+ * @param {number} [config.errorSampling.RATE_4XX=samplingRate] - promotion rate for 4xx roots
+ * @param {boolean} [config.errorSampling.EXPORT_FULL_TRACE_ON_ERROR=false] - export every buffered span on promotion, not just root + error spans
+ * @param {boolean} [config.errorSampling.PROMOTE_HANDLED_ERRORS=false] - promote 2xx roots (at RATE_5XX) if any child span recorded an error
+ * @param {boolean} [config.errorSampling.REPORT_ACTUAL_PROMOTION_RATE=false] - report the real promotion rate in the exported sample_rate attribute instead of samplingRate
+ * @param {number[]} [config.errorSampling.SKIP_PROMOTION_CODES=[408,504,524,598,599]] - status codes excluded from promotion regardless of 4xx/5xx
+ * @param {boolean} [config.errorSampling.PROMOTE_BOT_TRAFFIC=false] - allow bot-attributed traces (http.response.is_bot) to be promoted
+ * @returns {{sdk: NodeSDK|null, meter: object|null}}
+ */
 function init(config = {}) {
     // OpenTelemetry is opt-in — bail out unless explicitly enabled. Mirrors the
     // OTEL_ENABLE guard in server/expressServer.js and server/renderer/handler.jsx
     // so the SDK, exporters, instrumentations and signal handlers are never set
     // up when tracing is off. Returns the same shape so callers can destructure.
-    // if (process.env.OTEL_ENABLE !== true) {
-    //     return { sdk: null, meter: null }
-    // }
+    if (process.env.OTEL_ENABLE !== true) {
+        return { sdk: null, meter: null }
+    }
+
+    // Export failures (collector down, batch rejected, ...) otherwise vanish into
+    // OTEL's silent default diag logger — route them through the app logger.
+    setGlobalErrorHandler((err) => logger.error("❌ OpenTelemetry export error:", err))
 
     const {
         serviceName = "catalyst-server",
@@ -321,6 +378,7 @@ function init(config = {}) {
                 skipPromotionCodes: Array.isArray(errorSampling.SKIP_PROMOTION_CODES)
                     ? errorSampling.SKIP_PROMOTION_CODES
                     : [408, 504, 524, 598, 599],
+                promoteBotTraffic: errorSampling.PROMOTE_BOT_TRAFFIC === true,
                 batchProcessorConfig,
             }
 

--- a/src/server/utils/userAgentUtil.js
+++ b/src/server/utils/userAgentUtil.js
@@ -37,6 +37,9 @@ const aiCrawlerBots = {
 
     // Microsoft Bing bot (also powers Bing Chat/Copilot)
     Bingbot: "bingbot",
+
+    // Meta Crawler bot
+    MetaBot: "meta-externalagent",
 }
 
 // StatusCake synthetic monitoring user agents.


### PR DESCRIPTION
## Description
This PR implements **Status Aware Error Sampling** natively in the `catalyst-core` OpenTelemetry integration ([src/otel.js](file:///Users/vishal/Documents/catalyst-vishal/catalyst-core/src/otel.js)).

In high-throughput environments operating at low head-sampling rates (e.g. 1%), standard head-sampling discards 99% of all traces, resulting in the loss of 99% of error traces (4xx and 5xx). This feature introduces a two-stage sampling flow that defers the export decision until a request finishes, allowing the system to selectively promote and export error traces at independent rates (typically 100% for 5xx and 10% for 4xx) without inflating successful trace volume or incurring excessive memory overhead.

The implementation is fully backwards-compatible and operates as an opt-in feature under the `errorSampling` configuration block.

---

## Key Features & Components

### 1. Custom Sampler: [StatusAwareSampler](file:///Users/vishal/Documents/catalyst-vishal/catalyst-core/src/otel.js#L43-L71)
*   **Upstream Propagation:** Respects parent/upstream sampling decisions.
*   **Record Stage:** If a trace fails the initial head-sampling check, it returns `RECORD` (instead of `NOT_RECORD`). This instructs the SDK to build spans in memory so they can be analyzed upon request completion.
*   **Independent Bit-Ranges:** Uses characters `0–12` (first 48 bits) of the `traceId` hex string to evaluate the head-sampling probability.

### 2. Custom Processor: [PromotingSpanProcessor](file:///Users/vishal/Documents/catalyst-vishal/catalyst-core/src/otel.js#L74-L278)
*   **Pass-through:** Automatically routes head-sampled spans (`SAMPLED` bit set) straight to the internal `BatchSpanProcessor` to preserve standard low-latency batch exports.
*   **Trace Buffer:** Holds non-sampled spans (`RECORD` only) in an in-memory Map keyed by `traceId`.
*   **Bot Exclusion:** Root spans carrying `http.response.is_bot: true` are excluded from every promotion rule below by default (`PROMOTE_BOT_TRAFFIC`), so bot-triggered errors can't inflate promoted volume unless explicitly opted in.
*   **Deferred Promotion Evaluation:** When the root span of a request ends, the processor evaluates the HTTP status code:
    *   **5xx Errors / Exceptions:** Promoted at probability `RATE_5XX` (typically 100%). Evaluated using characters `12–24` of the `traceId` string. `SKIP_PROMOTION_CODES` is now consulted here too, not just for 4xx — gateway timeouts (504/524/598/599) are correctly excluded instead of always promoting anyway.
    *   **4xx Client Errors:** Promoted at probability `RATE_4XX` (excluding configured timeouts/gateway noise).
    *   **Handled Errors:** If enabled, promotes 2xx root spans that contain errored child spans underneath.
*   **Backpressure-Safe Export:** Promoted spans are handed to the same internal `BatchSpanProcessor` used for head-sampled traffic (`batchProcessor.onEnd()`) rather than exported directly. A burst of promotions during an incident queues and batches like any other traffic instead of opening a flood of individual export calls against the collector. Trade-off: promoted spans export on the processor's next batch flush (`scheduledDelayMillis`, default ~5s) rather than instantly — tunable via `batchProcessorConfig`.
*   **Late-Arriving Spans:** Employs a short-lived cache of recently promoted `traceIds` so that asynchronous child spans completing after the root span are still successfully tagged and routed for export.
*   **Export Failure Visibility:** `init()` registers a global OTEL error handler (`setGlobalErrorHandler`) that logs export failures — collector down, batch rejected, etc. — through the app logger, for both normal and promoted traffic, instead of failing silently.
*   **Memory Safeguards:** Features a 30-second interval sweep enforcing a 5-minute TTL on buffered traces, alongside a hard limit of `1024` traces in the buffer to prevent OOM errors.

---

## Configuration Reference
You can activate the feature by passing the `errorSampling` block to `Otel.init`:

```json
"ERROR_SAMPLING": {
  "ENABLED": true,
  "RATE_4XX": 0.1,
  "RATE_5XX": 1.0,
  "EXPORT_FULL_TRACE_ON_ERROR": true,
  "PROMOTE_HANDLED_ERRORS": true,
  "REPORT_ACTUAL_PROMOTION_RATE": false,
  "SKIP_PROMOTION_CODES": [408, 504, 524, 598, 599],
  "PROMOTE_BOT_TRAFFIC": false
}
```

Full config reference, including all defaults, is now documented via JSDoc on `init()` in `src/otel.js`, and in a new "Observability" section in `README.md`.

---

## Fixes since the initial implementation
A follow-up audit surfaced several issues, all addressed in this PR:
*   Restored the `OTEL_ENABLE` opt-in guard in `init()`, which had been temporarily commented out during development — without it, the SDK would initialize unconditionally in every environment.
*   Fixed `SKIP_PROMOTION_CODES`: the skip check previously only gated the 4xx branch, so 4 of its 5 default entries (504/524/598/599) were unreachable and got promoted anyway despite being configured to skip.
*   Removed the unbounded, un-backpressured direct export path for promoted spans (see Backpressure-Safe Export above).
*   Export failures are now logged instead of silently discarded.
*   Added `PROMOTE_BOT_TRAFFIC` to keep bot traffic from inflating promoted volume by default.
*   Documented the full config surface (README + JSDoc), which previously had zero mentions outside the source.

---

## Testing & Verification Done
*   **Unit & Integration Tests:** Validated ratio-based head sampling decisions, span buffering, 4xx/5xx promotion criteria, handled error routing, and cache cleanup routines.
*   **Local Verification:** Verified trace propagation using a local test script. Spans are correctly recorded, set with `traceFlags: 1` (`SAMPLED`), and exported to Jaeger.
*   **Application E2E Test:** Deployed and verified in local `mweb` and `dweb` apps, confirming successful traces are exported according to the sampling rate, while 4xx and 5xx errors are successfully promoted and tagged with the `"promoted": true` attribute.