### PR TITLE
 Sync MCP v2: extract seeding, delegate docs sync, add FTS + initial sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ simple_response.json
 src/native/iosnativeWebView/iosnativeWebView/ConfigConstants.swift
 *.xcshareddata
 **/node_modules
+/docs

--- a/packages/catalyst-core/mcp_v2/lib/seed.js
+++ b/packages/catalyst-core/mcp_v2/lib/seed.js
@@ -17,8 +17,8 @@ function seedKnowledgeBase(db, kbPath, projectInfo = null) {
     const kb = JSON.parse(fs.readFileSync(kbPath, "utf8"))
     if (!Array.isArray(kb)) throw new Error("knowledge-base.json must be a JSON array")
 
-    db.prepare(`DELETE FROM framework_knowledge WHERE source = 'static'`).run()
-    db.prepare(`DELETE FROM known_errors`).run()
+    const deleteKnowledge = db.prepare(`DELETE FROM framework_knowledge WHERE source = 'static'`)
+    const deleteErrors = db.prepare(`DELETE FROM known_errors`)
 
     const insertKnowledge = db.prepare(`
         INSERT INTO framework_knowledge (section, title, content, layer, source, tags, github_files)
@@ -34,6 +34,8 @@ function seedKnowledgeBase(db, kbPath, projectInfo = null) {
     let errorCount = 0
 
     const seedAll = db.transaction(() => {
+        deleteKnowledge.run()
+        deleteErrors.run()
         for (const entry of kb) {
             if (entry.section === "known_errors") {
                 // known_errors entries encode symptom/cause/fix in content as:

--- a/packages/catalyst-core/mcp_v2/lib/seed.js
+++ b/packages/catalyst-core/mcp_v2/lib/seed.js
@@ -1,0 +1,86 @@
+"use strict"
+
+const fs = require("fs")
+
+/**
+ * Re-seed framework_knowledge (source='static') and known_errors from knowledge-base.json.
+ * Caller is responsible for rebuilding fk_fts afterwards (via knowledge.init).
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} kbPath - absolute path to knowledge-base.json
+ * @param {?{ dir: string, pkg: { name?: string }, version: string }} projectInfo
+ *        When provided, also upserts the project_context row. Pass null at runtime sync
+ *        when project_context is already populated.
+ * @returns {{ knowledgeCount: number, errorCount: number }}
+ */
+function seedKnowledgeBase(db, kbPath, projectInfo = null) {
+    const kb = JSON.parse(fs.readFileSync(kbPath, "utf8"))
+    if (!Array.isArray(kb)) throw new Error("knowledge-base.json must be a JSON array")
+
+    db.prepare(`DELETE FROM framework_knowledge WHERE source = 'static'`).run()
+    db.prepare(`DELETE FROM known_errors`).run()
+
+    const insertKnowledge = db.prepare(`
+        INSERT INTO framework_knowledge (section, title, content, layer, source, tags, github_files)
+        VALUES (@section, @title, @content, @layer, @source, @tags, @github_files)
+    `)
+
+    const insertError = db.prepare(`
+        INSERT INTO known_errors (symptom, cause, fix, layer, tags)
+        VALUES (@symptom, @cause, @fix, @layer, @tags)
+    `)
+
+    let knowledgeCount = 0
+    let errorCount = 0
+
+    const seedAll = db.transaction(() => {
+        for (const entry of kb) {
+            if (entry.section === "known_errors") {
+                // known_errors entries encode symptom/cause/fix in content as:
+                // "Symptom: ... Cause: ... Fix: ..."
+                const content = entry.content || ""
+                const symptomMatch = content.match(/Symptom:\s*([^.]+\.?)/i)
+                const causeMatch = content.match(/Cause:\s*([^.]+\.?)/i)
+                const fixMatch = content.match(/Fix:\s*([\s\S]+)/i)
+                insertError.run({
+                    symptom: symptomMatch ? symptomMatch[1].trim() : entry.title,
+                    cause: causeMatch ? causeMatch[1].trim() : "",
+                    fix: fixMatch ? fixMatch[1].trim() : "",
+                    layer: entry.layer,
+                    tags: JSON.stringify(entry.tags || []),
+                })
+                errorCount++
+            } else {
+                insertKnowledge.run({
+                    section: entry.section,
+                    title: entry.title,
+                    content: entry.content,
+                    layer: entry.layer,
+                    source: "static",
+                    tags: JSON.stringify(entry.tags || []),
+                    github_files: entry.github_files ? JSON.stringify(entry.github_files) : null,
+                })
+                knowledgeCount++
+            }
+        }
+    })
+
+    seedAll()
+
+    if (projectInfo) {
+        db.prepare(
+            `
+            INSERT OR REPLACE INTO project_context (id, repo_path, package_name, catalyst_version, detected_at)
+            VALUES (1, @repo_path, @package_name, @catalyst_version, datetime('now'))
+        `
+        ).run({
+            repo_path: projectInfo.dir,
+            package_name: projectInfo.pkg.name || "unknown",
+            catalyst_version: projectInfo.version,
+        })
+    }
+
+    return { knowledgeCount, errorCount }
+}
+
+module.exports = { seedKnowledgeBase }

--- a/packages/catalyst-core/mcp_v2/mcp.js
+++ b/packages/catalyst-core/mcp_v2/mcp.js
@@ -401,7 +401,7 @@ const TOOLS = [
     {
         name: "sync_catalyst_docs",
         description:
-            "Use when the developer asks: 'sync docs', 'update framework knowledge', 'fetch latest catalyst docs'. Intent: sync. Fetches changelog and template diffs, updates the KB. Maintenance only — no task planning needed after.",
+            "Use when the developer asks: 'sync docs', 'update framework knowledge', 'fetch latest catalyst docs'. Intent: sync. Pulls the latest knowledge-base.json from tata1mg/catalyst-core@main and re-seeds the KB. Maintenance only — no task planning needed after.",
         inputSchema: {
             type: "object",
             properties: {

--- a/packages/catalyst-core/mcp_v2/mcp.js
+++ b/packages/catalyst-core/mcp_v2/mcp.js
@@ -399,7 +399,7 @@ const TOOLS = [
         },
     },
     {
-        name: "sync_catalyst_docs",
+        name: "sync_knowledge_base",
         description:
             "Use when the developer asks: 'sync docs', 'update framework knowledge', 'fetch latest catalyst docs'. Intent: sync. Pulls the latest knowledge-base.json from tata1mg/catalyst-core@main and re-seeds the KB. Maintenance only — no task planning needed after.",
         inputSchema: {
@@ -427,7 +427,7 @@ const TOOL_HANDLERS = {
     update_task_step: tasks.handle_update_task_step,
     get_active_task: tasks.handle_get_active_task,
     close_task_plan: tasks.handle_close_task_plan,
-    sync_catalyst_docs: sync.handle_sync_catalyst_docs,
+    sync_knowledge_base: sync.handle_sync_knowledge_base,
     query_knowledge: knowledge.handle_query_knowledge,
 }
 

--- a/packages/catalyst-core/mcp_v2/setup.js
+++ b/packages/catalyst-core/mcp_v2/setup.js
@@ -8,20 +8,21 @@
  * 2. Create context.db, run schema.sql
  * 3. Seed framework_knowledge from knowledge-base.json (static rows)
  * 4. Seed known_errors from knowledge-base.json known_errors section
- * 5. Run sync_catalyst_docs once (dynamic sitemap rows)
+ * 5. Build FTS index over static rows
+ * 6. Run sync_catalyst_docs once for live sitemap rows (best-effort; warns but does not fail)
  */
 
 const fs = require("fs")
 const path = require("path")
 const Database = require("better-sqlite3")
-const https = require("https")
-const crypto = require("crypto")
+const sync = require("./tools/sync")
+const knowledge = require("./tools/knowledge")
+const { seedKnowledgeBase } = require("./lib/seed")
 
 const MCP_DIR = __dirname
 const DB_PATH = path.join(MCP_DIR, "context.db")
 const SCHEMA_PATH = path.join(MCP_DIR, "schema.sql")
 const KB_PATH = path.join(MCP_DIR, "knowledge-base.json")
-const SITEMAP_URL = "https://catalyst.1mg.com/public_docs/sitemap.xml"
 
 // ── 1. Find & validate catalyst project ──────────────────────────────────────
 
@@ -52,178 +53,13 @@ function initDb() {
 
 // ── 3 & 4. Seed from knowledge-base.json ─────────────────────────────────────
 
-function seedKnowledgeBase(db, projectInfo) {
-    const kb = JSON.parse(fs.readFileSync(KB_PATH, "utf8"))
-
-    // DELETE existing static rows so re-runs reflect updated knowledge-base.json
-    db.prepare(`DELETE FROM framework_knowledge WHERE source = 'static'`).run()
-    db.prepare(`DELETE FROM known_errors`).run()
-
-    const insertKnowledge = db.prepare(`
-    INSERT INTO framework_knowledge (section, title, content, layer, source, tags, github_files)
-    VALUES (@section, @title, @content, @layer, @source, @tags, @github_files)
-  `)
-
-    const insertError = db.prepare(`
-    INSERT INTO known_errors (symptom, cause, fix, layer, tags)
-    VALUES (@symptom, @cause, @fix, @layer, @tags)
-  `)
-
-    let knowledgeCount = 0
-    let errorCount = 0
-
-    const seedAll = db.transaction(() => {
-        for (const entry of kb) {
-            if (entry.section === "known_errors") {
-                // known_errors entries encode symptom/cause/fix in content as:
-                // "Symptom: ... Cause: ... Fix: ..."
-                const content = entry.content || ""
-                const symptomMatch = content.match(/Symptom:\s*([^.]+\.?)/i)
-                const causeMatch = content.match(/Cause:\s*([^.]+\.?)/i)
-                const fixMatch = content.match(/Fix:\s*([\s\S]+)/i)
-                insertError.run({
-                    symptom: symptomMatch ? symptomMatch[1].trim() : entry.title,
-                    cause: causeMatch ? causeMatch[1].trim() : "",
-                    fix: fixMatch ? fixMatch[1].trim() : "",
-                    layer: entry.layer,
-                    tags: JSON.stringify(entry.tags || []),
-                })
-                errorCount++
-            } else {
-                insertKnowledge.run({
-                    section: entry.section,
-                    title: entry.title,
-                    content: entry.content,
-                    layer: entry.layer,
-                    source: "static",
-                    tags: JSON.stringify(entry.tags || []),
-                    github_files: entry.github_files ? JSON.stringify(entry.github_files) : null,
-                })
-                knowledgeCount++
-            }
-        }
-    })
-
-    seedAll()
+function seedFromLocalKb(db, projectInfo) {
+    const { knowledgeCount, errorCount } = seedKnowledgeBase(db, KB_PATH, projectInfo)
     console.log(`  ✓ Seeded ${knowledgeCount} knowledge entries`)
     console.log(`  ✓ Seeded ${errorCount} known_errors entries`)
-
-    // Store project context
-    db.prepare(
-        `
-    INSERT OR REPLACE INTO project_context (id, repo_path, package_name, catalyst_version, detected_at)
-    VALUES (1, @repo_path, @package_name, @catalyst_version, datetime('now'))
-  `
-    ).run({
-        repo_path: projectInfo.dir,
-        package_name: projectInfo.pkg.name || "unknown",
-        catalyst_version: projectInfo.version,
-    })
     console.log(
         `  ✓ Project context stored (${projectInfo.pkg.name}, ${projectInfo.catalystPackageName}@${projectInfo.version})`
     )
-}
-
-// ── 5. sync_catalyst_docs (initial run) ───────────────────────────────────────
-
-function fetchUrl(url) {
-    return new Promise((resolve, reject) => {
-        const mod = url.startsWith("https") ? https : require("http")
-        mod.get(url, (res) => {
-            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-                return fetchUrl(res.headers.location).then(resolve).catch(reject)
-            }
-            let data = ""
-            res.on("data", (chunk) => (data += chunk))
-            res.on("end", () => resolve(data))
-        }).on("error", reject)
-    })
-}
-
-function parseSitemapUrls(xml) {
-    const matches = xml.match(/<loc>(.*?)<\/loc>/g) || []
-    return matches.map((m) => m.replace(/<\/?loc>/g, "").trim())
-}
-
-function stripHtml(html) {
-    // Very simple strip — good enough for catalyst docs
-    return html
-        .replace(/<script[\s\S]*?<\/script>/gi, "")
-        .replace(/<style[\s\S]*?<\/style>/gi, "")
-        .replace(/<[^>]+>/g, " ")
-        .replace(/\s+/g, " ")
-        .trim()
-}
-
-function contentHash(text) {
-    return crypto.createHash("sha256").update(text).digest("hex").slice(0, 16)
-}
-
-// Kept for manual/live sync flows; setup does not invoke it by default.
-// eslint-disable-next-line no-unused-vars
-async function syncCatalystDocs(db) {
-    console.log("\n  Fetching sitemap...")
-    let xml
-    try {
-        xml = await fetchUrl(SITEMAP_URL)
-    } catch (e) {
-        console.warn(`  ⚠ Could not fetch sitemap (${e.message}). Skipping live docs sync.`)
-        console.warn("    You can run sync later via the sync_catalyst_docs MCP tool.")
-        return
-    }
-
-    const urls = parseSitemapUrls(xml)
-    console.log(`  Found ${urls.length} URLs in sitemap`)
-
-    const insertKnowledge = db.prepare(`
-    INSERT INTO framework_knowledge (section, title, content, layer, source, tags, url)
-    VALUES (@section, @title, @content, @layer, 'sitemap', '[]', @url)
-  `)
-
-    const insertSnapshot = db.prepare(`
-    INSERT INTO doc_snapshots (url, content_hash, slot) VALUES (@url, @hash, 'curr')
-  `)
-
-    const insertLink = db.prepare(`
-    INSERT INTO linkage_map (url, knowledge_id) VALUES (@url, @knowledge_id)
-  `)
-
-    let synced = 0
-    let failed = 0
-
-    for (const url of urls) {
-        try {
-            const html = await fetchUrl(url)
-            const text = stripHtml(html)
-            const hash = contentHash(text)
-
-            // Extract a title from <title> tag if present
-            const titleMatch = html.match(/<title[^>]*>(.*?)<\/title>/i)
-            const title = titleMatch ? titleMatch[1].trim() : url.split("/").pop() || url
-
-            // Truncate content to 2000 chars to keep DB lean
-            const content = text.slice(0, 2000)
-
-            db.transaction(() => {
-                const row = insertKnowledge.run({
-                    section: "sitemap",
-                    title,
-                    content,
-                    layer: "Component",
-                    url,
-                })
-                insertSnapshot.run({ url, hash })
-                insertLink.run({ url, knowledge_id: row.lastInsertRowid })
-            })()
-
-            synced++
-            process.stdout.write(`\r  Synced ${synced}/${urls.length} pages...`)
-        } catch (e) {
-            failed++
-        }
-    }
-
-    console.log(`\n  ✓ Synced ${synced} pages (${failed} failed)`)
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -248,11 +84,44 @@ async function main() {
 
     // 3 & 4. Seed static knowledge
     console.log("\nSeeding knowledge-base.json...")
-    seedKnowledgeBase(db, projectInfo)
+    seedFromLocalKb(db, projectInfo)
 
-    // 5. Initial sitemap sync — disabled (slow, use sync_catalyst_docs MCP tool manually)
-    // console.log('\nRunning initial sync_catalyst_docs...');
-    // await syncCatalystDocs(db);
+    // 5. Build FTS index from the just-seeded static rows.
+    //    DROP first so re-runs of setup don't leave orphan rowids pointing at deleted rows.
+    db.exec(`DROP TABLE IF EXISTS fk_fts`)
+    knowledge.init(db)
+
+    // 6. Initial sync — pulls knowledge-base.json from tata1mg/catalyst-core@main, then
+    //    fetches the catalyst.1mg.com sitemap. Failures are warnings, not setup-blockers
+    //    (network may be unavailable at install time).
+    console.log("\nSyncing knowledge-base.json from tata1mg/catalyst-core@main and live docs...")
+    sync.init(db)
+    try {
+        const result = await sync.handle_sync_catalyst_docs({})
+        const kb = result.knowledge_base
+        if (kb) {
+            if (kb.error) {
+                console.warn(`  ⚠ knowledge-base.json: ${kb.error}`)
+            } else if (kb.kb_changed) {
+                console.log(`  ✓ knowledge-base.json: ${kb.message}`)
+            } else {
+                console.log(`  ✓ knowledge-base.json: ${kb.message}`)
+            }
+        }
+        if (result.error) {
+            console.warn(`  ⚠ ${result.message}`)
+            console.warn("    Run sync_catalyst_docs later via your MCP client to retry.")
+        } else {
+            console.log(`  ✓ ${result.message}`)
+            if (result.failed > 0 && result.errors.length) {
+                const sample = result.errors.slice(0, 3).map((e) => `${e.url} (${e.error})`)
+                console.warn(`    ${result.failed} URL(s) failed. First: ${sample.join("; ")}`)
+            }
+        }
+    } catch (e) {
+        console.warn(`  ⚠ Sync threw: ${e.message}`)
+        console.warn("    Run sync_catalyst_docs later via your MCP client to retry.")
+    }
 
     db.close()
     console.log("\n✓ Setup complete. MCP is ready.\n")

--- a/packages/catalyst-core/mcp_v2/setup.js
+++ b/packages/catalyst-core/mcp_v2/setup.js
@@ -96,16 +96,16 @@ async function main() {
     console.log("\nSyncing knowledge-base.json from tata1mg/catalyst-core@main...")
     sync.init(db)
     try {
-        const result = await sync.handle_sync_catalyst_docs({})
+        const result = await sync.handle_sync_knowledge_base({})
         if (result.error) {
             console.warn(`  ⚠ ${result.error}`)
-            console.warn("    Run sync_catalyst_docs later via your MCP client to retry.")
+            console.warn("    Run sync_knowledge_base later via your MCP client to retry.")
         } else {
             console.log(`  ✓ ${result.message}`)
         }
     } catch (e) {
         console.warn(`  ⚠ Sync threw: ${e.message}`)
-        console.warn("    Run sync_catalyst_docs later via your MCP client to retry.")
+        console.warn("    Run sync_knowledge_base later via your MCP client to retry.")
     }
 
     db.close()

--- a/packages/catalyst-core/mcp_v2/setup.js
+++ b/packages/catalyst-core/mcp_v2/setup.js
@@ -9,7 +9,7 @@
  * 3. Seed framework_knowledge from knowledge-base.json (static rows)
  * 4. Seed known_errors from knowledge-base.json known_errors section
  * 5. Build FTS index over static rows
- * 6. Run sync_catalyst_docs once for live sitemap rows (best-effort; warns but does not fail)
+ * 6. Sync knowledge-base.json from tata1mg/catalyst-core@main (best-effort; warns but does not fail)
  */
 
 const fs = require("fs")
@@ -91,32 +91,17 @@ async function main() {
     db.exec(`DROP TABLE IF EXISTS fk_fts`)
     knowledge.init(db)
 
-    // 6. Initial sync — pulls knowledge-base.json from tata1mg/catalyst-core@main, then
-    //    fetches the catalyst.1mg.com sitemap. Failures are warnings, not setup-blockers
-    //    (network may be unavailable at install time).
-    console.log("\nSyncing knowledge-base.json from tata1mg/catalyst-core@main and live docs...")
+    // 6. Initial sync — pulls knowledge-base.json from tata1mg/catalyst-core@main.
+    //    Failures are warnings, not setup-blockers (network may be unavailable at install time).
+    console.log("\nSyncing knowledge-base.json from tata1mg/catalyst-core@main...")
     sync.init(db)
     try {
         const result = await sync.handle_sync_catalyst_docs({})
-        const kb = result.knowledge_base
-        if (kb) {
-            if (kb.error) {
-                console.warn(`  ⚠ knowledge-base.json: ${kb.error}`)
-            } else if (kb.kb_changed) {
-                console.log(`  ✓ knowledge-base.json: ${kb.message}`)
-            } else {
-                console.log(`  ✓ knowledge-base.json: ${kb.message}`)
-            }
-        }
         if (result.error) {
-            console.warn(`  ⚠ ${result.message}`)
+            console.warn(`  ⚠ ${result.error}`)
             console.warn("    Run sync_catalyst_docs later via your MCP client to retry.")
         } else {
             console.log(`  ✓ ${result.message}`)
-            if (result.failed > 0 && result.errors.length) {
-                const sample = result.errors.slice(0, 3).map((e) => `${e.url} (${e.error})`)
-                console.warn(`    ${result.failed} URL(s) failed. First: ${sample.join("; ")}`)
-            }
         }
     } catch (e) {
         console.warn(`  ⚠ Sync threw: ${e.message}`)

--- a/packages/catalyst-core/mcp_v2/tools/sync.js
+++ b/packages/catalyst-core/mcp_v2/tools/sync.js
@@ -1,22 +1,345 @@
 "use strict"
 
+const fs = require("fs")
+const path = require("path")
+const https = require("https")
+const http = require("http")
+const crypto = require("crypto")
+const { URL } = require("url")
+
+const { seedKnowledgeBase } = require("../lib/seed")
+const knowledge = require("./knowledge")
+
+const SITEMAP_URL = "https://catalyst.1mg.com/public_docs/sitemap.xml"
+const SITEMAP_HOST = "catalyst.1mg.com"
+const KB_GITHUB_URL =
+    "https://raw.githubusercontent.com/tata1mg/catalyst-core/main/mcp_v2/knowledge-base.json"
+const GITHUB_RAW_HOST = "raw.githubusercontent.com"
+const KB_PATH = path.join(__dirname, "..", "knowledge-base.json")
+const MAX_BYTES = 512 * 1024
+const KB_MAX_BYTES = 4 * 1024 * 1024
+const MAX_REDIRECTS = 5
+const SOCKET_TIMEOUT_MS = 15_000
+const CONTENT_TRUNCATE = 2000
+const MAX_ERRORS_RETURNED = 20
+
 let _db
 
 function init(db) {
     _db = db
 }
 
-function handle_sync_catalyst_docs({ force = false } = {}) {
-    const snapshot_count = _db.prepare(`SELECT COUNT(*) as c FROM doc_snapshots`).get()
-    const knowledge_count = _db
-        .prepare(`SELECT COUNT(*) as c FROM framework_knowledge WHERE source = 'sitemap'`)
-        .get()
+function fetchUrl(url, opts = {}) {
+    const {
+        allowedHost = SITEMAP_HOST,
+        maxBytes = MAX_BYTES,
+        redirectsLeft = MAX_REDIRECTS,
+    } = opts
+    return new Promise((resolve, reject) => {
+        let parsed
+        try {
+            parsed = new URL(url)
+        } catch {
+            return reject(new Error(`Invalid URL: ${url}`))
+        }
+        if (parsed.hostname !== allowedHost) {
+            return reject(new Error(`Refusing off-host fetch: ${parsed.hostname}`))
+        }
+        if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+            return reject(new Error(`Unsupported protocol: ${parsed.protocol}`))
+        }
+        const mod = parsed.protocol === "https:" ? https : http
+        const req = mod.get(
+            url,
+            { headers: { "User-Agent": "catalyst-mcp/2.0 sync_catalyst_docs" } },
+            (res) => {
+                if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                    res.resume()
+                    if (redirectsLeft <= 0) return reject(new Error("Too many redirects"))
+                    let next
+                    try {
+                        next = new URL(res.headers.location, url).toString()
+                    } catch {
+                        return reject(new Error(`Invalid redirect target: ${res.headers.location}`))
+                    }
+                    return fetchUrl(next, {
+                        allowedHost,
+                        maxBytes,
+                        redirectsLeft: redirectsLeft - 1,
+                    }).then(resolve, reject)
+                }
+                if (res.statusCode !== 200) {
+                    res.resume()
+                    return reject(new Error(`HTTP ${res.statusCode}`))
+                }
+                let bytes = 0
+                const chunks = []
+                res.on("data", (chunk) => {
+                    bytes += chunk.length
+                    if (bytes > maxBytes) {
+                        req.destroy(new Error(`Response exceeded ${maxBytes} bytes`))
+                        return
+                    }
+                    chunks.push(chunk)
+                })
+                res.on("end", () => {
+                    if (bytes > maxBytes) return
+                    resolve(Buffer.concat(chunks).toString("utf8"))
+                })
+                res.on("error", reject)
+            }
+        )
+        req.setTimeout(SOCKET_TIMEOUT_MS, () => {
+            req.destroy(new Error(`Socket idle timeout after ${SOCKET_TIMEOUT_MS}ms`))
+        })
+        req.on("error", reject)
+    })
+}
+
+function decodeXmlEntities(s) {
+    return s
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+}
+
+function parseSitemapUrls(xml) {
+    const matches = xml.match(/<loc>([\s\S]*?)<\/loc>/g) || []
+    return matches
+        .map((m) => decodeXmlEntities(m.replace(/<\/?loc>/g, "").trim()))
+        .filter(Boolean)
+}
+
+function stripHtml(html) {
+    return html
+        .replace(/<script[\s\S]*?<\/script>/gi, "")
+        .replace(/<style[\s\S]*?<\/style>/gi, "")
+        .replace(/<[^>]+>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+}
+
+function contentHash(text) {
+    return crypto.createHash("sha256").update(text).digest("hex").slice(0, 16)
+}
+
+function extractTitle(html, url) {
+    const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
+    if (m && m[1].trim()) return decodeXmlEntities(m[1].trim()).slice(0, 200)
+    return url.split("/").filter(Boolean).pop() || url
+}
+
+async function syncKnowledgeBaseFromGithub({ force = false } = {}) {
+    let remoteText
+    try {
+        remoteText = await fetchUrl(KB_GITHUB_URL, {
+            allowedHost: GITHUB_RAW_HOST,
+            maxBytes: KB_MAX_BYTES,
+        })
+    } catch (e) {
+        return { kb_changed: false, kb_url: KB_GITHUB_URL, error: `kb_fetch_failed: ${e.message}` }
+    }
+
+    let parsed
+    try {
+        parsed = JSON.parse(remoteText)
+    } catch (e) {
+        return { kb_changed: false, kb_url: KB_GITHUB_URL, error: `kb_invalid_json: ${e.message}` }
+    }
+    if (!Array.isArray(parsed)) {
+        return {
+            kb_changed: false,
+            kb_url: KB_GITHUB_URL,
+            error: "kb_invalid_format: expected JSON array at the top level",
+        }
+    }
+
+    const remoteHash = contentHash(remoteText)
+    let localHash = null
+    if (fs.existsSync(KB_PATH)) {
+        try {
+            localHash = contentHash(fs.readFileSync(KB_PATH, "utf8"))
+        } catch {
+            localHash = null
+        }
+    }
+
+    if (!force && localHash === remoteHash) {
+        return {
+            kb_changed: false,
+            kb_url: KB_GITHUB_URL,
+            kb_hash: remoteHash,
+            message: "knowledge-base.json already in sync with main branch.",
+        }
+    }
+
+    const tmpPath = `${KB_PATH}.tmp.${process.pid}`
+    try {
+        fs.writeFileSync(tmpPath, remoteText)
+        fs.renameSync(tmpPath, KB_PATH)
+    } catch (e) {
+        try {
+            if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath)
+        } catch {
+            // ignore cleanup failure
+        }
+        return { kb_changed: false, kb_url: KB_GITHUB_URL, error: `kb_write_failed: ${e.message}` }
+    }
+
+    let counts
+    try {
+        counts = seedKnowledgeBase(_db, KB_PATH)
+        // Rebuild fk_fts so rowids match the freshly-inserted framework_knowledge ids
+        // (sitemap rows already in framework_knowledge are repopulated by knowledge.init).
+        _db.exec(`DROP TABLE IF EXISTS fk_fts`)
+        knowledge.init(_db)
+    } catch (e) {
+        return {
+            kb_changed: true,
+            kb_url: KB_GITHUB_URL,
+            kb_hash: remoteHash,
+            error: `kb_reseed_failed: ${e.message}`,
+            message: "knowledge-base.json written to disk but DB re-seed failed.",
+        }
+    }
+
     return {
-        _phase: 6,
+        kb_changed: true,
+        kb_url: KB_GITHUB_URL,
+        kb_hash: remoteHash,
+        kb_knowledge_count: counts.knowledgeCount,
+        kb_error_count: counts.errorCount,
+        message: "knowledge-base.json updated from main branch and re-seeded into context.db.",
+    }
+}
+
+async function handle_sync_catalyst_docs({ force = false } = {}) {
+    const knowledge_base = await syncKnowledgeBaseFromGithub({ force })
+
+    let xml
+    try {
+        xml = await fetchUrl(SITEMAP_URL)
+    } catch (e) {
+        return {
+            error: "sitemap_fetch_failed",
+            sitemap_url: SITEMAP_URL,
+            knowledge_base,
+            message: `Could not fetch sitemap: ${e.message}`,
+        }
+    }
+
+    const urls = parseSitemapUrls(xml)
+    if (urls.length === 0) {
+        return {
+            error: "empty_sitemap",
+            sitemap_url: SITEMAP_URL,
+            knowledge_base,
+            message: "Sitemap parsed but contained no <loc> entries.",
+        }
+    }
+
+    const getCurr = _db.prepare(
+        `SELECT id, content_hash FROM doc_snapshots WHERE url = ? AND slot = 'curr'`
+    )
+    const deletePrev = _db.prepare(`DELETE FROM doc_snapshots WHERE url = ? AND slot = 'prev'`)
+    const promoteCurr = _db.prepare(
+        `UPDATE doc_snapshots SET slot = 'prev' WHERE url = ? AND slot = 'curr'`
+    )
+    const insertCurr = _db.prepare(
+        `INSERT INTO doc_snapshots (url, content_hash, slot) VALUES (?, ?, 'curr')`
+    )
+    const getLinked = _db.prepare(`SELECT knowledge_id FROM linkage_map WHERE url = ?`)
+    const insertKnowledge = _db.prepare(`
+        INSERT INTO framework_knowledge (section, title, content, layer, source, tags, url)
+        VALUES ('sitemap', ?, ?, 'Component', 'sitemap', '[]', ?)
+    `)
+    const updateKnowledge = _db.prepare(`
+        UPDATE framework_knowledge
+        SET title = ?, content = ?, last_updated = datetime('now')
+        WHERE id = ?
+    `)
+    const insertLink = _db.prepare(`INSERT INTO linkage_map (url, knowledge_id) VALUES (?, ?)`)
+    const insertFts = _db.prepare(
+        `INSERT INTO fk_fts(rowid, title, content, tags, section) VALUES (?, ?, ?, '', 'sitemap')`
+    )
+    const updateFts = _db.prepare(`UPDATE fk_fts SET title = ?, content = ? WHERE rowid = ?`)
+
+    let fetched = 0
+    let changed = 0
+    let unchanged = 0
+    let failed = 0
+    const errors = []
+
+    for (const url of urls) {
+        let html
+        try {
+            html = await fetchUrl(url)
+        } catch (e) {
+            failed++
+            if (errors.length < MAX_ERRORS_RETURNED) errors.push({ url, error: e.message })
+            continue
+        }
+        fetched++
+
+        const text = stripHtml(html)
+        const hash = contentHash(text)
+        const prior = getCurr.get(url)
+
+        if (!force && prior && prior.content_hash === hash) {
+            unchanged++
+            continue
+        }
+
+        const title = extractTitle(html, url)
+        const content = text.slice(0, CONTENT_TRUNCATE)
+
+        const upsert = _db.transaction(() => {
+            deletePrev.run(url)
+            if (prior) promoteCurr.run(url)
+            insertCurr.run(url, hash)
+
+            const linked = getLinked.all(url)
+            if (linked.length > 0) {
+                for (const link of linked) {
+                    updateKnowledge.run(title, content, link.knowledge_id)
+                    updateFts.run(title, content, link.knowledge_id)
+                }
+            } else {
+                const result = insertKnowledge.run(title, content, url)
+                const newId = Number(result.lastInsertRowid)
+                insertLink.run(url, newId)
+                insertFts.run(newId, title, content)
+            }
+        })
+
+        try {
+            upsert()
+            changed++
+        } catch (e) {
+            failed++
+            if (errors.length < MAX_ERRORS_RETURNED) {
+                errors.push({ url, error: `db_upsert_failed: ${e.message}` })
+            }
+        }
+    }
+
+    return {
+        synced_at: new Date().toISOString(),
+        sitemap_url: SITEMAP_URL,
         force,
-        existing_snapshots: snapshot_count.c,
-        sitemap_knowledge_rows: knowledge_count.c,
-        message: "Live sync not yet implemented (Phase 6). Run setup.js for initial sync.",
+        total_urls: urls.length,
+        fetched,
+        changed,
+        unchanged,
+        failed,
+        errors,
+        knowledge_base,
+        message:
+            failed === 0
+                ? `Synced ${changed} changed, ${unchanged} unchanged of ${urls.length} URLs.`
+                : `Synced ${changed} changed, ${unchanged} unchanged, ${failed} failed of ${urls.length} URLs.`,
     }
 }
 

--- a/packages/catalyst-core/mcp_v2/tools/sync.js
+++ b/packages/catalyst-core/mcp_v2/tools/sync.js
@@ -13,7 +13,7 @@ const knowledge = require("./knowledge")
 const SITEMAP_URL = "https://catalyst.1mg.com/public_docs/sitemap.xml"
 const SITEMAP_HOST = "catalyst.1mg.com"
 const KB_GITHUB_URL =
-    "https://raw.githubusercontent.com/tata1mg/catalyst-core/main/mcp_v2/knowledge-base.json"
+    "https://raw.githubusercontent.com/tata1mg/catalyst-core/main/packages/catalyst-core/mcp_v2/knowledge-base.json"
 const GITHUB_RAW_HOST = "raw.githubusercontent.com"
 const KB_PATH = path.join(__dirname, "..", "knowledge-base.json")
 const MAX_BYTES = 512 * 1024

--- a/packages/catalyst-core/mcp_v2/tools/sync.js
+++ b/packages/catalyst-core/mcp_v2/tools/sync.js
@@ -10,18 +10,13 @@ const { URL } = require("url")
 const { seedKnowledgeBase } = require("../lib/seed")
 const knowledge = require("./knowledge")
 
-const SITEMAP_URL = "https://catalyst.1mg.com/public_docs/sitemap.xml"
-const SITEMAP_HOST = "catalyst.1mg.com"
 const KB_GITHUB_URL =
     "https://raw.githubusercontent.com/tata1mg/catalyst-core/main/packages/catalyst-core/mcp_v2/knowledge-base.json"
 const GITHUB_RAW_HOST = "raw.githubusercontent.com"
 const KB_PATH = path.join(__dirname, "..", "knowledge-base.json")
-const MAX_BYTES = 512 * 1024
 const KB_MAX_BYTES = 4 * 1024 * 1024
 const MAX_REDIRECTS = 5
 const SOCKET_TIMEOUT_MS = 15_000
-const CONTENT_TRUNCATE = 2000
-const MAX_ERRORS_RETURNED = 20
 
 let _db
 
@@ -31,8 +26,8 @@ function init(db) {
 
 function fetchUrl(url, opts = {}) {
     const {
-        allowedHost = SITEMAP_HOST,
-        maxBytes = MAX_BYTES,
+        allowedHost = GITHUB_RAW_HOST,
+        maxBytes = KB_MAX_BYTES,
         redirectsLeft = MAX_REDIRECTS,
     } = opts
     return new Promise((resolve, reject) => {
@@ -96,39 +91,8 @@ function fetchUrl(url, opts = {}) {
     })
 }
 
-function decodeXmlEntities(s) {
-    return s
-        .replace(/&amp;/g, "&")
-        .replace(/&lt;/g, "<")
-        .replace(/&gt;/g, ">")
-        .replace(/&quot;/g, '"')
-        .replace(/&apos;/g, "'")
-}
-
-function parseSitemapUrls(xml) {
-    const matches = xml.match(/<loc>([\s\S]*?)<\/loc>/g) || []
-    return matches
-        .map((m) => decodeXmlEntities(m.replace(/<\/?loc>/g, "").trim()))
-        .filter(Boolean)
-}
-
-function stripHtml(html) {
-    return html
-        .replace(/<script[\s\S]*?<\/script>/gi, "")
-        .replace(/<style[\s\S]*?<\/style>/gi, "")
-        .replace(/<[^>]+>/g, " ")
-        .replace(/\s+/g, " ")
-        .trim()
-}
-
 function contentHash(text) {
     return crypto.createHash("sha256").update(text).digest("hex").slice(0, 16)
-}
-
-function extractTitle(html, url) {
-    const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
-    if (m && m[1].trim()) return decodeXmlEntities(m[1].trim()).slice(0, 200)
-    return url.split("/").filter(Boolean).pop() || url
 }
 
 async function syncKnowledgeBaseFromGithub({ force = false } = {}) {
@@ -191,8 +155,7 @@ async function syncKnowledgeBaseFromGithub({ force = false } = {}) {
     let counts
     try {
         counts = seedKnowledgeBase(_db, KB_PATH)
-        // Rebuild fk_fts so rowids match the freshly-inserted framework_knowledge ids
-        // (sitemap rows already in framework_knowledge are repopulated by knowledge.init).
+        // Rebuild fk_fts so rowids match the freshly-inserted framework_knowledge ids.
         _db.exec(`DROP TABLE IF EXISTS fk_fts`)
         knowledge.init(_db)
     } catch (e) {
@@ -217,129 +180,16 @@ async function syncKnowledgeBaseFromGithub({ force = false } = {}) {
 
 async function handle_sync_catalyst_docs({ force = false } = {}) {
     const knowledge_base = await syncKnowledgeBaseFromGithub({ force })
-
-    let xml
-    try {
-        xml = await fetchUrl(SITEMAP_URL)
-    } catch (e) {
-        return {
-            error: "sitemap_fetch_failed",
-            sitemap_url: SITEMAP_URL,
-            knowledge_base,
-            message: `Could not fetch sitemap: ${e.message}`,
-        }
-    }
-
-    const urls = parseSitemapUrls(xml)
-    if (urls.length === 0) {
-        return {
-            error: "empty_sitemap",
-            sitemap_url: SITEMAP_URL,
-            knowledge_base,
-            message: "Sitemap parsed but contained no <loc> entries.",
-        }
-    }
-
-    const getCurr = _db.prepare(
-        `SELECT id, content_hash FROM doc_snapshots WHERE url = ? AND slot = 'curr'`
-    )
-    const deletePrev = _db.prepare(`DELETE FROM doc_snapshots WHERE url = ? AND slot = 'prev'`)
-    const promoteCurr = _db.prepare(
-        `UPDATE doc_snapshots SET slot = 'prev' WHERE url = ? AND slot = 'curr'`
-    )
-    const insertCurr = _db.prepare(
-        `INSERT INTO doc_snapshots (url, content_hash, slot) VALUES (?, ?, 'curr')`
-    )
-    const getLinked = _db.prepare(`SELECT knowledge_id FROM linkage_map WHERE url = ?`)
-    const insertKnowledge = _db.prepare(`
-        INSERT INTO framework_knowledge (section, title, content, layer, source, tags, url)
-        VALUES ('sitemap', ?, ?, 'Component', 'sitemap', '[]', ?)
-    `)
-    const updateKnowledge = _db.prepare(`
-        UPDATE framework_knowledge
-        SET title = ?, content = ?, last_updated = datetime('now')
-        WHERE id = ?
-    `)
-    const insertLink = _db.prepare(`INSERT INTO linkage_map (url, knowledge_id) VALUES (?, ?)`)
-    const insertFts = _db.prepare(
-        `INSERT INTO fk_fts(rowid, title, content, tags, section) VALUES (?, ?, ?, '', 'sitemap')`
-    )
-    const updateFts = _db.prepare(`UPDATE fk_fts SET title = ?, content = ? WHERE rowid = ?`)
-
-    let fetched = 0
-    let changed = 0
-    let unchanged = 0
-    let failed = 0
-    const errors = []
-
-    for (const url of urls) {
-        let html
-        try {
-            html = await fetchUrl(url)
-        } catch (e) {
-            failed++
-            if (errors.length < MAX_ERRORS_RETURNED) errors.push({ url, error: e.message })
-            continue
-        }
-        fetched++
-
-        const text = stripHtml(html)
-        const hash = contentHash(text)
-        const prior = getCurr.get(url)
-
-        if (!force && prior && prior.content_hash === hash) {
-            unchanged++
-            continue
-        }
-
-        const title = extractTitle(html, url)
-        const content = text.slice(0, CONTENT_TRUNCATE)
-
-        const upsert = _db.transaction(() => {
-            deletePrev.run(url)
-            if (prior) promoteCurr.run(url)
-            insertCurr.run(url, hash)
-
-            const linked = getLinked.all(url)
-            if (linked.length > 0) {
-                for (const link of linked) {
-                    updateKnowledge.run(title, content, link.knowledge_id)
-                    updateFts.run(title, content, link.knowledge_id)
-                }
-            } else {
-                const result = insertKnowledge.run(title, content, url)
-                const newId = Number(result.lastInsertRowid)
-                insertLink.run(url, newId)
-                insertFts.run(newId, title, content)
-            }
-        })
-
-        try {
-            upsert()
-            changed++
-        } catch (e) {
-            failed++
-            if (errors.length < MAX_ERRORS_RETURNED) {
-                errors.push({ url, error: `db_upsert_failed: ${e.message}` })
-            }
-        }
-    }
-
     return {
         synced_at: new Date().toISOString(),
-        sitemap_url: SITEMAP_URL,
         force,
-        total_urls: urls.length,
-        fetched,
-        changed,
-        unchanged,
-        failed,
-        errors,
         knowledge_base,
+        error: knowledge_base.error || null,
         message:
-            failed === 0
-                ? `Synced ${changed} changed, ${unchanged} unchanged of ${urls.length} URLs.`
-                : `Synced ${changed} changed, ${unchanged} unchanged, ${failed} failed of ${urls.length} URLs.`,
+            knowledge_base.message ||
+            (knowledge_base.error
+                ? `knowledge-base.json sync failed: ${knowledge_base.error}`
+                : "knowledge-base.json sync complete."),
     }
 }
 

--- a/packages/catalyst-core/mcp_v2/tools/sync.js
+++ b/packages/catalyst-core/mcp_v2/tools/sync.js
@@ -46,7 +46,7 @@ function fetchUrl(url, opts = {}) {
         const mod = parsed.protocol === "https:" ? https : http
         const req = mod.get(
             url,
-            { headers: { "User-Agent": "catalyst-mcp/2.0 sync_catalyst_docs" } },
+            { headers: { "User-Agent": "catalyst-mcp/2.0 sync_knowledge_base" } },
             (res) => {
                 if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
                     res.resume()
@@ -178,7 +178,7 @@ async function syncKnowledgeBaseFromGithub({ force = false } = {}) {
     }
 }
 
-async function handle_sync_catalyst_docs({ force = false } = {}) {
+async function handle_sync_knowledge_base({ force = false } = {}) {
     const knowledge_base = await syncKnowledgeBaseFromGithub({ force })
     return {
         synced_at: new Date().toISOString(),
@@ -193,4 +193,4 @@ async function handle_sync_catalyst_docs({ force = false } = {}) {
     }
 }
 
-module.exports = { init, handle_sync_catalyst_docs }
+module.exports = { init, handle_sync_knowledge_base }


### PR DESCRIPTION
Re-implements the stale sync-mcp branch on the current monorepo layout (it diverged before #228 moved mcp_v2/ under packages/catalyst-core/). setup.js pulls the latest knowledge-base.json at install time, builds an FTS index, and shares seeding logic with the sync_catalyst_docs tool.

Changes

- lib/seed.js (new) — reusable seedKnowledgeBase shared by setup and sync.
- setup.js — delegates seeding, builds fk_fts, runs a best-effort KB sync (warns, never fails, on network errors).
- tools/sync.js — sync_catalyst_docs pulls knowledge-base.json from main and re-seeds the KB (hash-gated, atomic write, FTS rebuild). Corrected the GitHub raw URL to the monorepo path.