### PR TITLE
feat: add custom API routes with SSR loopback dispatch

### DIFF
--- a/apps/catalyst-core-test/server/api/index.js
+++ b/apps/catalyst-core-test/server/api/index.js
@@ -1,0 +1,16 @@
+import { defineApi } from "catalyst-core/api"
+import { getDogBreeds, getDogImages } from "../../src/js/utils/dogApi.js"
+
+const listBreeds = defineApi({
+    method: "GET",
+    path: "/api/breeds/list/all",
+    handler: () => getDogBreeds(),
+})
+
+const breedImages = defineApi({
+    method: "GET",
+    path: "/api/breed/:breed/images",
+    handler: () => getDogImages(),
+})
+
+export default [listBreeds, breedImages]

--- a/apps/catalyst-core-test/server/server.js
+++ b/apps/catalyst-core-test/server/server.js
@@ -10,7 +10,7 @@ export function addMiddlewares(app) {
 
     // /api/breeds/list/all and /api/breed/:breed/images are now defined once in
     // server/api/index.js via defineApi() and served through the API registry
-    // (mounted before addMiddlewares runs) — see docs/design-spec-data-fetching-v2.md.
+    // (mounted before addMiddlewares runs, so they take priority over this catch-all).
 
     app.use("/api", (req, res) => {
         res.send({

--- a/apps/catalyst-core-test/server/server.js
+++ b/apps/catalyst-core-test/server/server.js
@@ -1,7 +1,6 @@
 import express from "express"
 import path from "path"
 import { fileURLToPath } from "url"
-import { getDogBreeds, getDogImages } from "../src/js/utils/dogApi.js"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -9,13 +8,9 @@ const __dirname = path.dirname(__filename)
 export function addMiddlewares(app) {
     app.use("/assets", express.static(path.join(__dirname, "../src/static/images")))
 
-    app.get("/api/breeds/list/all", (req, res) => {
-        res.send(getDogBreeds())
-    })
-
-    app.get("/api/breed/:breed/images", (req, res) => {
-        res.send(getDogImages())
-    })
+    // /api/breeds/list/all and /api/breed/:breed/images are now defined once in
+    // server/api/index.js via defineApi() and served through the API registry
+    // (mounted before addMiddlewares runs) — see docs/design-spec-data-fetching-v2.md.
 
     app.use("/api", (req, res) => {
         res.send({

--- a/apps/catalyst-core-test/src/js/pages/BreedDetails/BreedDetails.js
+++ b/apps/catalyst-core-test/src/js/pages/BreedDetails/BreedDetails.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { useCurrentRouteData, useParams, Link } from "catalyst-core"
-import { getDogApiBaseUrl, getDogImages } from "../../utils/dogApi"
+import { api } from "catalyst-core/api"
 
 const BreedDetails = () => {
     const params = useParams()
@@ -40,25 +40,17 @@ const BreedDetails = () => {
     )
 }
 
-BreedDetails.clientFetcher = async ({ params }) => {
+// Same call on client and server — see Home.js for why.
+const fetchBreedImages = async ({ params }) => {
     try {
-        const breedName = params.breed
-        const response = await fetch(`${getDogApiBaseUrl()}/api/breed/${breedName}/images`)
-        const data = await response.json()
-        return data
+        return await api.get(`/api/breed/${params.breed}/images`)
     } catch (error) {
         console.error("Error fetching breed details:", error)
         throw error
     }
 }
 
-BreedDetails.serverFetcher = async ({ params }) => {
-    try {
-        return getDogImages()
-    } catch (error) {
-        console.error("Error fetching breed details:", error)
-        throw error
-    }
-}
+BreedDetails.clientFetcher = fetchBreedImages
+BreedDetails.serverFetcher = fetchBreedImages
 
 export default BreedDetails

--- a/apps/catalyst-core-test/src/js/pages/Home/Home.js
+++ b/apps/catalyst-core-test/src/js/pages/Home/Home.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Link, useCurrentRouteData } from "catalyst-core"
-import { getDogApiBaseUrl, getDogBreeds } from "../../utils/dogApi"
+import { api } from "catalyst-core/api"
 
 const Home = () => {
     const { data, error, isFetching } = useCurrentRouteData()
@@ -29,25 +29,20 @@ const Home = () => {
     )
 }
 
-Home.clientFetcher = async () => {
+// Same call on client and server: in the browser this is a normal fetch; during
+// SSR the api client dispatches directly to the handler in server/api/index.js
+// in-process (loopback), skipping the network round-trip entirely.
+const fetchBreeds = async () => {
     try {
-        const response = await fetch(`${getDogApiBaseUrl()}/api/breeds/list/all`)
-        const data = await response.json()
-        return data
+        return await api.get("/api/breeds/list/all")
     } catch (error) {
         console.error("Error fetching dog breeds:", error)
         throw error
     }
 }
 
-Home.serverFetcher = async () => {
-    try {
-        return getDogBreeds()
-    } catch (error) {
-        console.error("Error fetching dog breeds:", error)
-        throw error
-    }
-}
+Home.clientFetcher = fetchBreeds
+Home.serverFetcher = fetchBreeds
 
 Home.setMetaData = () => {
     return [<title key="title">Home</title>]

--- a/apps/catalyst-core-test/src/js/utils/dogApi.js
+++ b/apps/catalyst-core-test/src/js/utils/dogApi.js
@@ -17,15 +17,6 @@ const dogImages = [
     "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='240' viewBox='0 0 320 240'%3E%3Crect width='320' height='240' fill='%23e8f1ff'/%3E%3Ccircle cx='160' cy='108' r='54' fill='%237a4f2a'/%3E%3Ccircle cx='137' cy='96' r='8' fill='%23000'/%3E%3Ccircle cx='183' cy='96' r='8' fill='%23000'/%3E%3Cpath d='M140 132q20 18 40 0' stroke='%23000' stroke-width='8' fill='none' stroke-linecap='round'/%3E%3C/svg%3E",
 ]
 
-export const getDogApiBaseUrl = () => {
-    if (typeof window !== "undefined") return ""
-
-    const host = process.env.NODE_SERVER_HOSTNAME || "localhost"
-    const port = process.env.NODE_SERVER_PORT || 3005
-
-    return `http://${host}:${port}`
-}
-
 export const getDogBreeds = () => ({
     message: dogBreeds,
     status: "success",

--- a/docs/content/11-API Reference/00-Overview.md
+++ b/docs/content/11-API Reference/00-Overview.md
@@ -14,3 +14,4 @@ Catalyst API Reference is organized into a single hooks page followed by the rem
 - [Configuration API](./02-Configuration.mdx)
 - [File Conventions](./03-File-Conventions.md)
 - [SSR Lifecycle](./04-SSR-Lifecycle.md)
+- [API Routes & SSR Loopback](./05-API-Routes-and-Loopback.md)

--- a/docs/content/11-API Reference/05-API-Routes-and-Loopback.md
+++ b/docs/content/11-API Reference/05-API-Routes-and-Loopback.md
@@ -1,0 +1,140 @@
+---
+title: API Routes & SSR Loopback
+slug: api-routes-and-loopback
+id: api-routes-and-loopback
+---
+
+# API Routes & SSR Loopback
+
+`catalyst-core/api` lets you define an API endpoint once and call it the same way from
+anywhere in your app — a browser `fetch`, a `clientFetcher`, or SSR code running on the
+server. On the server, a call to your own endpoint skips the network entirely: it's
+dispatched as a direct, in-process function call instead of a real HTTP round trip.
+
+This is additive. It does not replace `clientFetcher`/`serverFetcher` or change how
+existing routes work — see [File Conventions](./03-File-Conventions.md) for those.
+Use it wherever you'd otherwise hand-write an Express route and a matching `fetch` call.
+
+## Defining a route
+
+```javascript title="server/api/breeds.js"
+import { defineApi } from "catalyst-core/api";
+
+export const listBreeds = defineApi({
+  method: "GET",
+  path: "/api/breeds/:id",
+  handler: async ({ params, query, body, headers, context }) => {
+    return db.getBreed(params.id); // return value -> 200 JSON response
+  },
+});
+```
+
+| Option | Default | Purpose |
+|---|---|---|
+| `method` | — required | `GET`, `POST`, `PUT`, `PATCH`, or `DELETE` |
+| `path` | — required | Express-style path, supports `:param` segments |
+| `handler` | — required | `({ params, query, body, headers, context }) => result` |
+| `loopback` | `true` | Set `false` to force this route through real HTTP even from SSR — see [When to disable loopback](#when-to-disable-loopback) |
+| `unsafeShareResult` | `false` | Skip the safety clone on the returned value — see [Loopback result copying](#loopback-result-copying) |
+
+Throw to produce a non-200 response instead of returning:
+
+```javascript
+import { ApiError } from "catalyst-core/api";
+
+handler: async ({ params }) => {
+  const breed = await db.getBreed(params.id);
+  if (!breed) throw new ApiError(404, { message: "Breed not found" });
+  return breed;
+};
+```
+
+## Registering routes
+
+List every route your app defines in a single `server/api/index.js`:
+
+```javascript title="server/api/index.js"
+import { listBreeds } from "./breeds";
+import { search } from "./search";
+
+export default [listBreeds, search];
+```
+
+Catalyst mounts these on Express automatically, before your app's own middleware, so
+they take priority — any broader manual handler you already register (a catch-all
+`/api/*`, for example) still runs as a fallback for paths this list doesn't cover. An
+app with no `server/api/index.js` is unaffected; this step is entirely optional.
+
+## Calling a route
+
+```javascript
+import { api } from "catalyst-core/api";
+
+const breed = await api.get(`/api/breeds/${id}`); // same call, every environment
+await api.post("/api/cart", { body: { sku } });
+await api.get("/api/search", { query: { q: "beagle" } });
+```
+
+`api.get`, `api.post`, `api.put`, `api.patch`, and `api.delete` all accept
+`(path, { query, body, headers })`. Use this from a `clientFetcher`/`serverFetcher`, an
+event handler, or anywhere else in your app — the same call works unmodified on the
+client and the server.
+
+### What happens on each side
+
+- **In the browser**, every call is a normal `fetch` against a relative URL.
+- **On the server**, a call to a path defined via `defineApi` is dispatched directly to
+  its handler — no socket, no HTTP parsing, no serialization round trip. A same-origin
+  path *not* covered by `defineApi` (a route your app added by hand) still resolves
+  locally, over real HTTP, rather than failing.
+- An absolute/external URL always goes over real `fetch`, in both environments.
+
+None of the dispatch logic ships to the browser bundle — the browser build only ever
+takes the `fetch` path.
+
+## Loopback result copying
+
+By default, the value a loopback call returns is deep-cloned before it reaches your
+calling code, so mutating it can never corrupt state the handler itself might be
+holding onto (an in-memory cache inside a DB client, for example) or leak between
+requests. This costs some clone time, but it's still far cheaper than the HTTP
+round-trip it replaces.
+
+If a route's handler is proven not to hand back anything shared or mutable, opt out for
+a true zero-copy call:
+
+```javascript
+defineApi({
+  method: "GET",
+  path: "/api/breeds/list",
+  unsafeShareResult: true,
+  handler: () => listBreeds(),
+});
+```
+
+## When to disable loopback
+
+Set `loopback: false` on a route whose handler needs to stream a response, issue a
+redirect, or otherwise do something beyond "return a JSON value" via `context.req`/
+`context.res`. Loopback dispatch is for plain request/response handlers only; routes
+that need the raw response object should go through the real HTTP path (the browser is
+unaffected either way — it always used `fetch`).
+
+## Setting cookies and headers
+
+A loopback handler can set cookies/headers on the real response via `context.res` — but
+only while the response is still writable. Once the page has started streaming (SSR has
+flushed its shell), headers are already sent, and Catalyst **throws** if a handler
+tries to write one after that point rather than dropping it silently. A cookie that
+silently fails to set — an auth token, a cart session, an experiment bucket — is the
+kind of bug nobody notices until a user reports something subtly broken days later,
+so this surfaces immediately at the call site instead.
+
+In practice: keep any route that sets cookies/headers on a code path that runs and
+completes before your page starts streaming, not one that resolves later in the
+response lifecycle.
+
+## Related Docs
+
+- [File Conventions](./03-File-Conventions.md)
+- [SSR Lifecycle](./04-SSR-Lifecycle.md)

--- a/packages/catalyst-core/package.json
+++ b/packages/catalyst-core/package.json
@@ -22,6 +22,7 @@
         "./caching": "./dist/caching.js",
         "./router/ClientRouter": "./dist/router/ClientRouter.js",
         "./document": "./dist/server/renderer/document/index.jsx",
+        "./api": "./dist/api/index.js",
         "./WebBridge": "./dist/native/bridge/WebBridge.js",
         "./hooks": "./dist/native/bridge/hooks.js",
         "./sentry": "./dist/sentry.cjs",

--- a/packages/catalyst-core/src/api/client.js
+++ b/packages/catalyst-core/src/api/client.js
@@ -52,7 +52,7 @@ const fetchOverHttp = async (method, url, { query, body, headers } = {}) => {
  * Isomorphic dispatch: same call site works in a browser fetcher/loader and in an
  * SSR fetcher/loader. On the server, same-origin requests try an in-process
  * loopback call (see dispatch.server.js) before falling back to a real HTTP
- * request against the app's own server — see design-spec-data-fetching-v2.md §6.
+ * request against the app's own server.
  */
 // catalyst-core is consumed as an installed node_modules package, which Vite's SSR
 // pipeline externalizes by default (loaded via plain Node, no Vite transform) — so

--- a/packages/catalyst-core/src/api/client.js
+++ b/packages/catalyst-core/src/api/client.js
@@ -1,0 +1,97 @@
+import { ApiError } from "./errors.js"
+
+const isAbsoluteUrl = (url) => /^[a-z][a-z0-9+.-]*:\/\//i.test(url)
+
+const splitPathAndQuery = (path, query) => {
+    const [pathname, existingQuery] = path.split("?")
+    const params = new URLSearchParams(existingQuery)
+    Object.entries(query || {}).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) params.set(key, value)
+    })
+    const queryString = params.toString()
+    return { pathname, queryString, queryObject: Object.fromEntries(params.entries()) }
+}
+
+const getServerOrigin = () => {
+    const host = process.env.NODE_SERVER_HOSTNAME || "localhost"
+    const port = process.env.NODE_SERVER_PORT || 3005
+    return `http://${host}:${port}`
+}
+
+const parseResponseBody = async (response) => {
+    const text = await response.text()
+    if (!text) return null
+    try {
+        return JSON.parse(text)
+    } catch {
+        return text
+    }
+}
+
+const fetchOverHttp = async (method, url, { query, body, headers } = {}) => {
+    const { pathname, queryString } = splitPathAndQuery(url, query)
+    const finalUrl = queryString ? `${pathname}?${queryString}` : pathname
+
+    const response = await fetch(finalUrl, {
+        method,
+        headers: {
+            ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+            ...headers,
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+
+    const data = await parseResponseBody(response)
+    if (!response.ok) {
+        throw new ApiError(response.status, data)
+    }
+    return data
+}
+
+/**
+ * Isomorphic dispatch: same call site works in a browser fetcher/loader and in an
+ * SSR fetcher/loader. On the server, same-origin requests try an in-process
+ * loopback call (see dispatch.server.js) before falling back to a real HTTP
+ * request against the app's own server — see design-spec-data-fetching-v2.md §6.
+ */
+// catalyst-core is consumed as an installed node_modules package, which Vite's SSR
+// pipeline externalizes by default (loaded via plain Node, no Vite transform) — so
+// import.meta.env.SSR is never statically replaced here and can't be relied on.
+// typeof window is a real runtime check that works regardless of how this module
+// got loaded; RouterDataProvider.jsx already uses the same check for the same
+// reason (server/client fetcher selection).
+const isSSR = () => typeof window === "undefined"
+
+const request = async (method, path, options = {}) => {
+    if (isSSR()) {
+        if (!isAbsoluteUrl(path)) {
+            const { pathname, queryObject } = splitPathAndQuery(path, options.query)
+            // Dynamic, non-literal-ish specifier so bundlers targeting the browser
+            // don't try to statically include this chunk (and the node:async_hooks
+            // import inside it) in a client bundle — see api/dispatch.server.js.
+            const dispatchModulePath = "./dispatch.server.js"
+            const { dispatchLoopback } = await import(/* @vite-ignore */ dispatchModulePath)
+            const result = await dispatchLoopback(method, pathname, {
+                query: queryObject,
+                body: options.body,
+                headers: options.headers,
+            })
+            if (result.matched) return result.data
+
+            // No registered route matches — fall back to a real HTTP request
+            // against this same server (still loopback, just the slower kind).
+            return fetchOverHttp(method, `${getServerOrigin()}${path}`, options)
+        }
+        return fetchOverHttp(method, path, options)
+    }
+
+    return fetchOverHttp(method, path, options)
+}
+
+export const api = {
+    get: (path, options) => request("GET", path, options),
+    post: (path, options) => request("POST", path, options),
+    put: (path, options) => request("PUT", path, options),
+    patch: (path, options) => request("PATCH", path, options),
+    delete: (path, options) => request("DELETE", path, options),
+}

--- a/packages/catalyst-core/src/api/dispatch.server.js
+++ b/packages/catalyst-core/src/api/dispatch.server.js
@@ -1,0 +1,98 @@
+import { getRequestContext } from "../server/requestContext.js"
+import { ApiError } from "./errors.js"
+
+// res methods that write headers/status. Guarded so a handler that runs via a
+// deferred loopback call fails loudly instead of silently dropping a cookie —
+// see design-spec-data-fetching-v2.md §6.2 / OQ-6.
+const HEADER_MUTATING_METHODS = [
+    "setHeader",
+    "cookie",
+    "clearCookie",
+    "append",
+    "writeHead",
+    "status",
+    "set",
+    "redirect",
+]
+
+const guardResponse = (res) => {
+    if (!res) return res
+
+    return new Proxy(res, {
+        get(target, prop, receiver) {
+            const value = Reflect.get(target, prop, receiver)
+            if (typeof value !== "function" || !HEADER_MUTATING_METHODS.includes(prop)) {
+                return typeof value === "function" ? value.bind(target) : value
+            }
+
+            return function guardedResMethod(...args) {
+                if (target.headersSent) {
+                    throw new Error(
+                        `[catalyst-core/api] An API handler called res.${String(prop)}() after the SSR ` +
+                            `shell had already started streaming (headers already sent). Handlers that set ` +
+                            `cookies/headers must be awaited as critical loader data — not called via a ` +
+                            `deferred/streamed loopback call, which resolves after the shell has flushed.`
+                    )
+                }
+                return value.apply(target, args)
+            }
+        },
+    })
+}
+
+const cloneResult = (result) => {
+    try {
+        return typeof structuredClone === "function" ? structuredClone(result) : result
+    } catch {
+        // result contains something structuredClone can't handle (functions, class
+        // instances, etc.) — sharing by reference here is safer than failing the
+        // request outright; routes with genuinely unclonable results should set
+        // unsafeShareResult explicitly rather than relying on this fallback.
+        return result
+    }
+}
+
+/**
+ * Attempts to serve a same-origin API request via a direct, in-process handler
+ * call instead of a real HTTP round-trip. Reads the registry off the current
+ * request (attached by expressServer.js) via ALS, so it works correctly regardless
+ * of whether this module and the one that built the registry ended up as the same
+ * physical module instance (they generally won't be, once Vite has bundled the SSR
+ * entry — see design-spec §6.2).
+ *
+ * @param {string} method
+ * @param {string} pathname
+ * @param {{ query?: Record<string, any>, body?: any, headers?: Record<string, string> }} [options]
+ * @returns {Promise<{ matched: false } | { matched: true, data: any }>}
+ */
+export const dispatchLoopback = async (method, pathname, options = {}) => {
+    const requestContext = getRequestContext()
+    const registry = requestContext?.req?.__catalystApiRegistry
+    const match = registry?.match(method, pathname)
+
+    if (!match || match.route.loopback === false) {
+        return { matched: false }
+    }
+
+    const { route, params } = match
+    const { query = {}, body, headers = {} } = options
+
+    const mergedHeaders = {
+        ...(requestContext?.req?.headers || {}),
+        ...headers,
+    }
+
+    const context = {
+        req: requestContext?.req,
+        res: guardResponse(requestContext?.res),
+        store: requestContext?.store,
+    }
+
+    try {
+        const result = await route.handler({ params, query, body, headers: mergedHeaders, context })
+        return { matched: true, data: route.unsafeShareResult ? result : cloneResult(result) }
+    } catch (error) {
+        if (error instanceof ApiError) throw error
+        throw new ApiError(500, { message: error.message }, { cause: error })
+    }
+}

--- a/packages/catalyst-core/src/api/dispatch.server.js
+++ b/packages/catalyst-core/src/api/dispatch.server.js
@@ -2,8 +2,7 @@ import { getRequestContext } from "../server/requestContext.js"
 import { ApiError } from "./errors.js"
 
 // res methods that write headers/status. Guarded so a handler that runs via a
-// deferred loopback call fails loudly instead of silently dropping a cookie —
-// see design-spec-data-fetching-v2.md §6.2 / OQ-6.
+// deferred loopback call fails loudly instead of silently dropping a cookie.
 const HEADER_MUTATING_METHODS = [
     "setHeader",
     "cookie",
@@ -58,7 +57,7 @@ const cloneResult = (result) => {
  * request (attached by expressServer.js) via ALS, so it works correctly regardless
  * of whether this module and the one that built the registry ended up as the same
  * physical module instance (they generally won't be, once Vite has bundled the SSR
- * entry — see design-spec §6.2).
+ * entry).
  *
  * @param {string} method
  * @param {string} pathname

--- a/packages/catalyst-core/src/api/errors.js
+++ b/packages/catalyst-core/src/api/errors.js
@@ -1,0 +1,19 @@
+/**
+ * Thrown by an API handler (or by the dispatch layer on its behalf) to produce a
+ * non-200 response. `status` maps directly to the HTTP status code for browser
+ * requests, and to the rejection callers see on a loopback dispatch.
+ */
+export class ApiError extends Error {
+    /**
+     * @param {number} status
+     * @param {any} body - sent as the JSON response body for HTTP requests
+     * @param {{ cause?: unknown }} [options]
+     */
+    constructor(status, body, options = {}) {
+        const message = typeof body === "string" ? body : body?.message || `API Error (${status})`
+        super(message, options.cause !== undefined ? { cause: options.cause } : undefined)
+        this.name = "ApiError"
+        this.status = status
+        this.body = body
+    }
+}

--- a/packages/catalyst-core/src/api/expressAdapter.js
+++ b/packages/catalyst-core/src/api/expressAdapter.js
@@ -1,0 +1,49 @@
+import { runWithRequestContext } from "../server/requestContext.js"
+import { ApiError } from "./errors.js"
+
+/**
+ * Mounts every route in an API registry onto an Express app as real HTTP endpoints
+ * — this is how browsers (and any HTTP client) reach them. SSR loopback dispatch
+ * (dispatch.server.js) bypasses this entirely for same-process calls; this adapter
+ * exists for everyone else.
+ *
+ * Mount before the app's own `addMiddlewares`/catch-all so explicit `defineApi`
+ * routes take priority, and any broader manual `/api` handler an app already has
+ * still works as a fallback for paths this registry doesn't cover.
+ *
+ * @param {import("express").Express} app
+ * @param {ReturnType<typeof import("./registry.js").createApiRegistry>} registry
+ */
+export const mountApiRegistry = (app, registry) => {
+    registry.routes.forEach((route) => {
+        app[route.method.toLowerCase()](route.path, async (req, res) => {
+            // Every request — including ones an API handler makes to another API
+            // route via loopback — runs inside its own ALS scope, so recursive
+            // api.get() calls from within a handler can find the registry and
+            // inherit this request's headers.
+            await runWithRequestContext({ req, res }, async () => {
+                try {
+                    const result = await route.handler({
+                        params: req.params,
+                        query: req.query,
+                        body: req.body,
+                        headers: req.headers,
+                        context: { req, res },
+                    })
+                    res.status(200).json(result)
+                } catch (error) {
+                    if (error instanceof ApiError) {
+                        res.status(error.status).json(
+                            typeof error.body === "object" && error.body !== null
+                                ? error.body
+                                : { message: error.message }
+                        )
+                        return
+                    }
+                    console.error(`[catalyst-core/api] Unhandled error in ${route.method} ${route.path}:`, error)
+                    res.status(500).json({ message: "Internal Server Error" })
+                }
+            })
+        })
+    })
+}

--- a/packages/catalyst-core/src/api/index.js
+++ b/packages/catalyst-core/src/api/index.js
@@ -1,0 +1,3 @@
+export { defineApi, createApiRegistry } from "./registry.js"
+export { api } from "./client.js"
+export { ApiError } from "./errors.js"

--- a/packages/catalyst-core/src/api/pathMatcher.js
+++ b/packages/catalyst-core/src/api/pathMatcher.js
@@ -1,0 +1,44 @@
+/**
+ * Minimal dependency-free path matcher for API route definitions, supporting
+ * `:param` segments (e.g. "/api/breeds/:breed"). Deliberately not a general-purpose
+ * router — API routes are simple REST paths, and a hand-rolled matcher avoids pulling
+ * in a dependency on Express's internal (and awkward, pre-1.0-API) path-to-regexp.
+ */
+
+/**
+ * @param {string} routePath
+ * @returns {{ regexp: RegExp, paramNames: string[] }}
+ */
+export const compilePath = (routePath) => {
+    const paramNames = []
+    const pattern = routePath
+        .split("/")
+        .map((segment) => {
+            if (segment.startsWith(":")) {
+                paramNames.push(segment.slice(1))
+                return "([^/]+)"
+            }
+            return segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+        })
+        .join("/")
+
+    return {
+        regexp: new RegExp(`^${pattern}/?$`),
+        paramNames,
+    }
+}
+
+/**
+ * @param {{ regexp: RegExp, paramNames: string[] }} compiled
+ * @param {string} pathname
+ * @returns {Record<string, string> | null}
+ */
+export const matchPath = (compiled, pathname) => {
+    const match = compiled.regexp.exec(pathname)
+    if (!match) return null
+
+    return compiled.paramNames.reduce((params, name, index) => {
+        params[name] = decodeURIComponent(match[index + 1])
+        return params
+    }, {})
+}

--- a/packages/catalyst-core/src/api/registry.js
+++ b/packages/catalyst-core/src/api/registry.js
@@ -1,0 +1,74 @@
+import { compilePath, matchPath } from "./pathMatcher.js"
+
+const SUPPORTED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
+
+/**
+ * @typedef ApiHandlerArgs
+ * @property {Record<string, string>} params
+ * @property {Record<string, any>} query
+ * @property {any} body
+ * @property {Record<string, string>} headers
+ * @property {{ req?: any, res?: any, store?: any }} context
+ */
+
+/**
+ * Declares a single API route with one handler used for both transports:
+ * mounted on Express for browser requests, and called directly (loopback) when
+ * an SSR loader/fetcher on the same server calls it via the universal api client.
+ *
+ * @param {{
+ *   method: "GET"|"POST"|"PUT"|"PATCH"|"DELETE",
+ *   path: string,
+ *   handler: (args: ApiHandlerArgs) => any,
+ *   loopback?: boolean,
+ *   unsafeShareResult?: boolean,
+ * }} config
+ */
+export const defineApi = ({ method, path, handler, loopback = true, unsafeShareResult = false }) => {
+    if (!method || !SUPPORTED_METHODS.includes(String(method).toUpperCase())) {
+        throw new Error(
+            `defineApi: invalid method "${method}" for path "${path}". Supported: ${SUPPORTED_METHODS.join(", ")}`
+        )
+    }
+    if (!path || typeof path !== "string" || !path.startsWith("/")) {
+        throw new Error(`defineApi: path must be a string starting with "/", got "${JSON.stringify(path)}"`)
+    }
+    if (typeof handler !== "function") {
+        throw new Error(`defineApi: handler for "${method} ${path}" must be a function`)
+    }
+
+    const { regexp, paramNames } = compilePath(path)
+
+    return {
+        method: method.toUpperCase(),
+        path,
+        handler,
+        loopback,
+        unsafeShareResult,
+        regexp,
+        paramNames,
+    }
+}
+
+/**
+ * @param {Array<ReturnType<typeof defineApi>>} routes
+ */
+export const createApiRegistry = (routes = []) => {
+    const normalized = routes.flat().filter(Boolean)
+
+    /**
+     * @param {string} method
+     * @param {string} pathname
+     */
+    const match = (method, pathname) => {
+        const upperMethod = String(method).toUpperCase()
+        for (const route of normalized) {
+            if (route.method !== upperMethod) continue
+            const params = matchPath(route, pathname)
+            if (params) return { route, params }
+        }
+        return null
+    }
+
+    return { routes: normalized, match }
+}

--- a/packages/catalyst-core/src/server/expressServer.js
+++ b/packages/catalyst-core/src/server/expressServer.js
@@ -12,7 +12,20 @@ const { cyan, yellow, green } = pc
 
 import { validateMiddleware, safeCall } from "./utils/validator.js"
 import { botDetectionMiddleware } from "./utils/botDetectionMiddleware.js"
+import { createApiRegistry } from "../api/registry.js"
+import { mountApiRegistry } from "../api/expressAdapter.js"
 const { addMiddlewares } = await import(path.join(process.env.src_path, "server/server.js"))
+
+// ─── Load app-defined API routes (optional — apps that don't define any get an
+// empty registry) ───────────────────────────────────────────────────────────────
+let apiRoutes = []
+try {
+    const apiModule = await import(path.join(process.env.src_path, "server/api/index.js"))
+    apiRoutes = apiModule.default || []
+} catch {
+    // No server/api/index.js — apiRoutes stays empty
+}
+const apiRegistry = createApiRegistry(apiRoutes)
 
 // OpenTelemetry is opt-in (OTEL_ENABLE) — mirrors server/renderer/handler.jsx.
 // Passthrough no-op middleware when disabled or packages aren't installed.
@@ -102,6 +115,21 @@ async function createServer() {
 
     // This middleware is being used to parse cookies!
     app.use(cookieParser())
+
+    // Attach the API registry to every request so loopback dispatch (called from
+    // inside SSR fetchers/loaders via the universal api client) can find it
+    // regardless of whether it ended up as the same physical module instance as
+    // this file once Vite has bundled the SSR entry — see
+    // docs/design-spec-data-fetching-v2.md §6.2.
+    app.use((req, _res, next) => {
+        req.__catalystApiRegistry = apiRegistry
+        next()
+    })
+
+    // Mount defineApi() routes before addMiddlewares so they take priority over
+    // any broader manual handler an app defines for the same path prefix (e.g. a
+    // catch-all `/api` handler still works as a fallback for unmatched routes).
+    mountApiRegistry(app, apiRegistry)
 
     // All the middlewares defined by the user will run here.
     if (validateMiddleware(addMiddlewares)) addMiddlewares(app)

--- a/packages/catalyst-core/src/server/expressServer.js
+++ b/packages/catalyst-core/src/server/expressServer.js
@@ -119,8 +119,7 @@ async function createServer() {
     // Attach the API registry to every request so loopback dispatch (called from
     // inside SSR fetchers/loaders via the universal api client) can find it
     // regardless of whether it ended up as the same physical module instance as
-    // this file once Vite has bundled the SSR entry — see
-    // docs/design-spec-data-fetching-v2.md §6.2.
+    // this file once Vite has bundled the SSR entry.
     app.use((req, _res, next) => {
         req.__catalystApiRegistry = apiRegistry
         next()

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -327,8 +327,7 @@ async function _handler(req, res) {
 
         // Everything below runs inside this request's ALS scope, so the universal
         // api client (loopback dispatch) and route loaders can read req/res/store
-        // without them being threaded through every call — see
-        // docs/design-spec-data-fetching-v2.md §7.
+        // without them being threaded through every call.
         await runWithRequestContext({ req, res, store }, async () => {
             const cachedRoutes = getCachedRoutes()
             const allMatches = cachedRoutes ? NestedMatchRoutes(cachedRoutes, req.originalUrl) || [] : []

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -30,6 +30,7 @@ import App from "@catalyst/template/src/js/containers/App/index"
 import { getRoutes } from "@catalyst/template/src/js/routes/utils"
 import createStore from "@catalyst/template/src/js/store/index.js"
 import { SsrRequestProvider } from "../../web-router/components/SsrRequestContext.jsx"
+import { runWithRequestContext } from "../requestContext.js"
 import { getManifest, getAssetManifest } from "../manifestCache.js"
 
 const DEFAULT_SAFE_AREA_INSETS = { top: 0, right: 0, bottom: 0, left: 0 }
@@ -324,56 +325,80 @@ async function _handler(req, res) {
         let fetcherData = {}
         const store = validateConfigureStore(createStore) ? await createStore({}, req, res) : null
 
-        const cachedRoutes = getCachedRoutes()
-        const allMatches = cachedRoutes ? NestedMatchRoutes(cachedRoutes, req.originalUrl) || [] : []
-        let allTags = []
+        // Everything below runs inside this request's ALS scope, so the universal
+        // api client (loopback dispatch) and route loaders can read req/res/store
+        // without them being threaded through every call — see
+        // docs/design-spec-data-fetching-v2.md §7.
+        await runWithRequestContext({ req, res, store }, async () => {
+            const cachedRoutes = getCachedRoutes()
+            const allMatches = cachedRoutes ? NestedMatchRoutes(cachedRoutes, req.originalUrl) || [] : []
+            let allTags = []
 
-        safeCall(onRouteMatch, { req, res, matches: allMatches, store })
-
-        if (res.headersSent) return
-
-        try {
-            await tracedAppServerSideFunction({ store, req, res })
-            safeCall(onAppServerSideSuccess, { req, res, store })
+            safeCall(onRouteMatch, { req, res, matches: allMatches, store })
 
             if (res.headersSent) return
 
             try {
-                fetcherData = await tracedServerDataFetcher(
-                    { routes: cachedRoutes, req, res, url: req.originalUrl },
-                    { store }
-                )
+                await tracedAppServerSideFunction({ store, req, res })
+                safeCall(onAppServerSideSuccess, { req, res, store })
 
                 if (res.headersSent) return
 
-                const err = fetcherData?.[req.originalUrl]?.error
-                allTags = tracedGetMetaData(allMatches, fetcherData)
-                const chunkExtractor = collectAssets(req, allMatches)
-
-                if (err) {
-                    safeCall(onFetcherError, { req, res, store, error: err })
-
-                    if (res.headersSent) return
-
-                    const statusCode = err.status_code || 404
-                    await tracedRenderMarkUp(
-                        statusCode,
-                        req,
-                        res,
-                        allTags,
-                        fetcherData,
-                        store,
-                        allMatches,
-                        context,
-                        chunkExtractor
+                try {
+                    fetcherData = await tracedServerDataFetcher(
+                        { routes: cachedRoutes, req, res, url: req.originalUrl },
+                        { store }
                     )
-                } else {
-                    safeCall(onFetcherSuccess, { req, res, store })
 
                     if (res.headersSent) return
 
+                    const err = fetcherData?.[req.originalUrl]?.error
+                    allTags = tracedGetMetaData(allMatches, fetcherData)
+                    const chunkExtractor = collectAssets(req, allMatches)
+
+                    if (err) {
+                        safeCall(onFetcherError, { req, res, store, error: err })
+
+                        if (res.headersSent) return
+
+                        const statusCode = err.status_code || 404
+                        await tracedRenderMarkUp(
+                            statusCode,
+                            req,
+                            res,
+                            allTags,
+                            fetcherData,
+                            store,
+                            allMatches,
+                            context,
+                            chunkExtractor
+                        )
+                    } else {
+                        safeCall(onFetcherSuccess, { req, res, store })
+
+                        if (res.headersSent) return
+
+                        await tracedRenderMarkUp(
+                            null,
+                            req,
+                            res,
+                            allTags,
+                            fetcherData,
+                            store,
+                            allMatches,
+                            context,
+                            chunkExtractor
+                        )
+                    }
+                } catch (error) {
+                    console.error("Error in executing serverFetcher functions:", error)
+                    safeCall(onFetcherError, { req, res, store, error })
+
+                    if (res.headersSent) return
+
+                    const chunkExtractor = collectAssets(req, allMatches)
                     await tracedRenderMarkUp(
-                        null,
+                        404,
                         req,
                         res,
                         allTags,
@@ -385,14 +410,14 @@ async function _handler(req, res) {
                     )
                 }
             } catch (error) {
-                console.error("Error in executing serverFetcher functions:", error)
-                safeCall(onFetcherError, { req, res, store, error })
+                console.error("Error in executing serverSideFunction inside App:", error)
+                safeCall(onAppServerSideError, { req, res, store, error })
 
                 if (res.headersSent) return
 
                 const chunkExtractor = collectAssets(req, allMatches)
                 await tracedRenderMarkUp(
-                    404,
+                    error.status_code,
                     req,
                     res,
                     allTags,
@@ -403,25 +428,7 @@ async function _handler(req, res) {
                     chunkExtractor
                 )
             }
-        } catch (error) {
-            console.error("Error in executing serverSideFunction inside App:", error)
-            safeCall(onAppServerSideError, { req, res, store, error })
-
-            if (res.headersSent) return
-
-            const chunkExtractor = collectAssets(req, allMatches)
-            await tracedRenderMarkUp(
-                error.status_code,
-                req,
-                res,
-                allTags,
-                fetcherData,
-                store,
-                allMatches,
-                context,
-                chunkExtractor
-            )
-        }
+        })
     } catch (error) {
         console.error("Error in handling document request:", error)
         safeCall(onRequestError, { req, res, error })

--- a/packages/catalyst-core/src/server/requestContext.js
+++ b/packages/catalyst-core/src/server/requestContext.js
@@ -1,0 +1,36 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+
+/**
+ * Per-request context, entered once at the top of the SSR handler and read by
+ * anything that needs to know "which request am I part of" without req/res being
+ * threaded through every call — the universal api client (loopback dispatch) and
+ * route loaders both rely on this.
+ *
+ * Stored on globalThis (keyed by a registry symbol) rather than as a plain
+ * module-scoped singleton: Vite's dev SSR pipeline loads its ssrLoadModule entry
+ * (handler.jsx) through its own module graph, but treats this file as an
+ * externalized node_modules dependency when reached from elsewhere (e.g. from
+ * dispatch.server.js via the api client) — loaded through Node's separate,
+ * plain-import module cache instead. A `new AsyncLocalStorage()` at module scope
+ * would silently split into two unrelated stores across that boundary, so
+ * runWithRequestContext and getRequestContext would never see each other's data.
+ * globalThis is the one thing guaranteed to be shared across both load paths.
+ */
+const REQUEST_CONTEXT_KEY = Symbol.for("catalyst-core.requestContextStorage")
+const requestContextStorage =
+    globalThis[REQUEST_CONTEXT_KEY] || (globalThis[REQUEST_CONTEXT_KEY] = new AsyncLocalStorage())
+
+/**
+ * @param {{ req: import("express").Request, res: import("express").Response, store?: any }} context
+ * @param {() => any} fn
+ */
+export const runWithRequestContext = (context, fn) => {
+    return requestContextStorage.run(context, fn)
+}
+
+/**
+ * @returns {{ req: import("express").Request, res: import("express").Response, store?: any } | undefined}
+ */
+export const getRequestContext = () => {
+    return requestContextStorage.getStore()
+}


### PR DESCRIPTION
## Summary

Adds `catalyst-core/api`: `defineApi()` for declaring an API route once, mounted on
Express for real browser/HTTP requests and dispatched **in-process** (no network hop)
when called from server-side code on the same server, via a single universal `api`
client.

**Design discussion:** [#374](https://github.com/tata1mg/catalyst-core/discussions/374)
— motivation, drawbacks, rejected alternatives, and diagrams of the dispatch/loopback
flow, for anyone who wants the design rationale rather than just the diff.

- `api/registry.js` — `defineApi()` / `createApiRegistry()`, with a dependency-free
  `:param` path matcher (no reliance on Express's internal `path-to-regexp`)
- `api/dispatch.server.js` — loopback dispatch. Reads the registry off the request
  (not a module singleton — Vite's dev SSR module graph and Node's own module cache
  don't share instances for `node_modules` siblings of the SSR entry point).
  `structuredClone()`s results by default (`unsafeShareResult: true` opts a route out);
  throws if a handler tries to set headers/cookies after the SSR shell has already
  started streaming, rather than silently dropping them
- `api/client.js` — isomorphic `api.get/post/put/patch/delete`. The server branch uses
  `typeof window === "undefined"` rather than `import.meta.env.SSR`, which is never
  statically replaced for code living in an installed `node_modules` package; falls
  back to real HTTP for same-origin paths the registry doesn't cover
- `server/requestContext.js` — an `AsyncLocalStorage` request-scoped context
  (`{ req, res, store }`), `globalThis`-backed for the same cross-module-instance
  reason as `dispatch.server.js` above
- `expressServer.js` / `handler.jsx` — load the app's optional `server/api/index.js`,
  mount routes before `addMiddlewares` (explicit routes win; a broader manual `/api`
  handler still works as a fallback), enter the request-scoped ALS context per request

`apps/catalyst-core-test` now defines its two dog-API routes once via `defineApi` and
shares one fetcher function between `clientFetcher` and `serverFetcher`, replacing
hand-duplicated client/server fetch logic — verified end-to-end against a live dev
server (SSR renders via loopback dispatch, direct browser requests hit the same
Express-mounted routes, unmatched `/api/*` paths still fall through to the app's
existing generic handler).

Also adds a reference doc, `docs/content/11-API Reference/05-API-Routes-and-Loopback.md`
(linked from the API Reference overview page), covering how to define/register/call a
route and the loopback-specific gotchas (result copying, `loopback: false`, the
late-header-write throw).

This is additive only — existing `clientFetcher`/`serverFetcher` routes are unaffected.

## Test plan

- [x] Live dev server: SSR request to a `defineApi`-backed route resolves via loopback dispatch (verified via temporary debug instrumentation, since removed)
- [x] Direct browser `curl`/fetch against the same path resolves via the Express-mounted route
- [x] Unmatched `/api/*` paths still fall through to the app's existing generic handler
- [x] `eslint` clean on all new files
- [x] New docs page's relative links resolve to existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
