### PR TITLE
Update iOS release docs and MCP guidance

### DIFF
--- a/docs/content/08-Deployment/02-Universal-App-Deployment.md
+++ b/docs/content/08-Deployment/02-Universal-App-Deployment.md
@@ -30,15 +30,17 @@ Required Android release fields:
 
 ## iOS Release Flow
 
-1. Set `WEBVIEW_CONFIG.ios.buildType` to `Release`.
-2. Set a real `appBundleId`.
-3. If Google Sign-In is enabled, include `GoogleService-Info.plist`.
-4. Run `catalyst build`.
-5. Run `npm run buildApp:ios`.
-6. Archive and export the IPA from Xcode or `xcodebuild`.
-7. Upload the build to App Store Connect or TestFlight.
+1. Deploy the production web application over HTTPS.
+2. Finalize `WEBVIEW_CONFIG`, the bundle identifier, version, build number, capabilities, and app assets.
+3. Run `npm run buildApp:ios` from the consuming Catalyst app.
+4. Open the generated `iosnativeWebView.xcodeproj` and configure Release signing.
+5. Archive the `iosnativeWebView` scheme with a generic iOS device destination.
+6. Validate and upload the archive through Xcode.
+7. Complete TestFlight testing and the App Store Connect release.
 
-`WEBVIEW_CONFIG.ios.buildType` is case-sensitive. Use `Release`, not `release`.
+`npm run buildApp:ios` prepares the package-owned Xcode project and performs a Debug native build. It does not create the App Store archive. The production artifact is created by the scheme's Release Archive action in Xcode. This flow is the same for Catalyst `0.2.x` and `0.3.x`.
+
+See [Building and Releasing a Catalyst iOS App](/content/Deployment/ios-production-release) for the complete release procedure and checklist.
 
 ## What to Validate Before Release
 

--- a/docs/content/08-Deployment/03-iOS-Production-Release.md
+++ b/docs/content/08-Deployment/03-iOS-Production-Release.md
@@ -1,0 +1,106 @@
+---
+title: Building and Releasing a Catalyst iOS App
+slug: ios-production-release
+id: ios-production-release
+---
+
+# Building and Releasing a Catalyst iOS App
+
+This guide explains how to produce an iOS app for TestFlight and the App Store from a Catalyst universal app.
+
+> **Important:** `npm run buildApp:ios` is a native-project generation and Debug-run command. It does not create the final production archive. The App Store artifact is created by archiving the generated Xcode project using its **Release** configuration.
+
+## Before you begin
+
+- Enroll the releasing Apple account in the Apple Developer Program.
+- Deploy the production web application first. Catalyst's iOS app loads the configured remote URL in a WebView.
+- Use an HTTPS production URL. Release configuration does not permit arbitrary HTTP loads.
+- Finalize application identity and assets:
+    - unique bundle identifier
+    - app name, version, and incremented build number
+    - app icons and splash image
+    - required permissions, capabilities, and privacy declarations
+    - production URL, initial route, and access-control configuration
+
+## 1. Generate the native iOS project
+
+From the root of the consuming Catalyst app, run:
+
+```bash
+npm run buildApp:ios
+```
+
+This command reads the app's `config/config.json` and selected `public/` assets, generates native configuration and plugin code, and prepares the iOS project.
+
+It also performs a **Debug** native build and may install or launch it on a connected device or simulator. This is expected; it is not the production binary.
+
+### Generated project location
+
+For a normal installed dependency, open:
+
+```text
+node_modules/catalyst-core/dist/native/iosnativeWebView/iosnativeWebView.xcodeproj
+```
+
+## 2. Open and prepare the project in Xcode
+
+1. Open `iosnativeWebView.xcodeproj` in Xcode.
+2. Select the **iosnativeWebView** target and scheme.
+3. Confirm the Archive action uses **Release**. The supplied scheme already does this; a separate production scheme is not required.
+4. In **Signing & Capabilities**, set the correct Apple Developer team and review the following:
+    - Bundle Identifier
+    - Version and Build
+    - capabilities and entitlement values
+    - app icon and launch assets
+
+### Signing configuration
+
+For the normal App Store route, prefer **Automatically manage signing** with the correct team selected. Xcode can then select the appropriate Apple Distribution signing assets.
+
+If the organization uses manual signing, select a valid Apple Distribution certificate and App Store provisioning profile for the Release target.
+
+## 3. Create the production archive
+
+1. In Xcode's destination selector, choose **Any iOS Device (arm64)** or another generic iOS device destination. Do not select a simulator.
+2. Choose **Product → Archive**.
+3. After the archive completes, Xcode opens the Organizer.
+4. Select the archive and choose **Validate App**.
+5. Choose **Distribute App**.
+6. Choose **TestFlight & App Store**.
+7. Complete the signing/export prompts and upload the build.
+
+## 4. Complete the release in App Store Connect
+
+1. Wait for Apple to process the uploaded build.
+2. Distribute it through TestFlight and complete release testing.
+3. In App Store Connect, complete required product details, including metadata, screenshots, privacy disclosures, pricing, and availability.
+4. Select the processed build for the release version.
+5. Submit the app for App Review.
+
+Apple's current release workflow is documented in [Distributing your app for beta testing and releases](https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases).
+
+## Regeneration and persistence warning
+
+The Xcode project is generated package-owned state. Run the final `npm run buildApp:ios` before making release-only changes in Xcode.
+
+A later Catalyst generation, package upgrade, or dependency installation can replace or regenerate:
+
+- native config constants and shared Xcode configuration
+- app plist and entitlement content
+- generated plugin code and resources
+- selected project-file entries and assets
+
+Therefore, do not treat manual edits inside the generated project as durable application configuration.
+
+## Release checklist
+
+- [ ] Production web application is deployed and reachable over HTTPS.
+- [ ] `config/config.json` uses the production host and initial route.
+- [ ] Bundle ID, version, and build number are final and unique.
+- [ ] Icons, splash assets, permissions, and capabilities are reviewed.
+- [ ] Final `npm run buildApp:ios` has completed.
+- [ ] Release signing uses the correct team and Apple Distribution assets.
+- [ ] Push notification entitlement is reviewed, if applicable.
+- [ ] Archive is built from a generic device destination, not a simulator.
+- [ ] Archive validates successfully and uploads to App Store Connect.
+- [ ] The TestFlight build is tested before App Review submission.

--- a/packages/catalyst-core/mcp_v2/knowledge-base.json
+++ b/packages/catalyst-core/mcp_v2/knowledge-base.json
@@ -170,15 +170,63 @@
     {
         "section": "build_system",
         "title": "iOS Build Pipeline",
-        "content": "1) Generate ConfigConstants.swift from WEBVIEW_CONFIG 2) Launch simulator 3) Clean Xcode project 4) Compile with Xcode 5) Install app + launch. Located in: src/native/iosnativeWebView/",
+        "content": "npm run buildApp:ios generates ConfigConstants.swift and plugin metadata from WEBVIEW_CONFIG, syncs selected public/ios assets into the package-owned Xcode project, detects a physical device or launches a simulator, cleans Xcode artifacts, compiles with the Debug configuration, and installs and launches the .app. It does not bundle the full Catalyst web client and does not create an App Store archive. The generated project is located under the resolved catalyst-core package at dist/native/iosnativeWebView/iosnativeWebView.xcodeproj.",
         "layer": "Build",
         "source": "static",
-        "tags": ["ios", "build"]
+        "tags": ["ios", "build", "buildApp:ios", "debug", "xcode"],
+        "github_files": [
+            "packages/catalyst-core/src/native/buildAppIos.js",
+            "packages/catalyst-core/src/native/buildIos/build.js"
+        ]
+    },
+    {
+        "section": "build_system",
+        "title": "Catalyst iOS Production Release Flow (0.2.x and 0.3.x)",
+        "content": "Catalyst 0.2.x and 0.3.x use the same iOS production-release flow: (1) deploy the production web application and verify its HTTPS URL, (2) finalize WEBVIEW_CONFIG, bundle ID, app version/build, plugins, permissions, capabilities, icons, splash assets, access-control rules, and privacy declarations, (3) run npm run buildApp:ios from the consuming app root to prepare the package-owned native project and perform its Debug build, (4) open the resolved catalyst-core package's dist/native/iosnativeWebView/iosnativeWebView.xcodeproj, (5) confirm the iosnativeWebView scheme's Archive action uses Release, configure Release signing and capabilities, choose a generic iOS device destination, and run Product -> Archive, (6) Validate App and upload with Distribute App -> TestFlight & App Store, then (7) finish TestFlight testing, App Store Connect metadata, build selection, and App Review submission. buildApp:ios does not create the final App Store artifact.",
+        "layer": "Build",
+        "source": "static",
+        "tags": [
+            "ios",
+            "release",
+            "production",
+            "0.2.x",
+            "0.3.x",
+            "buildApp:ios",
+            "xcode",
+            "archive",
+            "app-store",
+            "testflight"
+        ],
+        "github_files": [
+            "docs/content/08-Deployment/03-iOS-Production-Release.md",
+            "packages/catalyst-core/src/native/iosnativeWebView/iosnativeWebView.xcodeproj/xcshareddata/xcschemes/iosnativeWebView.xcscheme"
+        ]
+    },
+    {
+        "section": "build_system",
+        "title": "Generated iOS Project Signing and Persistence",
+        "content": "The generated Xcode project is package-owned state. Its shared xcconfig is regenerated with development-oriented code-signing defaults, and the bundled push entitlement can use aps-environment=development. Before an App Store archive, review the Release team, distribution signing, provisioning, capabilities, and entitlements in Xcode. Run the final npm run buildApp:ios before release-only Xcode changes: later Catalyst generation, package upgrades, or dependency installation can replace or regenerate native config constants, shared Xcode configuration, plist and entitlement content, generated plugin code/resources, selected project-file entries, and assets. Do not treat manual edits inside the generated project as durable app configuration.",
+        "layer": "Build",
+        "source": "static",
+        "tags": [
+            "ios",
+            "release",
+            "signing",
+            "provisioning",
+            "entitlements",
+            "push-notifications",
+            "generated-project",
+            "regeneration"
+        ],
+        "github_files": [
+            "packages/catalyst-core/src/native/buildIos/config.js",
+            "packages/catalyst-core/src/native/iosnativeWebView/iosnativeWebView/iosnativeWebView.entitlements"
+        ]
     },
     {
         "section": "build_system",
         "title": "Legacy 0.2.x Build NPM Scripts",
-        "content": "All catalyst npm scripts to add to package.json scripts block (each maps to: catalyst <scriptName>): devBuild \u2014 dev web build. devServe \u2014 dev server. buildApp \u2014 builds native app (both platforms). buildApp:android \u2014 Android native app build. buildApp:ios \u2014 iOS native app build. buildApp:android:release \u2014 Android release build. buildApp:ios:release \u2014 iOS release build. setupEmulator \u2014 sets up both emulators. setupEmulator:android \u2014 sets up Android AVD. setupEmulator:ios \u2014 sets up iOS simulator. NOTE: build:android / build:android:release / build:ios do NOT exist in catalyst \u2014 common mistake. The correct commands are buildApp:android and buildApp:ios. Missing any script = that npm run command fails.",
+        "content": "All catalyst npm scripts to add to package.json scripts block (each maps to: catalyst <scriptName>): devBuild \u2014 dev web build. devServe \u2014 dev server. buildApp \u2014 builds native apps. buildApp:android \u2014 Android native app build. buildApp:ios \u2014 iOS native project preparation and Debug build. buildApp:android:release \u2014 Android release build. setupEmulator \u2014 sets up both emulators. setupEmulator:android \u2014 sets up Android AVD. setupEmulator:ios \u2014 sets up iOS simulator. There is no separate buildApp:ios:release flow: run buildApp:ios, then create the production archive from the generated Xcode project's Release Archive action. NOTE: build:android / build:android:release / build:ios do NOT exist in catalyst \u2014 common mistake. Missing any script = that npm run command fails.",
         "layer": "Build",
         "source": "static",
         "tags": ["build", "scripts", "package.json", "native"]
@@ -434,7 +482,7 @@
     {
         "section": "config_structure",
         "title": "WEBVIEW_CONFIG Required Fields",
-        "content": "WEBVIEW_CONFIG field reference (from buildAppAndroid.js + buildAppIos.js source):\n\nTOP-LEVEL (both platforms):\n- port (string, required) \u2014 web server port e.g. \"3005\"\n- LOCAL_IP (string, required) \u2014 machine LAN IP e.g. \"192.168.0.11\". NOT localhost \u2014 emulator cannot resolve it\n- appInfo (string, required) \u2014 build identifier e.g. \"android-5Feb2026-v2.1.0\". Missing = iOS build breaks\n- useHttps (boolean, optional) \u2014 default false\n- cachePattern (string, optional) \u2014 comma-separated globs e.g. \"*.css\"\n- accessControl.enabled (boolean, optional) \u2014 default false\n- accessControl.allowedUrls (array, required if enabled) \u2014 URL patterns\n\nANDROID (WEBVIEW_CONFIG.android):\n- sdkPath (string, REQUIRED) \u2014 abs path to Android SDK. Build exits immediately without it\n- emulatorName (string, REQUIRED for debug) \u2014 AVD name. Run: emulator -list-avds\n- appName (string, optional) \u2014 default \"Catalyst Application\"\n- packageName (string, optional) \u2014 e.g. com.company.app. Derived from appName if missing\n- buildType (string, optional) \u2014 \"debug\" or \"release\". Default \"debug\"\n- keystore or keystoreConfig (required for release buildType only)\n- buildOptimisation (boolean, optional) \u2014 default false\n- cachePattern (string, optional)\n\nIOS (WEBVIEW_CONFIG.ios):\n- appBundleId (string, optional) \u2014 default \"com.debug.webview\". Must set for distribution\n- appName (string, optional) \u2014 default \"Catalyst Application\"\n- simulatorName (string, optional) \u2014 auto-detected if missing. e.g. \"iPhone 17 Pro\"\n- buildType (string, optional, CASE-SENSITIVE) \u2014 \"Debug\" or \"Release\". NOT lowercase \u2014 common mistake\n- deviceUDID (string, optional) \u2014 physical device builds only\n- developmentTeam (string, required if deviceUDID set) \u2014 Apple Developer Team ID\n- cachePattern (string, optional)",
+        "content": "WEBVIEW_CONFIG field reference (from buildAppAndroid.js + buildAppIos.js source):\n\nTOP-LEVEL (both platforms):\n- port (string, required) \u2014 web server port e.g. \"3005\"\n- LOCAL_IP (string, required) \u2014 machine LAN IP e.g. \"192.168.0.11\". NOT localhost \u2014 emulator cannot resolve it\n- appInfo (string, required) \u2014 build identifier e.g. \"android-5Feb2026-v2.1.0\". Missing = iOS build breaks\n- useHttps (boolean, optional) \u2014 default false\n- cachePattern (string, optional) \u2014 comma-separated globs e.g. \"*.css\"\n- accessControl.enabled (boolean, optional) \u2014 default false\n- accessControl.allowedUrls (array, required if enabled) \u2014 URL patterns\n\nANDROID (WEBVIEW_CONFIG.android):\n- sdkPath (string, REQUIRED) \u2014 abs path to Android SDK. Build exits immediately without it\n- emulatorName (string, REQUIRED for debug) \u2014 AVD name. Run: emulator -list-avds\n- appName (string, optional) \u2014 default \"Catalyst Application\"\n- packageName (string, optional) \u2014 e.g. com.company.app. Derived from appName if missing\n- buildType (string, optional) \u2014 \"debug\" or \"release\". Default \"debug\"\n- keystore or keystoreConfig (required for release buildType only)\n- buildOptimisation (boolean, optional) \u2014 default false\n- cachePattern (string, optional)\n\nIOS (WEBVIEW_CONFIG.ios):\n- appBundleId (string, optional) \u2014 default \"com.debug.webview\". Must set for distribution\n- appName (string, optional) \u2014 default \"Catalyst Application\"\n- simulatorName (string, optional) \u2014 auto-detected if missing. e.g. \"iPhone 17 Pro\"\n- buildType (string, optional) \u2014 may label copied Debug output but does not select the Xcode build configuration or create an App Store archive\n- deviceUDID (string, optional) \u2014 physical device builds only\n- developmentTeam (string, required if deviceUDID set) \u2014 Apple Developer Team ID\n- cachePattern (string, optional)\n\nFor iOS production, run buildApp:ios to prepare the generated project, then archive the iosnativeWebView scheme using its Release Archive action in Xcode.",
         "layer": "Config",
         "source": "static",
         "tags": ["config", "WEBVIEW_CONFIG", "android", "ios", "required", "fields"]

--- a/packages/catalyst-core/mcp_v2/tools/build.js
+++ b/packages/catalyst-core/mcp_v2/tools/build.js
@@ -149,19 +149,19 @@ const MASTER_FLOWS = {
             step: 1,
             cmd: null,
             label: "Pre-check: config",
-            detail: 'Reads WEBVIEW_CONFIG.ios. Requires: appBundleId, simulatorName, buildType (default "debug").',
+            detail: "Reads WEBVIEW_CONFIG and WEBVIEW_CONFIG.ios. Confirm the development URL, appBundleId, simulatorName, plugins, and selected public/ios assets.",
         },
         {
             step: 2,
-            cmd: "catalyst build",
-            label: "Build web assets",
-            detail: "Compiles web app. iOS build embeds these.",
+            cmd: "npm run buildApp:ios",
+            label: "iOS simulator build",
+            detail: "Generates native configuration and plugin code in the package-owned Xcode project, syncs selected assets, compiles with Xcode's Debug configuration, installs the .app, and launches it.",
         },
         {
             step: 3,
-            cmd: "npm run buildApp:ios",
-            label: "iOS simulator build",
-            detail: "Runs buildAppIos.js: generates ConfigConstants.swift from config (bundleId, URL, port, protocol), launches simulator (simulatorName), cleans Xcode artifacts, compiles with xcodebuild, installs .app, launches.",
+            cmd: null,
+            label: "Remote web application",
+            detail: "The iOS shell loads the configured remote URL. buildApp:ios does not bundle the full Catalyst web client, so the target web application must be reachable.",
         },
         {
             step: 4,
@@ -175,27 +175,44 @@ const MASTER_FLOWS = {
         {
             step: 1,
             cmd: null,
-            label: "Pre-check: config",
-            detail: 'buildType must be "Release" (capital R — case-sensitive). appBundleId required. If googleSignIn enabled, GoogleService-Info.plist must be present.',
+            label: "Deploy the production web application",
+            detail: "Deploy the web application first and confirm its production URL is reachable over HTTPS. The iOS shell loads this remote URL; it does not embed the full web client bundle.",
         },
-        { step: 2, cmd: "catalyst build", label: "Build web assets", detail: "Production build." },
+        {
+            step: 2,
+            cmd: null,
+            label: "Pre-check: config",
+            detail: "Finalize WEBVIEW_CONFIG, appBundleId, app name, version, incremented build number, access-control rules, plugins, permissions, capabilities, icons, splash assets, and privacy declarations.",
+        },
         {
             step: 3,
             cmd: "npm run buildApp:ios",
-            label: "iOS release build",
-            detail: "Same script — build type is driven by WEBVIEW_CONFIG.ios.buildType. Generates ConfigConstants.swift with production URL and bundleId. Xcode compiles Release scheme.",
+            label: "Prepare the native project",
+            detail: "Run from the consuming Catalyst app root. This generates native configuration and plugin code, syncs selected assets, and performs a Debug native build. It does not create an App Store archive.",
         },
         {
             step: 4,
             cmd: null,
-            label: "Archive + export IPA",
-            detail: "Post-build: archive via Xcode Organizer or xcodebuild -exportArchive. Requires Apple distribution certificate + provisioning profile configured in Xcode.",
+            label: "Open the generated Xcode project",
+            detail: "Open node_modules/catalyst-core/dist/native/iosnativeWebView/iosnativeWebView.xcodeproj (or the resolved package equivalent). Confirm the iosnativeWebView scheme's Archive action uses Release.",
         },
         {
             step: 5,
             cmd: null,
-            label: "App Store submission",
-            detail: "Upload IPA via Transporter or Xcode Organizer. TestFlight for beta before release.",
+            label: "Configure signing and archive",
+            detail: "Select the correct Apple Developer team, distribution signing, capabilities, entitlements, bundle ID, version, and build. Choose a generic iOS device destination, then Product → Archive.",
+        },
+        {
+            step: 6,
+            cmd: null,
+            label: "Validate and upload",
+            detail: "In Xcode Organizer, run Validate App, then Distribute App → TestFlight & App Store and upload the build.",
+        },
+        {
+            step: 7,
+            cmd: null,
+            label: "Complete the release",
+            detail: "Wait for App Store Connect processing, test through TestFlight, complete store metadata and privacy disclosures, select the processed build, and submit it for App Review.",
         },
     ],
 }
@@ -495,6 +512,7 @@ function getProjectContext(root) {
         iosBuildType: (wv.ios?.buildType || "debug").toLowerCase(),
         hasKeystore: !!wv.android?.keystoreConfig,
         hasGoogleSignIn: !!wv.googleSignIn?.enabled,
+        hasNotifications: !!wv.notifications?.enabled,
         hasEcosystem: fileExists("ecosystem.config.js"),
         port: wv.port,
         useHttps: !!wv.useHttps,
@@ -618,7 +636,7 @@ function handle_get_build_flow({ platform, mode, symptom } = {}) {
             )
         }
 
-        const isRelease = m === "release" || ctx.iosBuildType === "release"
+        const isRelease = m === "release"
         flow_key = isRelease ? "ios_release" : "ios_debug"
 
         if (!ctx.wv.ios?.appBundleId) {
@@ -634,13 +652,23 @@ function handle_get_build_flow({ platform, mode, symptom } = {}) {
                 "googleSignIn.enabled=true but iosClientId may be missing — check WEBVIEW_CONFIG.googleSignIn.iosClientId."
             )
         }
-        if (isRelease && ctx.iosBuildType !== "release") {
+        if (isRelease && !ctx.useHttps) {
             warnings.push(
-                'ios.buildType is not "Release" (case-sensitive). Release builds require exactly "Release" — not "release".'
+                "WEBVIEW_CONFIG.useHttps is not enabled — the App Store flow requires a reachable HTTPS production web application."
+            )
+        }
+        if (isRelease && ctx.hasNotifications) {
+            warnings.push(
+                "Push notifications are enabled — review the generated aps-environment entitlement and Release provisioning before archiving."
             )
         }
 
         notes.push(`buildType detected: ${ctx.wv.ios?.buildType || "not set (defaults to debug)"}`)
+        if (isRelease) {
+            notes.push(
+                "ios.buildType does not select the App Store build configuration; buildApp:ios still performs a Debug build. Archive the generated project with the scheme's Release action."
+            )
+        }
         if (ctx.wv.ios?.appBundleId) notes.push(`appBundleId: ${ctx.wv.ios.appBundleId}`)
         if (ctx.wv.ios?.simulatorName) notes.push(`simulatorName: ${ctx.wv.ios.simulatorName}`)
         if (ctx.hasGoogleSignIn) notes.push("googleSignIn: enabled")

--- a/packages/create-catalyst-app/templates/common/buildConfig.js
+++ b/packages/create-catalyst-app/templates/common/buildConfig.js
@@ -1,0 +1,4 @@
+export default {
+    clientPlugins: [],
+    ssrPlugins: [],
+}

--- a/packages/create-catalyst-app/templates/common/webpackConfig.js
+++ b/packages/create-catalyst-app/templates/common/webpackConfig.js
@@ -1,6 +1,0 @@
-module.exports = {
-    developmentPlugins: [],
-    ssrPlugins: [],
-    clientPlugins: [],
-    transpileModules: [],
-}


### PR DESCRIPTION
### PR summary

## What changed

- Added a complete Catalyst iOS production-release guide.
- Updated the deployment documentation to link to the new guide.
- Added the verified iOS release flow to the MCP knowledge base and build-flow tool.
- Clarified that the process is the same for Catalyst `0.2.x` and `0.3.x`.
- Renamed the CCA template’s `webpackConfig.js` to `buildConfig.js`.
- Updated the template config to use an ESM default export and removed obsolete webpack-specific keys.