### PR TITLE
Fix(docs): run docs Express server with NODE_ENV=production

### DIFF
--- a/docs/server/package.json
+++ b/docs/server/package.json
@@ -6,7 +6,7 @@
     "main": "index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
-        "start": "node index.js",
+        "start": "NODE_ENV=production node index.js",
         "dev": "nodemon index.js"
     },
     "author": "Shubham Sharma",


### PR DESCRIPTION
The docs proxy server (server/index.js) ran with NODE_ENV unset, so Express used its default (development) error handler and rendered full stack traces into HTTP error responses. A malformed JSON POST leaked the absolute server path (/opt/1mg/web/docs/...) and dependency internals, flagged by the node-express-dev-env scanner on catalyst.1mg.com.

Set NODE_ENV=production for the server process by updating the start script to `NODE_ENV=production node index.js`. The inline assignment takes effect for the node process and wins even if the runtime environment sets NODE_ENV=development, so Express uses its production error handler and no longer leaks stack traces.