### PR TITLE
fix(ssr): surface response stream errors in logs and OTel traces

### DIFF
--- a/packages/catalyst-core/src/otel.js
+++ b/packages/catalyst-core/src/otel.js
@@ -295,6 +295,33 @@ export function withObservability(serviceName, fn, name) {
 }
 
 /**
+ * Creates a recorder for out-of-band response stream errors.
+ *
+ * Stream errors (e.g. Node's ERR_STREAM_WRITE_AFTER_END) surface on the
+ * response object's "error" event, typically after the span that performed
+ * the offending write has already ended, so recording the exception on the
+ * active span at error time would be silently dropped. Instead, capture the
+ * ambient context while the request span is still active and emit a dedicated
+ * error span into the same trace for each stream error (the same parenting
+ * approach responseFlushMiddleware uses for its post-end spans).
+ *
+ * @param {string} serviceName - The name of the service
+ * @param {string} name - Span name (optional)
+ * @returns {Function} (error) => void, safe to call after the request span ended
+ */
+export function createStreamErrorRecorder(serviceName, name = "responseStreamError") {
+    const tracer = trace.getTracer(serviceName)
+    const parentContext = context.active()
+    return function recordStreamError(error) {
+        const span = tracer.startSpan(name, undefined, parentContext)
+        if (error && error.code) span.setAttribute("error.type", String(error.code))
+        span.recordException(error)
+        span.setStatus({ code: 2, message: error && error.message ? error.message : String(error) })
+        span.end()
+    }
+}
+
+/**
  * Express middleware that emits two spans describing what happens to the
  * response body AFTER the app calls res.end() — the work that lives past the
  * `handler` span and makes the HTTP server span run longer:
@@ -398,4 +425,10 @@ export function responseFlushMiddleware(
     }
 }
 
-export default { init, withObservability, withSyncObservability, responseFlushMiddleware }
+export default {
+    init,
+    withObservability,
+    withSyncObservability,
+    responseFlushMiddleware,
+    createStreamErrorRecorder,
+}

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -91,12 +91,14 @@ try {
 // Passthrough no-ops used when OTEL_ENABLE is not set; replaced below if enabled.
 let withObservability = (_service, fn) => fn
 let withSyncObservability = (_service, fn) => fn
+let createStreamErrorRecorder = null
 
 if (process.env.OTEL_ENABLE === true) {
     try {
         const otel = await import("../../otel.js")
         withObservability = otel.withObservability
         withSyncObservability = otel.withSyncObservability
+        createStreamErrorRecorder = otel.createStreamErrorRecorder
     } catch {
         // otel packages not installed — continue without tracing
     }
@@ -144,6 +146,26 @@ const getComponent = (store, context, req, fetcherData, isBot) => (
 )
 
 // ── Render and stream ──────────────────────────────────────────────────
+// Responses that already have a stream-error listener attached. Guarded via
+// WeakSet because renderMarkUp can run twice for one response (the fetcher
+// error path re-renders with a 404) and "error" listeners must not stack.
+const _observedResponses = new WeakSet()
+
+// Node swallows response stream errors (e.g. ERR_STREAM_WRITE_AFTER_END) when
+// res has no "error" listener: the write is dropped, nothing is logged, and a
+// truncated document ships silently. Log every stream error and, when tracing
+// is enabled, record it as an error span in the request's trace. Must be
+// called while the request span is still active so the span parents correctly.
+const observeResponseStreamErrors = (req, res) => {
+    if (_observedResponses.has(res)) return
+    _observedResponses.add(res)
+    const recordStreamError = createStreamErrorRecorder ? createStreamErrorRecorder(SSR_SERVICE) : null
+    res.on("error", (error) => {
+        console.error(`Response stream error while streaming SSR for ${req.originalUrl}:`, error)
+        if (recordStreamError) recordStreamError(error)
+    })
+}
+
 const _renderMarkUp = async (
     errorCode,
     req,
@@ -240,6 +262,7 @@ const _renderMarkUp = async (
         const status = errorCode || (allMatches.length && allMatches[0]?.route?.path === "*" ? 404 : 200)
         res.set({ "content-type": "text/html; charset=utf-8" })
         res.status(status)
+        observeResponseStreamErrors(req, res)
 
         return new Promise((resolve, reject) => {
             const { pipe } = renderToPipeableStream(<CompleteDocument />, {


### PR DESCRIPTION
## Summary

Makes response stream errors during SSR streaming observable. Today they are invisible: Node swallows errors like `ERR_STREAM_WRITE_AFTER_END` when the response has no `error` listener, so the write is dropped, nothing is logged anywhere, and a truncated document ships silently. That silence is exactly how the streaming race in #320 went unnoticed (every SSR response on react-dom 19 currently loses React's closing `</body></html>` chunk with a swallowed write-after-end on every request).

This PR is observability only. It does not fix the race (#320 tracks that); it makes the failure, and any future response stream error, impossible to miss in logs and traces.

## What changed

**`src/server/renderer/handler.jsx`**
- `renderMarkUp` now attaches a single `error` listener to `res` before streaming starts. Every stream error is logged with the request URL:

  ```
  Response stream error while streaming SSR for /: Error [ERR_STREAM_WRITE_AFTER_END]: write after end
      at write_ (node:_http_outgoing:900:11)
      at ServerResponse.write (node:_http_outgoing:849:15)
  ```
- The listener is guarded by a `WeakSet` because `renderMarkUp` can run twice for one response (the fetcher error path re-renders with a 404) and `error` listeners must not stack.

**`src/otel.js`**
- New `createStreamErrorRecorder(serviceName, name = "responseStreamError")` helper. Stream errors fire on the response's `error` event, typically after the span that performed the offending write has already ended, and `recordException` on an ended span is silently dropped. The helper therefore captures `context.active()` while the request span is alive and, per error, emits a dedicated `responseStreamError` span into the same trace: status `ERROR`, `exception` event, and an `error.type` attribute carrying the error code. Same parenting approach as `responseFlushMiddleware`'s post-end spans.
- The handler wires this up only when `OTEL_ENABLE` is set, through the existing lazy `otel.js` import; when tracing is off, the recorder is `null` and only the console log runs.

## How it was verified

1. **Lint parity**: `eslint` on both files reports the same 5 pre-existing errors as `main`, nothing new.
2. **OTel recorder semantics** (in-memory exporter, `@opentelemetry/sdk-trace-node`): recorder created inside an active `renderMarkUp` span, span ended, error fired on a later tick. All checks pass: error span exported, same `traceId` as the request span, parented to the `renderMarkUp` span, status `ERROR` with the error message, `exception` event recorded, `error.type = ERR_STREAM_WRITE_AFTER_END`.
3. **End to end** via `apps/catalyst-core-test` (packed current branch, `catalyst build`, `NODE_ENV=production catalyst serve`): every request to `/` now produces the log line above; on this branch's `main` the same requests produce no output at all.
4. **No behavior change**: the served document is byte-shape identical before and after (doctype present, same `<script src>` count, and, per #320, still no `</html>`; that bug is intentionally untouched here).

A side benefit: response error paths that end in `res.destroy(err)` (fatal render errors, client disconnects) now also have a listener, so they are logged instead of relying on Node's default handling.

Refs #320.
