### PR TITLE
fix: eliminate SSR streaming race between onShellReady and onAllReady

### DIFF
--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -23,6 +23,7 @@ import {
     generateModulePreloadLinkElements,
 } from "./extract.js"
 import path from "path"
+import { Transform } from "node:stream"
 
 import CustomDocument from "@catalyst/template/server/document"
 
@@ -242,13 +243,17 @@ const _renderMarkUp = async (
         res.status(status)
 
         return new Promise((resolve, reject) => {
-            const { pipe } = renderToPipeableStream(<CompleteDocument />, {
-                onShellReady() {
-                    res.setHeader("content-type", "text/html")
-                    pipe(res)
+            // Single completion path: React's pipe() auto-ends `tail`, and
+            // `flush()` appends the deferred asset tags before that end
+            // signal propagates to `res` via the plain pipe below. This
+            // avoids the onShellReady/onAllReady race where React's own
+            // stream-end and a manual res.end() compete to close `res`
+            // (see issue #320).
+            const tail = new Transform({
+                transform(chunk, _enc, cb) {
+                    cb(null, chunk)
                 },
-
-                onAllReady() {
+                flush(cb) {
                     // Deferred assets — injected after body (non-blocking)
                     const deferredAssets = chunkExtractor
                         ? chunkExtractor.getDeferredAssets()
@@ -256,10 +261,10 @@ const _renderMarkUp = async (
 
                     // Tell client which components were SSR'd so split() can
                     // eagerly import them (prevents Suspense fallback flash)
-                    res.write(`<script>window.__CATALYST_IS_BOT__=${isBot ? "true" : "false"};</script>`)
+                    this.push(`<script>window.__CATALYST_IS_BOT__=${isBot ? "true" : "false"};</script>`)
                     if (chunkExtractor) {
                         const renderedKeys = chunkExtractor.getRenderedComponentKeys()
-                        res.write(
+                        this.push(
                             `<script>window.__SSR_RENDERED_COMPONENTS__=new Set(${JSON.stringify(renderedKeys)})</script>`
                         )
                     }
@@ -270,13 +275,24 @@ const _renderMarkUp = async (
                         isBot
                     )
                     if (newCssPaths.length) {
-                        res.write(`<style>${readCssFromDisk(newCssPaths, buildDir)}</style>`)
+                        this.push(`<style>${readCssFromDisk(newCssPaths, buildDir)}</style>`)
                     }
                     if (!isBot) {
-                        res.write(generateScriptStrings(deferredAssets.js))
+                        this.push(generateScriptStrings(deferredAssets.js))
                     }
 
-                    res.end()
+                    cb()
+                },
+            })
+            tail.pipe(res)
+
+            const { pipe } = renderToPipeableStream(<CompleteDocument />, {
+                onShellReady() {
+                    res.setHeader("content-type", "text/html")
+                    pipe(tail)
+                },
+
+                onAllReady() {
                     cleanupSafeArea()
                     resolve()
                 },
@@ -285,6 +301,7 @@ const _renderMarkUp = async (
                     console.error("Error in renderToPipeableStream:", error)
                     safeCall(onRenderError, { req, res, store, error })
                     cleanupSafeArea()
+                    tail.destroy(error)
                     reject(error)
                 },
             })


### PR DESCRIPTION
## Summary
- `renderToPipeableStream`'s `pipe(res)` in `onShellReady` and the handler's own `res.write(firstFoldCss/firstFoldJS)`/`res.end()` in `onAllReady` (`packages/catalyst-core/src/server/renderer/handler.js`) are two independent completion paths racing to close the same response. Whichever loses is silently dropped (no `error` listener on `res`), truncating every SSR response and permanently sticking async `<Suspense>` boundaries on their fallback in some documents.
- Fixes this by routing React's output through an intermediate `Transform` ("tail"). React auto-ends `tail` exactly like it auto-ended `res` before, but `tail`'s `flush()` hook is guaranteed to run exactly once — appending `firstFoldCss`/`firstFoldJS` — before a plain `tail.pipe(res)` is allowed to end `res`. Exactly one caller of `res.end()` now.
- Progressive streaming is unchanged: every chunk still flows to `res` immediately as React writes it; only the trailing asset tags were ever deferred to the end, same as before.

Fixes #320

Visual walkthrough of the race and the fix: https://claude.ai/code/artifact/79a44698-079d-47f0-b72e-911a352f05e4

## Test plan
- [ ] Build a fixture app against this branch and confirm `</html>` is present and Suspense content resolves
- [ ] Verify `firstFoldCss`/`firstFoldJS` still injected correctly for both bot and non-bot requests