### PR TITLE
fix: patch @tailwindcss/postcss base so Vite scans the whole app

### DIFF
--- a/packages/catalyst-core/src/vite/vite.config.js
+++ b/packages/catalyst-core/src/vite/vite.config.js
@@ -130,6 +130,51 @@ try {
 const allAliases = { ..._moduleAliases, ...catalyst_moduleAliases }
 
 import { imageUrl, fontUrl } from "./scssParams.js"
+import { createRequire } from "module"
+
+// Tailwind v4's zero-config scanner (`@tailwindcss/postcss`) walks up from
+// `dirname(from)` — the directory of the file PostCSS is currently compiling —
+// unless given an explicit `base`. Vite passes each CSS file's own resolved
+// path as `from`, so for catalyst-core's conventional layout (global
+// stylesheet under `src/static/css`, components under `src/js`, no shared
+// parent short of the app root) the scanner never reaches component files and
+// silently drops every class actually used in JSX. Webpack's postcss-loader
+// doesn't populate `from` the same way, which is why this only regresses
+// under Vite. We resolve the app's own postcss.config.js ourselves and patch
+// in `base: process.env.src_path` so the scan root covers the whole app.
+// Only the `{ pluginName: options }` shorthand can be patched this way —
+// array-form configs (`[require(...)()]`) have already closed over their
+// options — so anything else is left alone and Vite falls back to its normal
+// auto-loaded postcss.config.js resolution.
+const resolvePostcssPlugins = () => {
+    const configPath = path.join(process.env.src_path, "postcss.config.js")
+    if (!fs.existsSync(configPath)) return null
+
+    const appRequire = createRequire(configPath)
+
+    try {
+        const userConfig = appRequire(configPath)
+        const pluginsConfig = userConfig?.plugins
+
+        if (!pluginsConfig || Array.isArray(pluginsConfig) || typeof pluginsConfig !== "object") {
+            return null
+        }
+
+        return Object.entries(pluginsConfig).map(([name, options]) => {
+            const plugin = appRequire(name)
+            const finalOptions =
+                name === "@tailwindcss/postcss" && (!options || options.base === undefined)
+                    ? { ...options, base: process.env.src_path }
+                    : options
+            return plugin(finalOptions)
+        })
+    } catch (error) {
+        console.warn(`Failed to patch postcss config at ${configPath}:`, error.message)
+        return null
+    }
+}
+
+const postcssPlugins = resolvePostcssPlugins()
 
 const alias = () => {
     if (!allAliases || typeof allAliases !== "object") {
@@ -377,6 +422,7 @@ export default defineConfig({
             localsConvention: "camelCase",
             generateScopedName: "[name]__[local]___[hash:base64:5]",
         },
+        ...(postcssPlugins ? { postcss: { plugins: postcssPlugins } } : {}),
         preprocessorOptions: {
             scss: {
                 additionalData: (content) =>


### PR DESCRIPTION
## Summary
- Tailwind v4's zero-config scanner (`@tailwindcss/postcss`) computes its scan root as `dirname(from)`. Vite passes each CSS file's own resolved path as `from`, so for catalyst-core's conventional layout (global stylesheet under `src/static/css`, components under `src/js`) the scanner never reaches component files and silently drops every class actually used in JSX. Webpack's `postcss-loader` didn't populate `from` the same way, so this only regressed after the Vite migration (#284).
- `packages/catalyst-core/src/vite/vite.config.js` now resolves the app's own `postcss.config.js` and injects `base: process.env.src_path` into `@tailwindcss/postcss` when the app hasn't set one, leaving every other plugin's options untouched. If the app's postcss config can't be patched this way (no file, or array-form plugins), `css.postcss` is left unset so Vite falls back to its normal auto-loaded resolution — no behavior change for apps without Tailwind.

Fixes #325

## Test plan
- [x] `node --check` on the modified `vite.config.js`
- [x] Standalone Node simulation with fake `@tailwindcss/postcss` + `autoprefixer` packages confirming only the Tailwind plugin gets `base` injected and other plugins pass through untouched
- [ ] Manual repro from the issue against a real Vite app (add Tailwind v4 zero-config, confirm compiled CSS includes classes used in `src/js/**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)