### PR TITLE
fix: stabilize publish workflow npm version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ on:
                 required: true
                 type: boolean
                 default: false
+            release_pr_number:
+                description: "Release PR number override for release automation"
+                required: false
+                type: string
+                default: ""
     push:
         branches:
             - main
@@ -337,7 +342,7 @@ jobs:
 
             - name: Update npm for OIDC support
               if: steps.context.outputs.should_run == 'true' && steps.context.outputs.dry_run != 'true'
-              run: npm install -g npm@latest
+              run: npm install -g npm@10
 
             - name: Publish catalyst-core to npm
               id: publish_core
@@ -443,11 +448,21 @@ jobs:
               if: success() && steps.context.outputs.should_run == 'true' && steps.context.outputs.publish_core == 'true' && steps.context.outputs.dry_run != 'true'
               env:
                   GH_TOKEN: ${{ github.token }}
+                  INPUT_RELEASE_PR_NUMBER: ${{ inputs.release_pr_number }}
               run: |
-                  PR_NUMBER=$(gh api \
-                    -H "Accept: application/vnd.github+json" \
-                    "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
-                    --jq '.[0].number // ""' 2>/dev/null || true)
+                  PR_NUMBER="$INPUT_RELEASE_PR_NUMBER"
+
+                  if [ -n "$PR_NUMBER" ] && ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+                    echo "::error::release_pr_number must be numeric when provided"
+                    exit 1
+                  fi
+
+                  if [ -z "$PR_NUMBER" ]; then
+                    PR_NUMBER=$(gh api \
+                      -H "Accept: application/vnd.github+json" \
+                      "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+                      --jq '.[0].number // ""' 2>/dev/null || true)
+                  fi
 
                   if [ -z "$PR_NUMBER" ]; then
                     echo "::error::Could not resolve pull request number for commit $GITHUB_SHA"


### PR DESCRIPTION
**PR Summary**

Fixes the publish workflow failure caused by `npm@latest` requiring a newer Node version than the workflow’s pinned Node 20 runtime.

**Changes**

- Pins the publish workflow npm upgrade from `npm@latest` to `npm@10`.
- Adds optional `release_pr_number` input for manual publish runs.
- Uses `release_pr_number` for release automation when provided.
- Falls back to existing commit-to-PR lookup when the input is omitted.
- Validates that `release_pr_number` is numeric when supplied.

**Why**

`npm@latest` now resolves to npm 12, which requires Node 22.22.2+ and fails on the current Node 20 GitHub runner with `EBADENGINE`.

The optional PR override lets us manually rerun publish for an already-merged release while still attaching release automation to the original feature PR instead of this workflow hotfix PR.