### PR TITLE
docs: clarify setMetaData must return array of JSX elements

### DIFF
--- a/docs/content/14-Best Practices/01-Dynamic-Metadata.md
+++ b/docs/content/14-Best Practices/01-Dynamic-Metadata.md
@@ -11,6 +11,7 @@ Catalyst renders pages through SSR, so metadata should be treated as part of the
 ## Core Practice
 
 Define metadata on the route component with `setMetaData` so search engines receive the correct tags in the initial HTML.
+> **Warning:** `setMetaData` must return an array, not an object. If you return an object, it breaks silently in the background without throwing any error, but your titles and meta tags won't show up.
 
 ```jsx title="src/js/containers/Home/Home.js"
 function HomePage() {
@@ -52,6 +53,9 @@ export default HomePage;
 - reusing the same title and description across many routes
 - generating canonicals from unstable query params
 - omitting social tags on pages that are frequently shared externally
+- returning an object instead of an array
+- returning a single JSX element without wrapping it in an array
+- forgetting the key prop on elements
 
 ## Related Docs
 

--- a/packages/catalyst-core/src/web-router/types/utils/metaDataUtils.d.ts
+++ b/packages/catalyst-core/src/web-router/types/utils/metaDataUtils.d.ts
@@ -22,3 +22,19 @@ export function deleteHeadTagsByDataAttribute(attributeName: string, attributeVa
  * @returns {Array<JSX.Element>} - List of all meta tags for the matched location.
  */
 export function getMetaData(matchedRoutes: Array<Match>, routeData: Object): Array<JSX.Element>
+/**
+ * Static function defined on a route component that returns metadata elements
+ * to be rendered in the document head for that route.
+ * Must return an array of JSX elements (e.g. <title>, <meta>), NOT a plain
+ * object. Returning an object fails silently: no error is thrown, but the
+ * tags will not appear in the rendered <head>.
+ *
+ * @param {any} fetcherData - Data returned from the route's fetcher (serverFetcher/clientFetcher).
+ * @returns {Array<JSX.Element>} - Array of JSX head elements (title, meta, link, etc).
+ *
+ * @example
+ * HomePage.setMetaData = (apiResponse) => [
+ *   <title key="title">{apiResponse?.title || "Home"}</title>,
+ * ];
+ */
+export type SetMetaData = (fetcherData: any) => Array<JSX.Element>


### PR DESCRIPTION
closes #300 

## Changes:
- Added warning section in 'Dynamic-Metadata.md', warning that `setMetaData` must return an array not an object
- Added a TypeScript type for `setMetaData` in `metaDataUtils.d.ts`, since it wasn't there before 

## Why
if `setMetaData` returned an object, it silently broke in the background without any error message and the title and the meta tag didn't show up 