### PR TITLE
feat(errors): unified error code system (RFC #155)

### DIFF
--- a/errors/ANDROID/ANDROID-000.md
+++ b/errors/ANDROID/ANDROID-000.md
@@ -1,0 +1,19 @@
+# ANDROID-000
+
+**Category:** ANDROID
+
+## Message
+
+Android build failed in an upstream toolchain step
+
+## Details
+
+This wraps an error from Gradle. See the printed upstream output for the cause.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Read the upstream Gradle error printed above and fix the underlying issue.

--- a/errors/BUNDLE/BUNDLE-000.md
+++ b/errors/BUNDLE/BUNDLE-000.md
@@ -1,0 +1,19 @@
+# BUNDLE-000
+
+**Category:** BUNDLE
+
+## Message
+
+Build failed in an upstream bundler step
+
+## Details
+
+This is a wrapper around an error from Vite/Rollup or another upstream build tool. See the printed upstream code/message for the actual cause — catalyst-core does not reinterpret it.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Read the upstream error message/code printed above and fix the underlying issue.

--- a/errors/IOS/IOS-000.md
+++ b/errors/IOS/IOS-000.md
@@ -1,0 +1,19 @@
+# IOS-000
+
+**Category:** IOS
+
+## Message
+
+iOS build failed in an upstream toolchain step
+
+## Details
+
+This wraps an error from Xcode/CocoaPods. See the printed upstream output for the cause.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Read the upstream Xcode/CocoaPods error printed above and fix the underlying issue.

--- a/errors/PREFLIGHT/PREFLIGHT-001.md
+++ b/errors/PREFLIGHT/PREFLIGHT-001.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-001
+
+**Category:** PREFLIGHT
+
+## Message
+
+config not found in config folder
+
+## Details
+
+A config object must be exported from the config folder in your project root.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Create config/config.json (or config/index.js) exporting the required config object.

--- a/errors/PREFLIGHT/PREFLIGHT-002.md
+++ b/errors/PREFLIGHT/PREFLIGHT-002.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-002
+
+**Category:** PREFLIGHT
+
+## Message
+
+config export is not an object
+
+## Details
+
+The config folder must export a plain object.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure config/config.json exports an object, not a string, array, or function.

--- a/errors/PREFLIGHT/PREFLIGHT-003.md
+++ b/errors/PREFLIGHT/PREFLIGHT-003.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-003
+
+**Category:** PREFLIGHT
+
+## Message
+
+required key missing inside config.json
+
+## Details
+
+config.json is missing one or more required keys.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Add the missing key to config.json. See the config.json reference in the framework docs.

--- a/errors/PREFLIGHT/PREFLIGHT-004.md
+++ b/errors/PREFLIGHT/PREFLIGHT-004.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-004
+
+**Category:** PREFLIGHT
+
+## Message
+
+package.json not found in the project
+
+## Details
+
+A package.json must exist in the project root directory.
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Run this command from the project root, or restore package.json.

--- a/errors/PREFLIGHT/PREFLIGHT-005.md
+++ b/errors/PREFLIGHT/PREFLIGHT-005.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-005
+
+**Category:** PREFLIGHT
+
+## Message
+
+package.json should be defined in project root directory
+
+## Details
+
+package.json exists but could not be parsed as an object.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Check package.json for valid JSON syntax.

--- a/errors/PREFLIGHT/PREFLIGHT-006.md
+++ b/errors/PREFLIGHT/PREFLIGHT-006.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-006
+
+**Category:** PREFLIGHT
+
+## Message
+
+moduleAliases not found in package.json
+
+## Details
+
+package.json must export a moduleAliases object.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Add a moduleAliases object to package.json.

--- a/errors/PREFLIGHT/PREFLIGHT-007.md
+++ b/errors/PREFLIGHT/PREFLIGHT-007.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-007
+
+**Category:** PREFLIGHT
+
+## Message
+
+moduleAliases named object should be exported from package.json
+
+## Details
+
+moduleAliases was found in package.json but is not an object.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure moduleAliases is exported as an object in package.json.

--- a/errors/PREFLIGHT/PREFLIGHT-008.md
+++ b/errors/PREFLIGHT/PREFLIGHT-008.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-008
+
+**Category:** PREFLIGHT
+
+## Message
+
+catalyst keyword is restricted for defining aliases
+
+## Details
+
+Module alias keys containing 'catalyst' are reserved by the framework.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Rename the alias to something that does not contain 'catalyst'.

--- a/errors/PREFLIGHT/PREFLIGHT-009.md
+++ b/errors/PREFLIGHT/PREFLIGHT-009.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-009
+
+**Category:** PREFLIGHT
+
+## Message
+
+required module alias not defined inside package.json
+
+## Details
+
+One or more required module aliases are missing from moduleAliases.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Add the missing alias to the moduleAliases object in package.json.

--- a/errors/PREFLIGHT/PREFLIGHT-010.md
+++ b/errors/PREFLIGHT/PREFLIGHT-010.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-010
+
+**Category:** PREFLIGHT
+
+## Message
+
+preServerInit named function should be defined in server/index.js
+
+## Details
+
+server/index.js must export a preServerInit function.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Export a preServerInit function from server/index.js, or remove the reference to it.

--- a/errors/PREFLIGHT/PREFLIGHT-011.md
+++ b/errors/PREFLIGHT/PREFLIGHT-011.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-011
+
+**Category:** PREFLIGHT
+
+## Message
+
+preServerInit should be a function present in server/index.js
+
+## Details
+
+preServerInit was found but is not a function.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure preServerInit is exported as a function.

--- a/errors/PREFLIGHT/PREFLIGHT-012.md
+++ b/errors/PREFLIGHT/PREFLIGHT-012.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-012
+
+**Category:** PREFLIGHT
+
+## Message
+
+addMiddlewares named function not found in server/server.js
+
+## Details
+
+server/server.js must export an addMiddlewares function.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Export an addMiddlewares function from server/server.js.

--- a/errors/PREFLIGHT/PREFLIGHT-013.md
+++ b/errors/PREFLIGHT/PREFLIGHT-013.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-013
+
+**Category:** PREFLIGHT
+
+## Message
+
+addMiddlewares should be a function present in server/server.js
+
+## Details
+
+addMiddlewares was found but is not a function.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure addMiddlewares is exported as a function.

--- a/errors/PREFLIGHT/PREFLIGHT-014.md
+++ b/errors/PREFLIGHT/PREFLIGHT-014.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-014
+
+**Category:** PREFLIGHT
+
+## Message
+
+reducer not found in src/js/containers/App/reducer
+
+## Details
+
+A reducer must be exported from src/js/containers/App/reducer.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Export a reducer from src/js/containers/App/reducer.

--- a/errors/PREFLIGHT/PREFLIGHT-015.md
+++ b/errors/PREFLIGHT/PREFLIGHT-015.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-015
+
+**Category:** PREFLIGHT
+
+## Message
+
+reducer should be present in src/js/containers/App/reducer
+
+## Details
+
+The reducer export was found but is not a function.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure the reducer is exported as a function.

--- a/errors/PREFLIGHT/PREFLIGHT-016.md
+++ b/errors/PREFLIGHT/PREFLIGHT-016.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-016
+
+**Category:** PREFLIGHT
+
+## Message
+
+configureStore not found in file src/js/store/index.js
+
+## Details
+
+src/js/store/index.js must export a configureStore function.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Export a configureStore function from src/js/store/index.js.

--- a/errors/PREFLIGHT/PREFLIGHT-017.md
+++ b/errors/PREFLIGHT/PREFLIGHT-017.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-017
+
+**Category:** PREFLIGHT
+
+## Message
+
+configureStore should be a function exported from src/js/store/index.js
+
+## Details
+
+configureStore was found but is not a function.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure configureStore is exported as a function.

--- a/errors/PREFLIGHT/PREFLIGHT-018.md
+++ b/errors/PREFLIGHT/PREFLIGHT-018.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-018
+
+**Category:** PREFLIGHT
+
+## Message
+
+getRoutes not found in file src/js/routes/utils.js
+
+## Details
+
+src/js/routes/utils.js must export a getRoutes function.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Export a getRoutes function from src/js/routes/utils.js.

--- a/errors/PREFLIGHT/PREFLIGHT-019.md
+++ b/errors/PREFLIGHT/PREFLIGHT-019.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-019
+
+**Category:** PREFLIGHT
+
+## Message
+
+getRoutes should be a function exported from src/js/routers/index.js
+
+## Details
+
+getRoutes was found but is not a function.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure getRoutes is exported as a function.

--- a/errors/PREFLIGHT/PREFLIGHT-020.md
+++ b/errors/PREFLIGHT/PREFLIGHT-020.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-020
+
+**Category:** PREFLIGHT
+
+## Message
+
+document not found in file server/document.js
+
+## Details
+
+server/document.js must export a document component.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Export a document React component from server/document.js.

--- a/errors/PREFLIGHT/PREFLIGHT-021.md
+++ b/errors/PREFLIGHT/PREFLIGHT-021.md
@@ -1,0 +1,19 @@
+# PREFLIGHT-021
+
+**Category:** PREFLIGHT
+
+## Message
+
+document should be a react component exported from server/document.js
+
+## Details
+
+document was found but is not a function/component.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure document is exported as a React component (function).

--- a/errors/PROCESS/PROCESS-001.md
+++ b/errors/PROCESS/PROCESS-001.md
@@ -1,0 +1,19 @@
+# PROCESS-001
+
+**Category:** PROCESS
+
+## Message
+
+preServerInit threw an error during server startup
+
+## Details
+
+The preServerInit hook failed. Note: server startup currently continues despite this error (tracked separately as a fix — see issue #298); this code only identifies which hook failed.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Fix the error thrown inside your preServerInit hook (see the cause above).

--- a/errors/PROCESS/PROCESS-002.md
+++ b/errors/PROCESS/PROCESS-002.md
@@ -1,0 +1,19 @@
+# PROCESS-002
+
+**Category:** PROCESS
+
+## Message
+
+A user-defined hook threw an error
+
+## Details
+
+A user-defined hook (e.g. onRouteMatch, onFetcherError, onServerError) threw. It was caught so the SSR pipeline keeps running; see the cause above for which hook and why.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Fix the error thrown inside the hook (see the cause above).

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-001.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-001.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-001
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Permission denied
+
+## Details
+
+Required permission was not granted by the user
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Grant permission in device settings and try again

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-002.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-002.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-002
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Permission required
+
+## Details
+
+This operation requires additional permissions
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Grant the required permission to continue

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-003.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-003.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-003
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+No internet connection
+
+## Details
+
+Network connection is required for this operation
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Check your internet connection and try again

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-004.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-004.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-004
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Download failed
+
+## Details
+
+The download could not be completed
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Check your connection and try again

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-005.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-005.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-005
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+File not found
+
+## Details
+
+The requested file could not be located
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+The file may have been moved or deleted

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-006.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-006.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-006
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+File too large
+
+## Details
+
+File exceeds the maximum size limit
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Choose a smaller file or compress the current file

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-007.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-007.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-007
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Storage full
+
+## Details
+
+Device storage is full and cannot save the file
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Free up some storage space and try again

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-008.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-008.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-008
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+File corrupted
+
+## Details
+
+The file could not be read or is corrupted
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Try selecting a different file

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-009.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-009.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-009
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Operation cancelled
+
+## Details
+
+The operation was cancelled by the user
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Try again if you want to complete the operation

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-010.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-010.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-010
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+No file selected
+
+## Details
+
+No file was selected by the user
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Select a file and try again

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-011.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-011.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-011
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Invalid file type
+
+## Details
+
+The selected file type is not supported
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Choose a file with a supported format

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-012.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-012.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-012
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Invalid parameters
+
+## Details
+
+One or more parameters passed to the native call were invalid
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Check the parameters passed to the native API call

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-013.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-013.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-013
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Native feature unavailable
+
+## Details
+
+The native bridge is not available or not initialized
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Use web fallback if available

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-014.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-014.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-014
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Feature not supported
+
+## Details
+
+This feature is not supported on the current platform
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Try using an alternative method or device

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-015.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-015.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-015
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+An unexpected error occurred
+
+## Details
+
+An internal error occurred while processing the request
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Try again or contact support if the problem persists

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-016.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-016.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-016
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Camera unavailable
+
+## Details
+
+Camera hardware is not available or accessible
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Check if your device has a camera and try again

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-017.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-017.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-017
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Camera in use
+
+## Details
+
+Camera is being used by another application
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Close other camera apps and try again

--- a/errors/index.json
+++ b/errors/index.json
@@ -1,0 +1,346 @@
+{
+    "PREFLIGHT-001": {
+        "category": "PREFLIGHT",
+        "message": "config not found in config folder",
+        "details": "A config object must be exported from the config folder in your project root.",
+        "recoverable": true,
+        "suggestedAction": "Create config/config.json (or config/index.js) exporting the required config object.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-001.md"
+    },
+    "PREFLIGHT-002": {
+        "category": "PREFLIGHT",
+        "message": "config export is not an object",
+        "details": "The config folder must export a plain object.",
+        "recoverable": true,
+        "suggestedAction": "Ensure config/config.json exports an object, not a string, array, or function.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-002.md"
+    },
+    "PREFLIGHT-003": {
+        "category": "PREFLIGHT",
+        "message": "required key missing inside config.json",
+        "details": "config.json is missing one or more required keys.",
+        "recoverable": true,
+        "suggestedAction": "Add the missing key to config.json. See the config.json reference in the framework docs.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-003.md"
+    },
+    "PREFLIGHT-004": {
+        "category": "PREFLIGHT",
+        "message": "package.json not found in the project",
+        "details": "A package.json must exist in the project root directory.",
+        "recoverable": false,
+        "suggestedAction": "Run this command from the project root, or restore package.json.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-004.md"
+    },
+    "PREFLIGHT-005": {
+        "category": "PREFLIGHT",
+        "message": "package.json should be defined in project root directory",
+        "details": "package.json exists but could not be parsed as an object.",
+        "recoverable": true,
+        "suggestedAction": "Check package.json for valid JSON syntax.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-005.md"
+    },
+    "PREFLIGHT-006": {
+        "category": "PREFLIGHT",
+        "message": "moduleAliases not found in package.json",
+        "details": "package.json must export a moduleAliases object.",
+        "recoverable": true,
+        "suggestedAction": "Add a moduleAliases object to package.json.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-006.md"
+    },
+    "PREFLIGHT-007": {
+        "category": "PREFLIGHT",
+        "message": "moduleAliases named object should be exported from package.json",
+        "details": "moduleAliases was found in package.json but is not an object.",
+        "recoverable": true,
+        "suggestedAction": "Ensure moduleAliases is exported as an object in package.json.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-007.md"
+    },
+    "PREFLIGHT-008": {
+        "category": "PREFLIGHT",
+        "message": "catalyst keyword is restricted for defining aliases",
+        "details": "Module alias keys containing 'catalyst' are reserved by the framework.",
+        "recoverable": true,
+        "suggestedAction": "Rename the alias to something that does not contain 'catalyst'.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-008.md"
+    },
+    "PREFLIGHT-009": {
+        "category": "PREFLIGHT",
+        "message": "required module alias not defined inside package.json",
+        "details": "One or more required module aliases are missing from moduleAliases.",
+        "recoverable": true,
+        "suggestedAction": "Add the missing alias to the moduleAliases object in package.json.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-009.md"
+    },
+    "PREFLIGHT-010": {
+        "category": "PREFLIGHT",
+        "message": "preServerInit named function should be defined in server/index.js",
+        "details": "server/index.js must export a preServerInit function.",
+        "recoverable": true,
+        "suggestedAction": "Export a preServerInit function from server/index.js, or remove the reference to it.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-010.md"
+    },
+    "PREFLIGHT-011": {
+        "category": "PREFLIGHT",
+        "message": "preServerInit should be a function present in server/index.js",
+        "details": "preServerInit was found but is not a function.",
+        "recoverable": true,
+        "suggestedAction": "Ensure preServerInit is exported as a function.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-011.md"
+    },
+    "PREFLIGHT-012": {
+        "category": "PREFLIGHT",
+        "message": "addMiddlewares named function not found in server/server.js",
+        "details": "server/server.js must export an addMiddlewares function.",
+        "recoverable": true,
+        "suggestedAction": "Export an addMiddlewares function from server/server.js.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-012.md"
+    },
+    "PREFLIGHT-013": {
+        "category": "PREFLIGHT",
+        "message": "addMiddlewares should be a function present in server/server.js",
+        "details": "addMiddlewares was found but is not a function.",
+        "recoverable": true,
+        "suggestedAction": "Ensure addMiddlewares is exported as a function.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-013.md"
+    },
+    "PREFLIGHT-014": {
+        "category": "PREFLIGHT",
+        "message": "reducer not found in src/js/containers/App/reducer",
+        "details": "A reducer must be exported from src/js/containers/App/reducer.",
+        "recoverable": true,
+        "suggestedAction": "Export a reducer from src/js/containers/App/reducer.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-014.md"
+    },
+    "PREFLIGHT-015": {
+        "category": "PREFLIGHT",
+        "message": "reducer should be present in src/js/containers/App/reducer",
+        "details": "The reducer export was found but is not a function.",
+        "recoverable": true,
+        "suggestedAction": "Ensure the reducer is exported as a function.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-015.md"
+    },
+    "PREFLIGHT-016": {
+        "category": "PREFLIGHT",
+        "message": "configureStore not found in file src/js/store/index.js",
+        "details": "src/js/store/index.js must export a configureStore function.",
+        "recoverable": true,
+        "suggestedAction": "Export a configureStore function from src/js/store/index.js.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-016.md"
+    },
+    "PREFLIGHT-017": {
+        "category": "PREFLIGHT",
+        "message": "configureStore should be a function exported from src/js/store/index.js",
+        "details": "configureStore was found but is not a function.",
+        "recoverable": true,
+        "suggestedAction": "Ensure configureStore is exported as a function.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-017.md"
+    },
+    "PREFLIGHT-018": {
+        "category": "PREFLIGHT",
+        "message": "getRoutes not found in file src/js/routes/utils.js",
+        "details": "src/js/routes/utils.js must export a getRoutes function.",
+        "recoverable": true,
+        "suggestedAction": "Export a getRoutes function from src/js/routes/utils.js.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-018.md"
+    },
+    "PREFLIGHT-019": {
+        "category": "PREFLIGHT",
+        "message": "getRoutes should be a function exported from src/js/routers/index.js",
+        "details": "getRoutes was found but is not a function.",
+        "recoverable": true,
+        "suggestedAction": "Ensure getRoutes is exported as a function.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-019.md"
+    },
+    "PREFLIGHT-020": {
+        "category": "PREFLIGHT",
+        "message": "document not found in file server/document.js",
+        "details": "server/document.js must export a document component.",
+        "recoverable": true,
+        "suggestedAction": "Export a document React component from server/document.js.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-020.md"
+    },
+    "PREFLIGHT-021": {
+        "category": "PREFLIGHT",
+        "message": "document should be a react component exported from server/document.js",
+        "details": "document was found but is not a function/component.",
+        "recoverable": true,
+        "suggestedAction": "Ensure document is exported as a React component (function).",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PREFLIGHT/PREFLIGHT-021.md"
+    },
+    "PROCESS-001": {
+        "category": "PROCESS",
+        "message": "preServerInit threw an error during server startup",
+        "details": "The preServerInit hook failed. Note: server startup currently continues despite this error (tracked separately as a fix — see issue #298); this code only identifies which hook failed.",
+        "recoverable": true,
+        "suggestedAction": "Fix the error thrown inside your preServerInit hook (see the cause above).",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PROCESS/PROCESS-001.md"
+    },
+    "PROCESS-002": {
+        "category": "PROCESS",
+        "message": "A user-defined hook threw an error",
+        "details": "A user-defined hook (e.g. onRouteMatch, onFetcherError, onServerError) threw. It was caught so the SSR pipeline keeps running; see the cause above for which hook and why.",
+        "recoverable": true,
+        "suggestedAction": "Fix the error thrown inside the hook (see the cause above).",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/PROCESS/PROCESS-002.md"
+    },
+    "BUNDLE-000": {
+        "category": "BUNDLE",
+        "message": "Build failed in an upstream bundler step",
+        "details": "This is a wrapper around an error from Vite/Rollup or another upstream build tool. See the printed upstream code/message for the actual cause — catalyst-core does not reinterpret it.",
+        "recoverable": true,
+        "suggestedAction": "Read the upstream error message/code printed above and fix the underlying issue.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/BUNDLE/BUNDLE-000.md"
+    },
+    "IOS-000": {
+        "category": "IOS",
+        "message": "iOS build failed in an upstream toolchain step",
+        "details": "This wraps an error from Xcode/CocoaPods. See the printed upstream output for the cause.",
+        "recoverable": true,
+        "suggestedAction": "Read the upstream Xcode/CocoaPods error printed above and fix the underlying issue.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/IOS/IOS-000.md"
+    },
+    "ANDROID-000": {
+        "category": "ANDROID",
+        "message": "Android build failed in an upstream toolchain step",
+        "details": "This wraps an error from Gradle. See the printed upstream output for the cause.",
+        "recoverable": true,
+        "suggestedAction": "Read the upstream Gradle error printed above and fix the underlying issue.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/ANDROID/ANDROID-000.md"
+    },
+    "RUNTIME-NATIVE-001": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Permission denied",
+        "details": "Required permission was not granted by the user",
+        "recoverable": true,
+        "suggestedAction": "Grant permission in device settings and try again",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-001.md"
+    },
+    "RUNTIME-NATIVE-002": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Permission required",
+        "details": "This operation requires additional permissions",
+        "recoverable": true,
+        "suggestedAction": "Grant the required permission to continue",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-002.md"
+    },
+    "RUNTIME-NATIVE-003": {
+        "category": "RUNTIME-NATIVE",
+        "message": "No internet connection",
+        "details": "Network connection is required for this operation",
+        "recoverable": true,
+        "suggestedAction": "Check your internet connection and try again",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-003.md"
+    },
+    "RUNTIME-NATIVE-004": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Download failed",
+        "details": "The download could not be completed",
+        "recoverable": true,
+        "suggestedAction": "Check your connection and try again",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-004.md"
+    },
+    "RUNTIME-NATIVE-005": {
+        "category": "RUNTIME-NATIVE",
+        "message": "File not found",
+        "details": "The requested file could not be located",
+        "recoverable": false,
+        "suggestedAction": "The file may have been moved or deleted",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-005.md"
+    },
+    "RUNTIME-NATIVE-006": {
+        "category": "RUNTIME-NATIVE",
+        "message": "File too large",
+        "details": "File exceeds the maximum size limit",
+        "recoverable": true,
+        "suggestedAction": "Choose a smaller file or compress the current file",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-006.md"
+    },
+    "RUNTIME-NATIVE-007": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Storage full",
+        "details": "Device storage is full and cannot save the file",
+        "recoverable": true,
+        "suggestedAction": "Free up some storage space and try again",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-007.md"
+    },
+    "RUNTIME-NATIVE-008": {
+        "category": "RUNTIME-NATIVE",
+        "message": "File corrupted",
+        "details": "The file could not be read or is corrupted",
+        "recoverable": false,
+        "suggestedAction": "Try selecting a different file",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-008.md"
+    },
+    "RUNTIME-NATIVE-009": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Operation cancelled",
+        "details": "The operation was cancelled by the user",
+        "recoverable": true,
+        "suggestedAction": "Try again if you want to complete the operation",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-009.md"
+    },
+    "RUNTIME-NATIVE-010": {
+        "category": "RUNTIME-NATIVE",
+        "message": "No file selected",
+        "details": "No file was selected by the user",
+        "recoverable": true,
+        "suggestedAction": "Select a file and try again",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-010.md"
+    },
+    "RUNTIME-NATIVE-011": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Invalid file type",
+        "details": "The selected file type is not supported",
+        "recoverable": true,
+        "suggestedAction": "Choose a file with a supported format",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-011.md"
+    },
+    "RUNTIME-NATIVE-012": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Invalid parameters",
+        "details": "One or more parameters passed to the native call were invalid",
+        "recoverable": true,
+        "suggestedAction": "Check the parameters passed to the native API call",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-012.md"
+    },
+    "RUNTIME-NATIVE-013": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Native feature unavailable",
+        "details": "The native bridge is not available or not initialized",
+        "recoverable": false,
+        "suggestedAction": "Use web fallback if available",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-013.md"
+    },
+    "RUNTIME-NATIVE-014": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Feature not supported",
+        "details": "This feature is not supported on the current platform",
+        "recoverable": false,
+        "suggestedAction": "Try using an alternative method or device",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-014.md"
+    },
+    "RUNTIME-NATIVE-015": {
+        "category": "RUNTIME-NATIVE",
+        "message": "An unexpected error occurred",
+        "details": "An internal error occurred while processing the request",
+        "recoverable": true,
+        "suggestedAction": "Try again or contact support if the problem persists",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-015.md"
+    },
+    "RUNTIME-NATIVE-016": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Camera unavailable",
+        "details": "Camera hardware is not available or accessible",
+        "recoverable": false,
+        "suggestedAction": "Check if your device has a camera and try again",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-016.md"
+    },
+    "RUNTIME-NATIVE-017": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Camera in use",
+        "details": "Camera is being used by another application",
+        "recoverable": true,
+        "suggestedAction": "Close other camera apps and try again",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-017.md"
+    }
+}

--- a/packages/catalyst-core/mcp_v2/mcp.js
+++ b/packages/catalyst-core/mcp_v2/mcp.js
@@ -26,6 +26,7 @@ const tasks = require("./tools/tasks")
 const sync = require("./tools/sync")
 const knowledge = require("./tools/knowledge")
 const github = require("./tools/github")
+const errors = require("./tools/errors")
 
 const MCP_DIR = __dirname
 const DB_PATH = path.join(MCP_DIR, "context.db")
@@ -121,6 +122,7 @@ tasks.init(db)
 sync.init(db)
 knowledge.init(db)
 github.init(projectInfo)
+errors.init()
 
 // ── Intent classification (internal, not exposed as tool) ─────────────────────
 
@@ -232,6 +234,21 @@ const TOOLS = [
                 },
             },
             required: ["symptom"],
+        },
+    },
+    {
+        name: "explain_error",
+        description:
+            "Use when the developer has a specific catalyst-core error code (e.g. 'PREFLIGHT-001', 'BUNDLE-000') and wants to know what it means and how to fix it. Looks it up against the generated errors/ registry. If the code isn't catalyst-owned (e.g. a raw Vite/Rollup/Gradle/Xcode code), says so rather than guessing — those are not reinterpreted.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                code: {
+                    type: "string",
+                    description: "The error code to explain, e.g. 'PREFLIGHT-001'.",
+                },
+            },
+            required: ["code"],
         },
     },
     {
@@ -607,6 +624,7 @@ const TOOL_HANDLERS = {
     sync_knowledge_base: sync.handle_sync_knowledge_base,
     query_knowledge: knowledge.handle_query_knowledge,
     create_github_issue: github.handle_create_github_issue,
+    explain_error: errors.handle_explain_error,
 }
 
 // ── MCP JSON-RPC over stdio ───────────────────────────────────────────────────

--- a/packages/catalyst-core/mcp_v2/tools/errors.js
+++ b/packages/catalyst-core/mcp_v2/tools/errors.js
@@ -1,0 +1,55 @@
+"use strict"
+
+const fs = require("fs")
+const path = require("path")
+
+let _index = null
+let _loadError = null
+
+// packages/catalyst-core/mcp_v2/tools -> repo root /errors/index.json
+const ERRORS_INDEX_PATH = path.join(__dirname, "..", "..", "..", "..", "errors", "index.json")
+
+function init() {
+    try {
+        _index = JSON.parse(fs.readFileSync(ERRORS_INDEX_PATH, "utf-8"))
+    } catch (e) {
+        _loadError = e
+        _index = {}
+    }
+}
+
+function handle_explain_error({ code } = {}) {
+    if (!code) {
+        return { error: "code is required, e.g. 'PREFLIGHT-001'" }
+    }
+
+    if (_loadError) {
+        return {
+            code,
+            error: `Could not load errors/index.json (run generateDocs.js): ${_loadError.message}`,
+        }
+    }
+
+    const entry = _index[code]
+
+    if (!entry) {
+        return {
+            code,
+            is_catalyst_owned: false,
+            note: `"${code}" is not a catalyst-owned error code. It likely came from an upstream tool (Vite, Rollup, Xcode, Gradle, etc). Catalyst does not reinterpret foreign error codes — check the upstream tool's own documentation for this code.`,
+        }
+    }
+
+    return {
+        code,
+        is_catalyst_owned: true,
+        category: entry.category,
+        message: entry.message,
+        details: entry.details,
+        recoverable: entry.recoverable,
+        suggestedAction: entry.suggestedAction,
+        docUrl: entry.docUrl,
+    }
+}
+
+module.exports = { init, handle_explain_error }

--- a/packages/catalyst-core/src/errors/generateDocs.js
+++ b/packages/catalyst-core/src/errors/generateDocs.js
@@ -1,0 +1,78 @@
+import { mkdirSync, writeFileSync, readdirSync, rmSync, existsSync } from "fs"
+import path from "path"
+import { fileURLToPath } from "url"
+import { ERROR_DEFINITIONS } from "./registry.js"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// packages/catalyst-core/src/errors -> repo root /errors
+const ERRORS_DIR = path.resolve(__dirname, "../../../../errors")
+
+function renderMarkdown(code, def) {
+    return `# ${code}
+
+**Category:** ${def.category}
+
+## Message
+
+${def.defaultMessage}
+
+## Details
+
+${def.defaultDetails}
+
+## Recoverable
+
+${def.recoverable ? "Yes — you can fix this and retry without restarting your workflow." : "No — this typically requires investigating the underlying cause."}
+
+## Suggested action
+
+${def.suggestedAction}
+`
+}
+
+function clearGeneratedCategoryDirs() {
+    if (!existsSync(ERRORS_DIR)) return
+    const categories = new Set(Object.values(ERROR_DEFINITIONS).map((d) => d.category))
+    for (const category of categories) {
+        const dir = path.join(ERRORS_DIR, category)
+        if (existsSync(dir)) {
+            for (const file of readdirSync(dir)) {
+                if (file.endsWith(".md")) rmSync(path.join(dir, file))
+            }
+        }
+    }
+}
+
+export function generateDocs() {
+    clearGeneratedCategoryDirs()
+
+    const index = {}
+
+    for (const [code, def] of Object.entries(ERROR_DEFINITIONS)) {
+        const dir = path.join(ERRORS_DIR, def.category)
+        mkdirSync(dir, { recursive: true })
+        const filePath = path.join(dir, `${code}.md`)
+        writeFileSync(filePath, renderMarkdown(code, def))
+
+        index[code] = {
+            category: def.category,
+            message: def.defaultMessage,
+            details: def.defaultDetails,
+            recoverable: def.recoverable,
+            suggestedAction: def.suggestedAction,
+            docUrl: `https://github.com/tata1mg/catalyst-core/blob/main/errors/${def.category}/${code}.md`,
+        }
+    }
+
+    mkdirSync(ERRORS_DIR, { recursive: true })
+    writeFileSync(path.join(ERRORS_DIR, "index.json"), JSON.stringify(index, null, 4))
+
+    return { count: Object.keys(index).length, errorsDir: ERRORS_DIR }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const { count, errorsDir } = generateDocs()
+    console.log(`Generated ${count} error doc(s) + index.json in ${errorsDir}`)
+}

--- a/packages/catalyst-core/src/errors/index.js
+++ b/packages/catalyst-core/src/errors/index.js
@@ -1,0 +1,91 @@
+import { ERROR_CODES, getDefinition, getDocUrl } from "./registry.js"
+
+export { ERROR_CODES }
+
+export class CatalystError extends Error {
+    constructor(code, { message, details, recoverable, suggestedAction, category, docUrl, cause } = {}) {
+        super(message)
+        this.name = "CatalystError"
+        this.code = code
+        this.category = category
+        this.details = details
+        this.recoverable = recoverable
+        this.suggestedAction = suggestedAction
+        this.docUrl = docUrl
+        if (cause !== undefined) this.cause = cause
+    }
+}
+
+/**
+ * Create a CatalystError for a code we own, using registry.js defaults
+ * unless overridden.
+ */
+export function createError(code, overrides = {}) {
+    const def = getDefinition(code)
+    return new CatalystError(code, {
+        category: def.category,
+        message: overrides.message || def.defaultMessage,
+        details: overrides.details || def.defaultDetails,
+        recoverable: overrides.recoverable ?? def.recoverable,
+        suggestedAction: overrides.suggestedAction || def.suggestedAction,
+        docUrl: getDocUrl(code),
+        cause: overrides.cause,
+    })
+}
+
+const STAGE_WRAPPER_CODE = {
+    BUNDLE: ERROR_CODES.BUNDLE_UPSTREAM_ERROR,
+    IOS: ERROR_CODES.IOS_UPSTREAM_ERROR,
+    ANDROID: ERROR_CODES.ANDROID_UPSTREAM_ERROR,
+}
+
+const STAGE_UPSTREAM_NAME = {
+    BUNDLE: "Vite/Rollup",
+    IOS: "Xcode/CocoaPods",
+    ANDROID: "Gradle",
+}
+
+/**
+ * Wrap a foreign error (Vite/Rollup/native toolchain) that already carries
+ * its own code/message. We do not replace or reinterpret it — we attach a
+ * generic per-stage wrapper code and preserve the original as `cause`, so
+ * the upstream code/message is always what gets shown to the user.
+ */
+export function wrapForeignError(stage, err) {
+    const code = STAGE_WRAPPER_CODE[stage]
+    if (!code) {
+        throw new Error(`wrapForeignError: unknown stage "${stage}"`)
+    }
+    const upstreamName = STAGE_UPSTREAM_NAME[stage]
+    // Only show err.code when it's a real upstream identifier (e.g. Rollup's
+    // "PLUGIN_LOAD_ERROR"), not a bare numeric process exit status — a spawned
+    // child's exit code is not an "upstream error code" and would be misleading.
+    const hasNamedCode = err && typeof err.code === "string"
+    const upstreamCode = hasNamedCode ? ` ${upstreamName} ${err.code}` : ` ${upstreamName}`
+    const wrapped = createError(code, {
+        message: `Build failed (upstream:${upstreamCode})`,
+        cause: err,
+    })
+    return wrapped
+}
+
+/**
+ * Format a CatalystError for terminal output. Foreign-wrapped errors always
+ * show the original upstream message/code, never a paraphrase of it.
+ */
+export function formatError(err) {
+    const lines = [`[${err.code}] ${err.message}`]
+    if (err.cause) {
+        const causeMessage = err.cause.message || String(err.cause)
+        lines.push(`→ ${causeMessage}`)
+    } else if (err.details) {
+        lines.push(err.details)
+    }
+    if (err.suggestedAction) {
+        lines.push(`Suggested action: ${err.suggestedAction}`)
+    }
+    if (err.docUrl) {
+        lines.push(`Docs: ${err.docUrl}`)
+    }
+    return lines.join("\n")
+}

--- a/packages/catalyst-core/src/errors/registry.js
+++ b/packages/catalyst-core/src/errors/registry.js
@@ -1,0 +1,378 @@
+const REPO_BLOB_BASE = "https://github.com/tata1mg/catalyst-core/blob/main/errors"
+
+function docUrl(category, code) {
+    return `${REPO_BLOB_BASE}/${category}/${code}.md`
+}
+
+export const ERROR_CODES = {
+    PREFLIGHT_CONFIG_MISSING: "PREFLIGHT-001",
+    PREFLIGHT_CONFIG_NOT_OBJECT: "PREFLIGHT-002",
+    PREFLIGHT_CONFIG_KEY_MISSING: "PREFLIGHT-003",
+    PREFLIGHT_PACKAGE_JSON_MISSING: "PREFLIGHT-004",
+    PREFLIGHT_PACKAGE_JSON_INVALID: "PREFLIGHT-005",
+    PREFLIGHT_MODULE_ALIAS_MISSING: "PREFLIGHT-006",
+    PREFLIGHT_MODULE_ALIAS_NOT_OBJECT: "PREFLIGHT-007",
+    PREFLIGHT_MODULE_ALIAS_RESTRICTED: "PREFLIGHT-008",
+    PREFLIGHT_MODULE_ALIAS_KEY_MISSING: "PREFLIGHT-009",
+    PREFLIGHT_PRE_SERVER_INIT_MISSING: "PREFLIGHT-010",
+    PREFLIGHT_PRE_SERVER_INIT_NOT_FUNCTION: "PREFLIGHT-011",
+    PREFLIGHT_MIDDLEWARE_MISSING: "PREFLIGHT-012",
+    PREFLIGHT_MIDDLEWARE_NOT_FUNCTION: "PREFLIGHT-013",
+    PREFLIGHT_REDUCER_MISSING: "PREFLIGHT-014",
+    PREFLIGHT_REDUCER_NOT_FUNCTION: "PREFLIGHT-015",
+    PREFLIGHT_CONFIGURE_STORE_MISSING: "PREFLIGHT-016",
+    PREFLIGHT_CONFIGURE_STORE_NOT_FUNCTION: "PREFLIGHT-017",
+    PREFLIGHT_GET_ROUTES_MISSING: "PREFLIGHT-018",
+    PREFLIGHT_GET_ROUTES_NOT_FUNCTION: "PREFLIGHT-019",
+    PREFLIGHT_CUSTOM_DOCUMENT_MISSING: "PREFLIGHT-020",
+    PREFLIGHT_CUSTOM_DOCUMENT_NOT_FUNCTION: "PREFLIGHT-021",
+
+    PROCESS_SERVER_INIT_FAILED: "PROCESS-001",
+    PROCESS_USER_HOOK_FAILED: "PROCESS-002",
+
+    BUNDLE_UPSTREAM_ERROR: "BUNDLE-000",
+    IOS_UPSTREAM_ERROR: "IOS-000",
+    ANDROID_UPSTREAM_ERROR: "ANDROID-000",
+
+    RUNTIME_NATIVE_PERMISSION_DENIED: "RUNTIME-NATIVE-001",
+    RUNTIME_NATIVE_PERMISSION_REQUIRED: "RUNTIME-NATIVE-002",
+    RUNTIME_NATIVE_NETWORK_UNAVAILABLE: "RUNTIME-NATIVE-003",
+    RUNTIME_NATIVE_DOWNLOAD_FAILED: "RUNTIME-NATIVE-004",
+    RUNTIME_NATIVE_FILE_NOT_FOUND: "RUNTIME-NATIVE-005",
+    RUNTIME_NATIVE_FILE_TOO_LARGE: "RUNTIME-NATIVE-006",
+    RUNTIME_NATIVE_STORAGE_FULL: "RUNTIME-NATIVE-007",
+    RUNTIME_NATIVE_FILE_CORRUPTED: "RUNTIME-NATIVE-008",
+    RUNTIME_NATIVE_OPERATION_CANCELLED: "RUNTIME-NATIVE-009",
+    RUNTIME_NATIVE_NO_FILE_SELECTED: "RUNTIME-NATIVE-010",
+    RUNTIME_NATIVE_INVALID_FILE_TYPE: "RUNTIME-NATIVE-011",
+    RUNTIME_NATIVE_INVALID_PARAMETERS: "RUNTIME-NATIVE-012",
+    RUNTIME_NATIVE_BRIDGE_UNAVAILABLE: "RUNTIME-NATIVE-013",
+    RUNTIME_NATIVE_FEATURE_UNSUPPORTED: "RUNTIME-NATIVE-014",
+    RUNTIME_NATIVE_INTERNAL_ERROR: "RUNTIME-NATIVE-015",
+    RUNTIME_NATIVE_CAMERA_UNAVAILABLE: "RUNTIME-NATIVE-016",
+    RUNTIME_NATIVE_CAMERA_IN_USE: "RUNTIME-NATIVE-017",
+}
+
+// One entry per catalyst-owned code. Foreign/wrapped errors (see wrapForeignError)
+// intentionally do not get an entry here beyond their per-stage wrapper code —
+// we don't author docs or specific meanings for errors we don't originate.
+export const ERROR_DEFINITIONS = {
+    [ERROR_CODES.PREFLIGHT_CONFIG_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "config not found in config folder",
+        defaultDetails: "A config object must be exported from the config folder in your project root.",
+        recoverable: true,
+        suggestedAction: "Create config/config.json (or config/index.js) exporting the required config object.",
+    },
+    [ERROR_CODES.PREFLIGHT_CONFIG_NOT_OBJECT]: {
+        category: "PREFLIGHT",
+        defaultMessage: "config export is not an object",
+        defaultDetails: "The config folder must export a plain object.",
+        recoverable: true,
+        suggestedAction: "Ensure config/config.json exports an object, not a string, array, or function.",
+    },
+    [ERROR_CODES.PREFLIGHT_CONFIG_KEY_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "required key missing inside config.json",
+        defaultDetails: "config.json is missing one or more required keys.",
+        recoverable: true,
+        suggestedAction:
+            "Add the missing key to config.json. See the config.json reference in the framework docs.",
+    },
+    [ERROR_CODES.PREFLIGHT_PACKAGE_JSON_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "package.json not found in the project",
+        defaultDetails: "A package.json must exist in the project root directory.",
+        recoverable: false,
+        suggestedAction: "Run this command from the project root, or restore package.json.",
+    },
+    [ERROR_CODES.PREFLIGHT_PACKAGE_JSON_INVALID]: {
+        category: "PREFLIGHT",
+        defaultMessage: "package.json should be defined in project root directory",
+        defaultDetails: "package.json exists but could not be parsed as an object.",
+        recoverable: true,
+        suggestedAction: "Check package.json for valid JSON syntax.",
+    },
+    [ERROR_CODES.PREFLIGHT_MODULE_ALIAS_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "moduleAliases not found in package.json",
+        defaultDetails: "package.json must export a moduleAliases object.",
+        recoverable: true,
+        suggestedAction: "Add a moduleAliases object to package.json.",
+    },
+    [ERROR_CODES.PREFLIGHT_MODULE_ALIAS_NOT_OBJECT]: {
+        category: "PREFLIGHT",
+        defaultMessage: "moduleAliases named object should be exported from package.json",
+        defaultDetails: "moduleAliases was found in package.json but is not an object.",
+        recoverable: true,
+        suggestedAction: "Ensure moduleAliases is exported as an object in package.json.",
+    },
+    [ERROR_CODES.PREFLIGHT_MODULE_ALIAS_RESTRICTED]: {
+        category: "PREFLIGHT",
+        defaultMessage: "catalyst keyword is restricted for defining aliases",
+        defaultDetails: "Module alias keys containing 'catalyst' are reserved by the framework.",
+        recoverable: true,
+        suggestedAction: "Rename the alias to something that does not contain 'catalyst'.",
+    },
+    [ERROR_CODES.PREFLIGHT_MODULE_ALIAS_KEY_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "required module alias not defined inside package.json",
+        defaultDetails: "One or more required module aliases are missing from moduleAliases.",
+        recoverable: true,
+        suggestedAction: "Add the missing alias to the moduleAliases object in package.json.",
+    },
+    [ERROR_CODES.PREFLIGHT_PRE_SERVER_INIT_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "preServerInit named function should be defined in server/index.js",
+        defaultDetails: "server/index.js must export a preServerInit function.",
+        recoverable: true,
+        suggestedAction: "Export a preServerInit function from server/index.js, or remove the reference to it.",
+    },
+    [ERROR_CODES.PREFLIGHT_PRE_SERVER_INIT_NOT_FUNCTION]: {
+        category: "PREFLIGHT",
+        defaultMessage: "preServerInit should be a function present in server/index.js",
+        defaultDetails: "preServerInit was found but is not a function.",
+        recoverable: true,
+        suggestedAction: "Ensure preServerInit is exported as a function.",
+    },
+    [ERROR_CODES.PREFLIGHT_MIDDLEWARE_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "addMiddlewares named function not found in server/server.js",
+        defaultDetails: "server/server.js must export an addMiddlewares function.",
+        recoverable: true,
+        suggestedAction: "Export an addMiddlewares function from server/server.js.",
+    },
+    [ERROR_CODES.PREFLIGHT_MIDDLEWARE_NOT_FUNCTION]: {
+        category: "PREFLIGHT",
+        defaultMessage: "addMiddlewares should be a function present in server/server.js",
+        defaultDetails: "addMiddlewares was found but is not a function.",
+        recoverable: true,
+        suggestedAction: "Ensure addMiddlewares is exported as a function.",
+    },
+    [ERROR_CODES.PREFLIGHT_REDUCER_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "reducer not found in src/js/containers/App/reducer",
+        defaultDetails: "A reducer must be exported from src/js/containers/App/reducer.",
+        recoverable: true,
+        suggestedAction: "Export a reducer from src/js/containers/App/reducer.",
+    },
+    [ERROR_CODES.PREFLIGHT_REDUCER_NOT_FUNCTION]: {
+        category: "PREFLIGHT",
+        defaultMessage: "reducer should be present in src/js/containers/App/reducer",
+        defaultDetails: "The reducer export was found but is not a function.",
+        recoverable: true,
+        suggestedAction: "Ensure the reducer is exported as a function.",
+    },
+    [ERROR_CODES.PREFLIGHT_CONFIGURE_STORE_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "configureStore not found in file src/js/store/index.js",
+        defaultDetails: "src/js/store/index.js must export a configureStore function.",
+        recoverable: true,
+        suggestedAction: "Export a configureStore function from src/js/store/index.js.",
+    },
+    [ERROR_CODES.PREFLIGHT_CONFIGURE_STORE_NOT_FUNCTION]: {
+        category: "PREFLIGHT",
+        defaultMessage: "configureStore should be a function exported from src/js/store/index.js",
+        defaultDetails: "configureStore was found but is not a function.",
+        recoverable: true,
+        suggestedAction: "Ensure configureStore is exported as a function.",
+    },
+    [ERROR_CODES.PREFLIGHT_GET_ROUTES_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "getRoutes not found in file src/js/routes/utils.js",
+        defaultDetails: "src/js/routes/utils.js must export a getRoutes function.",
+        recoverable: true,
+        suggestedAction: "Export a getRoutes function from src/js/routes/utils.js.",
+    },
+    [ERROR_CODES.PREFLIGHT_GET_ROUTES_NOT_FUNCTION]: {
+        category: "PREFLIGHT",
+        defaultMessage: "getRoutes should be a function exported from src/js/routers/index.js",
+        defaultDetails: "getRoutes was found but is not a function.",
+        recoverable: true,
+        suggestedAction: "Ensure getRoutes is exported as a function.",
+    },
+    [ERROR_CODES.PREFLIGHT_CUSTOM_DOCUMENT_MISSING]: {
+        category: "PREFLIGHT",
+        defaultMessage: "document not found in file server/document.js",
+        defaultDetails: "server/document.js must export a document component.",
+        recoverable: true,
+        suggestedAction: "Export a document React component from server/document.js.",
+    },
+    [ERROR_CODES.PREFLIGHT_CUSTOM_DOCUMENT_NOT_FUNCTION]: {
+        category: "PREFLIGHT",
+        defaultMessage: "document should be a react component exported from server/document.js",
+        defaultDetails: "document was found but is not a function/component.",
+        recoverable: true,
+        suggestedAction: "Ensure document is exported as a React component (function).",
+    },
+
+    [ERROR_CODES.PROCESS_SERVER_INIT_FAILED]: {
+        category: "PROCESS",
+        defaultMessage: "preServerInit threw an error during server startup",
+        defaultDetails:
+            "The preServerInit hook failed. Note: server startup currently continues despite this error (tracked separately as a fix — see issue #298); this code only identifies which hook failed.",
+        recoverable: true,
+        suggestedAction: "Fix the error thrown inside your preServerInit hook (see the cause above).",
+    },
+    [ERROR_CODES.PROCESS_USER_HOOK_FAILED]: {
+        category: "PROCESS",
+        defaultMessage: "A user-defined hook threw an error",
+        defaultDetails:
+            "A user-defined hook (e.g. onRouteMatch, onFetcherError, onServerError) threw. It was caught so the SSR pipeline keeps running; see the cause above for which hook and why.",
+        recoverable: true,
+        suggestedAction: "Fix the error thrown inside the hook (see the cause above).",
+    },
+
+    [ERROR_CODES.BUNDLE_UPSTREAM_ERROR]: {
+        category: "BUNDLE",
+        defaultMessage: "Build failed in an upstream bundler step",
+        defaultDetails:
+            "This is a wrapper around an error from Vite/Rollup or another upstream build tool. See the printed upstream code/message for the actual cause — catalyst-core does not reinterpret it.",
+        recoverable: true,
+        suggestedAction: "Read the upstream error message/code printed above and fix the underlying issue.",
+    },
+    [ERROR_CODES.IOS_UPSTREAM_ERROR]: {
+        category: "IOS",
+        defaultMessage: "iOS build failed in an upstream toolchain step",
+        defaultDetails: "This wraps an error from Xcode/CocoaPods. See the printed upstream output for the cause.",
+        recoverable: true,
+        suggestedAction: "Read the upstream Xcode/CocoaPods error printed above and fix the underlying issue.",
+    },
+    [ERROR_CODES.ANDROID_UPSTREAM_ERROR]: {
+        category: "ANDROID",
+        defaultMessage: "Android build failed in an upstream toolchain step",
+        defaultDetails: "This wraps an error from Gradle. See the printed upstream output for the cause.",
+        recoverable: true,
+        suggestedAction: "Read the upstream Gradle error printed above and fix the underlying issue.",
+    },
+
+    [ERROR_CODES.RUNTIME_NATIVE_PERMISSION_DENIED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Permission denied",
+        defaultDetails: "Required permission was not granted by the user",
+        recoverable: true,
+        suggestedAction: "Grant permission in device settings and try again",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_PERMISSION_REQUIRED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Permission required",
+        defaultDetails: "This operation requires additional permissions",
+        recoverable: true,
+        suggestedAction: "Grant the required permission to continue",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_NETWORK_UNAVAILABLE]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "No internet connection",
+        defaultDetails: "Network connection is required for this operation",
+        recoverable: true,
+        suggestedAction: "Check your internet connection and try again",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_DOWNLOAD_FAILED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Download failed",
+        defaultDetails: "The download could not be completed",
+        recoverable: true,
+        suggestedAction: "Check your connection and try again",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_FILE_NOT_FOUND]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "File not found",
+        defaultDetails: "The requested file could not be located",
+        recoverable: false,
+        suggestedAction: "The file may have been moved or deleted",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_FILE_TOO_LARGE]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "File too large",
+        defaultDetails: "File exceeds the maximum size limit",
+        recoverable: true,
+        suggestedAction: "Choose a smaller file or compress the current file",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_STORAGE_FULL]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Storage full",
+        defaultDetails: "Device storage is full and cannot save the file",
+        recoverable: true,
+        suggestedAction: "Free up some storage space and try again",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_FILE_CORRUPTED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "File corrupted",
+        defaultDetails: "The file could not be read or is corrupted",
+        recoverable: false,
+        suggestedAction: "Try selecting a different file",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_OPERATION_CANCELLED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Operation cancelled",
+        defaultDetails: "The operation was cancelled by the user",
+        recoverable: true,
+        suggestedAction: "Try again if you want to complete the operation",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_NO_FILE_SELECTED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "No file selected",
+        defaultDetails: "No file was selected by the user",
+        recoverable: true,
+        suggestedAction: "Select a file and try again",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_INVALID_FILE_TYPE]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Invalid file type",
+        defaultDetails: "The selected file type is not supported",
+        recoverable: true,
+        suggestedAction: "Choose a file with a supported format",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_INVALID_PARAMETERS]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Invalid parameters",
+        defaultDetails: "One or more parameters passed to the native call were invalid",
+        recoverable: true,
+        suggestedAction: "Check the parameters passed to the native API call",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_UNAVAILABLE]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Native feature unavailable",
+        defaultDetails: "The native bridge is not available or not initialized",
+        recoverable: false,
+        suggestedAction: "Use web fallback if available",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_FEATURE_UNSUPPORTED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Feature not supported",
+        defaultDetails: "This feature is not supported on the current platform",
+        recoverable: false,
+        suggestedAction: "Try using an alternative method or device",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_INTERNAL_ERROR]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "An unexpected error occurred",
+        defaultDetails: "An internal error occurred while processing the request",
+        recoverable: true,
+        suggestedAction: "Try again or contact support if the problem persists",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_CAMERA_UNAVAILABLE]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Camera unavailable",
+        defaultDetails: "Camera hardware is not available or accessible",
+        recoverable: false,
+        suggestedAction: "Check if your device has a camera and try again",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_CAMERA_IN_USE]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Camera in use",
+        defaultDetails: "Camera is being used by another application",
+        recoverable: true,
+        suggestedAction: "Close other camera apps and try again",
+    },
+}
+
+export function getDefinition(code) {
+    return ERROR_DEFINITIONS[code] || ERROR_DEFINITIONS[ERROR_CODES.RUNTIME_NATIVE_INTERNAL_ERROR]
+}
+
+export function getDocUrl(code) {
+    const def = ERROR_DEFINITIONS[code]
+    if (!def) return null
+    return docUrl(def.category, code)
+}

--- a/packages/catalyst-core/src/native/bridge/errors.js
+++ b/packages/catalyst-core/src/native/bridge/errors.js
@@ -1,181 +1,51 @@
 /**
  * Standardized Error System for Catalyst Framework
  * Translates native errors into web developer-friendly messages
+ *
+ * Codes/definitions now live in ../../errors/registry.js as RUNTIME-NATIVE-xxx
+ * (shared taxonomy across CLI/build/server/native, see RFC #155). This module
+ * keeps its own ERROR_CODES map for backwards-compatible imports, aliased to
+ * the shared codes, plus the native-error string-sniffing logic in
+ * translateError(), which is the one piece of real value here.
  */
+import { ERROR_CODES as SHARED_ERROR_CODES, createError } from "../../errors/index.js"
 
-// Error categories for logical grouping
-export const ERROR_CATEGORIES = {
-    PERMISSION: "PERMISSION",
-    NETWORK: "NETWORK",
-    FILE_SYSTEM: "FILE_SYSTEM",
-    USER_ACTION: "USER_ACTION",
-    VALIDATION: "VALIDATION",
-    SYSTEM: "SYSTEM",
-    UNKNOWN: "UNKNOWN",
-}
-
-// Standardized error codes
+// Backwards-compatible local names, aliased to the shared RUNTIME-NATIVE-xxx codes.
 export const ERROR_CODES = {
-    // Permission errors
-    PERMISSION_DENIED: "PERMISSION_DENIED",
-    PERMISSION_REQUIRED: "PERMISSION_REQUIRED",
-
-    // Network errors
-    NETWORK_UNAVAILABLE: "NETWORK_UNAVAILABLE",
-    DOWNLOAD_FAILED: "DOWNLOAD_FAILED",
-
-    // File system errors
-    FILE_NOT_FOUND: "FILE_NOT_FOUND",
-    FILE_TOO_LARGE: "FILE_TOO_LARGE",
-    STORAGE_FULL: "STORAGE_FULL",
-    FILE_CORRUPTED: "FILE_CORRUPTED",
-
-    // User action errors
-    OPERATION_CANCELLED: "OPERATION_CANCELLED",
-    NO_FILE_SELECTED: "NO_FILE_SELECTED",
-
-    // Validation errors
-    INVALID_FILE_TYPE: "INVALID_FILE_TYPE",
-    INVALID_PARAMETERS: "INVALID_PARAMETERS",
-
-    // System errors
-    BRIDGE_UNAVAILABLE: "BRIDGE_UNAVAILABLE",
-    FEATURE_UNSUPPORTED: "FEATURE_UNSUPPORTED",
-    INTERNAL_ERROR: "INTERNAL_ERROR",
-
-    // Camera specific errors
-    CAMERA_UNAVAILABLE: "CAMERA_UNAVAILABLE",
-    CAMERA_IN_USE: "CAMERA_IN_USE",
-}
-
-// Error definitions with user-friendly messages and recovery actions
-export const ERROR_DEFINITIONS = {
-    [ERROR_CODES.PERMISSION_DENIED]: {
-        category: ERROR_CATEGORIES.PERMISSION,
-        defaultMessage: "Permission denied",
-        defaultDetails: "Required permission was not granted by the user",
-        recoverable: true,
-        suggestedAction: "Grant permission in device settings and try again",
-    },
-
-    [ERROR_CODES.PERMISSION_REQUIRED]: {
-        category: ERROR_CATEGORIES.PERMISSION,
-        defaultMessage: "Permission required",
-        defaultDetails: "This operation requires additional permissions",
-        recoverable: true,
-        suggestedAction: "Grant the required permission to continue",
-    },
-
-    [ERROR_CODES.NETWORK_UNAVAILABLE]: {
-        category: ERROR_CATEGORIES.NETWORK,
-        defaultMessage: "No internet connection",
-        defaultDetails: "Network connection is required for this operation",
-        recoverable: true,
-        suggestedAction: "Check your internet connection and try again",
-    },
-
-    [ERROR_CODES.FILE_NOT_FOUND]: {
-        category: ERROR_CATEGORIES.FILE_SYSTEM,
-        defaultMessage: "File not found",
-        defaultDetails: "The requested file could not be located",
-        recoverable: false,
-        suggestedAction: "The file may have been moved or deleted",
-    },
-
-    [ERROR_CODES.FILE_TOO_LARGE]: {
-        category: ERROR_CATEGORIES.VALIDATION,
-        defaultMessage: "File too large",
-        defaultDetails: "File exceeds the maximum size limit",
-        recoverable: true,
-        suggestedAction: "Choose a smaller file or compress the current file",
-    },
-
-    [ERROR_CODES.STORAGE_FULL]: {
-        category: ERROR_CATEGORIES.FILE_SYSTEM,
-        defaultMessage: "Storage full",
-        defaultDetails: "Device storage is full and cannot save the file",
-        recoverable: true,
-        suggestedAction: "Free up some storage space and try again",
-    },
-
-    [ERROR_CODES.OPERATION_CANCELLED]: {
-        category: ERROR_CATEGORIES.USER_ACTION,
-        defaultMessage: "Operation cancelled",
-        defaultDetails: "The operation was cancelled by the user",
-        recoverable: true,
-        suggestedAction: "Try again if you want to complete the operation",
-    },
-
-    [ERROR_CODES.INVALID_FILE_TYPE]: {
-        category: ERROR_CATEGORIES.VALIDATION,
-        defaultMessage: "Invalid file type",
-        defaultDetails: "The selected file type is not supported",
-        recoverable: true,
-        suggestedAction: "Choose a file with a supported format",
-    },
-
-    [ERROR_CODES.BRIDGE_UNAVAILABLE]: {
-        category: ERROR_CATEGORIES.SYSTEM,
-        defaultMessage: "Native feature unavailable",
-        defaultDetails: "The native bridge is not available or not initialized",
-        recoverable: false,
-        suggestedAction: "Use web fallback if available",
-    },
-
-    [ERROR_CODES.FEATURE_UNSUPPORTED]: {
-        category: ERROR_CATEGORIES.SYSTEM,
-        defaultMessage: "Feature not supported",
-        defaultDetails: "This feature is not supported on the current platform",
-        recoverable: false,
-        suggestedAction: "Try using an alternative method or device",
-    },
-
-    [ERROR_CODES.CAMERA_UNAVAILABLE]: {
-        category: ERROR_CATEGORIES.SYSTEM,
-        defaultMessage: "Camera unavailable",
-        defaultDetails: "Camera hardware is not available or accessible",
-        recoverable: false,
-        suggestedAction: "Check if your device has a camera and try again",
-    },
-
-    [ERROR_CODES.CAMERA_IN_USE]: {
-        category: ERROR_CATEGORIES.SYSTEM,
-        defaultMessage: "Camera in use",
-        defaultDetails: "Camera is being used by another application",
-        recoverable: true,
-        suggestedAction: "Close other camera apps and try again",
-    },
-
-    [ERROR_CODES.INTERNAL_ERROR]: {
-        category: ERROR_CATEGORIES.UNKNOWN,
-        defaultMessage: "An unexpected error occurred",
-        defaultDetails: "An internal error occurred while processing the request",
-        recoverable: true,
-        suggestedAction: "Try again or contact support if the problem persists",
-    },
+    PERMISSION_DENIED: SHARED_ERROR_CODES.RUNTIME_NATIVE_PERMISSION_DENIED,
+    PERMISSION_REQUIRED: SHARED_ERROR_CODES.RUNTIME_NATIVE_PERMISSION_REQUIRED,
+    NETWORK_UNAVAILABLE: SHARED_ERROR_CODES.RUNTIME_NATIVE_NETWORK_UNAVAILABLE,
+    DOWNLOAD_FAILED: SHARED_ERROR_CODES.RUNTIME_NATIVE_DOWNLOAD_FAILED,
+    FILE_NOT_FOUND: SHARED_ERROR_CODES.RUNTIME_NATIVE_FILE_NOT_FOUND,
+    FILE_TOO_LARGE: SHARED_ERROR_CODES.RUNTIME_NATIVE_FILE_TOO_LARGE,
+    STORAGE_FULL: SHARED_ERROR_CODES.RUNTIME_NATIVE_STORAGE_FULL,
+    FILE_CORRUPTED: SHARED_ERROR_CODES.RUNTIME_NATIVE_FILE_CORRUPTED,
+    OPERATION_CANCELLED: SHARED_ERROR_CODES.RUNTIME_NATIVE_OPERATION_CANCELLED,
+    NO_FILE_SELECTED: SHARED_ERROR_CODES.RUNTIME_NATIVE_NO_FILE_SELECTED,
+    INVALID_FILE_TYPE: SHARED_ERROR_CODES.RUNTIME_NATIVE_INVALID_FILE_TYPE,
+    INVALID_PARAMETERS: SHARED_ERROR_CODES.RUNTIME_NATIVE_INVALID_PARAMETERS,
+    BRIDGE_UNAVAILABLE: SHARED_ERROR_CODES.RUNTIME_NATIVE_BRIDGE_UNAVAILABLE,
+    FEATURE_UNSUPPORTED: SHARED_ERROR_CODES.RUNTIME_NATIVE_FEATURE_UNSUPPORTED,
+    INTERNAL_ERROR: SHARED_ERROR_CODES.RUNTIME_NATIVE_INTERNAL_ERROR,
+    CAMERA_UNAVAILABLE: SHARED_ERROR_CODES.RUNTIME_NATIVE_CAMERA_UNAVAILABLE,
+    CAMERA_IN_USE: SHARED_ERROR_CODES.RUNTIME_NATIVE_CAMERA_IN_USE,
 }
 
 /**
- * Create a standardized error object
+ * Create a standardized error object (CatalystError instance) for a
+ * RUNTIME-NATIVE-xxx code, with the native error attached as `cause`.
  * @param {string} code - Error code from ERROR_CODES
  * @param {string} userMessage - Custom user-friendly message (optional)
  * @param {any} nativeError - Original native error for debugging
  * @param {string} customDetails - Custom details (optional)
- * @returns {Object} Standardized error object
+ * @returns {import("../../errors/index.js").CatalystError}
  */
 export const createStandardError = (code, userMessage = null, nativeError = null, customDetails = null) => {
-    const errorInfo = ERROR_DEFINITIONS[code] || ERROR_DEFINITIONS[ERROR_CODES.INTERNAL_ERROR]
-
-    return {
-        code,
-        category: errorInfo.category,
-        message: userMessage || errorInfo.defaultMessage,
-        details: customDetails || errorInfo.defaultDetails,
-        recoverable: errorInfo.recoverable,
-        action: errorInfo.suggestedAction,
-        nativeError: nativeError,
-        timestamp: new Date().toISOString(),
-    }
+    return createError(code, {
+        message: userMessage,
+        details: customDetails,
+        cause: nativeError,
+    })
 }
 
 /**

--- a/packages/catalyst-core/src/native/buildAppAndroid.js
+++ b/packages/catalyst-core/src/native/buildAppAndroid.js
@@ -9,6 +9,12 @@ async function main() {
     try {
         await buildAndroidApp()
     } catch (error) {
+        // src/native is a CJS-only subtree (see src/native/package.json) and cannot
+        // synchronously require() the ESM errors/index.js module under Node 20, so
+        // we format inline here. Code ANDROID-000 = generic "upstream Gradle error"
+        // wrapper — see errors/ANDROID/ANDROID-000.md. Message was previously
+        // swallowed entirely; now preserved verbatim, not reinterpreted.
+        console.error(`[ANDROID-000] Build failed (upstream: Gradle)\n→ ${error.message}`)
         process.exit(1)
     }
     process.exit(0)

--- a/packages/catalyst-core/src/native/buildAppIos.js
+++ b/packages/catalyst-core/src/native/buildAppIos.js
@@ -33,7 +33,12 @@ async function main() {
         await syncPluginResources(pluginComposition)
         await buildForIOS(pluginComposition)
     } catch (error) {
-        progress.log("Build failed: " + error.message, "error")
+        // src/native is a CJS-only subtree (see src/native/package.json) and cannot
+        // synchronously require() the ESM errors/index.js module under Node 20, so
+        // we format inline here rather than reconstructing that module system boundary.
+        // Code IOS-000 = generic "upstream Xcode/CocoaPods toolchain error" wrapper —
+        // see errors/IOS/IOS-000.md. We never reinterpret the underlying message.
+        progress.log(`[IOS-000] Build failed (upstream: Xcode/CocoaPods)\n→ ${error.message}`, "error")
         process.exit(1)
     }
     process.exit(0)

--- a/packages/catalyst-core/src/scripts/build.js
+++ b/packages/catalyst-core/src/scripts/build.js
@@ -4,6 +4,7 @@ import { arrayToObject } from "./scriptUtils.js"
 import { fileURLToPath } from "url"
 import { dirname } from "path"
 import { readFileSync, existsSync, rmSync } from "fs"
+import { wrapForeignError, formatError } from "../errors/index.js"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -89,8 +90,9 @@ async function build() {
                 env: { ...baseEnv, CATALYST_VITE_CACHE_ID: "client" },
             }),
         ])
-    } catch {
+    } catch (err) {
         console.error("❌ Build failed!")
+        console.error(formatError(wrapForeignError("BUNDLE", err)))
         process.exit(1)
     }
 

--- a/packages/catalyst-core/src/scripts/preServerInit.js
+++ b/packages/catalyst-core/src/scripts/preServerInit.js
@@ -1,6 +1,6 @@
 import path from "path"
 import loadEnvironmentVariables from "./loadEnvironmentVariables.js"
-import { safeCall } from "../server/utils/validator.js"
+import { safeCallNamed } from "../server/utils/validator.js"
 
 let preServerInit
 try {
@@ -10,4 +10,4 @@ try {
     // No hooks file — preServerInit remains undefined
 }
 await loadEnvironmentVariables()
-safeCall(preServerInit)
+safeCallNamed("preServerInit", preServerInit)

--- a/packages/catalyst-core/src/scripts/validator.js
+++ b/packages/catalyst-core/src/scripts/validator.js
@@ -1,14 +1,14 @@
 import pc from "picocolors"
+import { createError, formatError, ERROR_CODES } from "../errors/index.js"
 
 const handleError = (e) => {
-    console.log(pc.red("Failed to start server: "), e)
+    console.log(pc.red("Failed to start server: "), formatError(e))
 }
 
 const validatePreInitServer = (fn) => {
     try {
-        if (!fn) throw new Error("preServerInit named function should be defined in server/index.js")
-        if (typeof fn !== "function")
-            throw new Error("preServerInit should be function present in server/index.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_PRE_SERVER_INIT_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_PRE_SERVER_INIT_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -17,9 +17,8 @@ const validatePreInitServer = (fn) => {
 
 const validateMiddleware = (fn) => {
     try {
-        if (!fn) throw new Error("addMiddlewares named function not found in server/server.js")
-        if (typeof fn !== "function")
-            throw new Error("addMiddlewares should be function present in server/server.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_MIDDLEWARE_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_MIDDLEWARE_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -28,9 +27,8 @@ const validateMiddleware = (fn) => {
 
 const validateReducerFunction = (fn) => {
     try {
-        if (!fn) throw new Error("reducer not found in src/js/containers/App/reducer")
-        if (typeof fn !== "function")
-            throw new Error("reducer should present in src/js/containers/App/reducer")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_REDUCER_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_REDUCER_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -39,11 +37,8 @@ const validateReducerFunction = (fn) => {
 
 const validateConfigFile = (obj) => {
     try {
-        if (!obj) throw new Error("config not found in config folder")
-        if (typeof obj !== "object")
-            throw new Error(
-                "config object should be exported from config folder inside your project root directory"
-            )
+        if (!obj) throw createError(ERROR_CODES.PREFLIGHT_CONFIG_MISSING)
+        if (typeof obj !== "object") throw createError(ERROR_CODES.PREFLIGHT_CONFIG_NOT_OBJECT)
         if (typeof obj === "object") {
             const requiredConfigKeys = {
                 NODE_SERVER_HOSTNAME: "",
@@ -57,7 +52,10 @@ const validateConfigFile = (obj) => {
                 ANALYZE_BUNDLE: "",
             }
             for (let key in requiredConfigKeys) {
-                if (!(key in obj)) throw new Error(`${key} key not found inside config.json`)
+                if (!(key in obj))
+                    throw createError(ERROR_CODES.PREFLIGHT_CONFIG_KEY_MISSING, {
+                        details: `${key} key not found inside config.json`,
+                    })
             }
         }
         return true
@@ -68,9 +66,8 @@ const validateConfigFile = (obj) => {
 
 const validatePackageJson = (obj) => {
     try {
-        if (!obj) throw new Error("package.json not found in the project")
-        if (typeof obj !== "object")
-            throw new Error("package.json should be defined in project root directory")
+        if (!obj) throw createError(ERROR_CODES.PREFLIGHT_PACKAGE_JSON_MISSING)
+        if (typeof obj !== "object") throw createError(ERROR_CODES.PREFLIGHT_PACKAGE_JSON_INVALID)
         return true
     } catch (e) {
         handleError(e)
@@ -79,9 +76,8 @@ const validatePackageJson = (obj) => {
 
 const validateModuleAlias = (obj) => {
     try {
-        if (!obj) throw new Error("moduleAliases not found in package.json file present in root directory.")
-        if (typeof obj !== "object")
-            throw new Error("moduleAliases named object should be exported from package.json")
+        if (!obj) throw createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_MISSING)
+        if (typeof obj !== "object") throw createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_NOT_OBJECT)
         if (typeof obj === "object") {
             const requiredModuleAliases = {
                 "@api": "api.js",
@@ -92,9 +88,11 @@ const validateModuleAlias = (obj) => {
                 "@routes": "src/js/routes/",
             }
             for (let key in requiredModuleAliases) {
-                if (key.includes("catalyst"))
-                    throw new Error(`Catalyst keyword is restricted for defining aliases`)
-                if (!(key in obj)) throw new Error(`${key} module alias not defined inside package.json`)
+                if (key.includes("catalyst")) throw createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_RESTRICTED)
+                if (!(key in obj))
+                    throw createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_KEY_MISSING, {
+                        details: `${key} module alias not defined inside package.json`,
+                    })
             }
         }
         return true
@@ -105,9 +103,8 @@ const validateModuleAlias = (obj) => {
 
 const validateConfigureStore = (fn) => {
     try {
-        if (!fn) throw new Error("configureStore not found in file src/js/store/index.js")
-        if (typeof fn !== "function")
-            throw new Error("configureStore should be function exported from src/js/store/index.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_CONFIGURE_STORE_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_CONFIGURE_STORE_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -116,9 +113,8 @@ const validateConfigureStore = (fn) => {
 
 const validateGetRoutes = (fn) => {
     try {
-        if (!fn) throw new Error("getRoutes not found in file src/js/routes/utils.js")
-        if (typeof fn !== "function")
-            throw new Error("getRoutes should be function exported from src/js/routers/index.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_GET_ROUTES_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_GET_ROUTES_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -127,9 +123,8 @@ const validateGetRoutes = (fn) => {
 
 const validateCustomDocument = (fn) => {
     try {
-        if (!fn) throw new Error("document not found in file server/document.js")
-        if (typeof fn !== "function")
-            throw new Error("document should be a react component exported from server/document.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_CUSTOM_DOCUMENT_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_CUSTOM_DOCUMENT_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)

--- a/packages/catalyst-core/src/server/utils/validator.js
+++ b/packages/catalyst-core/src/server/utils/validator.js
@@ -1,14 +1,14 @@
 import pc from "picocolors"
+import { createError, formatError, ERROR_CODES } from "../../errors/index.js"
 
 const handleError = (e) => {
-    console.log(pc.red("Failed to start server: "), e)
+    console.log(pc.red("Failed to start server: "), formatError(e))
 }
 
 const validatePreInitServer = (fn) => {
     try {
-        if (!fn) throw new Error("preServerInit named function should be defined in server/index.js")
-        if (typeof fn !== "function")
-            throw new Error("preServerInit should be function present in server/index.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_PRE_SERVER_INIT_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_PRE_SERVER_INIT_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -17,9 +17,8 @@ const validatePreInitServer = (fn) => {
 
 const validateMiddleware = (fn) => {
     try {
-        if (!fn) throw new Error("addMiddlewares named function not found in server/server.js")
-        if (typeof fn !== "function")
-            throw new Error("addMiddlewares should be function present in server/server.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_MIDDLEWARE_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_MIDDLEWARE_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -28,9 +27,8 @@ const validateMiddleware = (fn) => {
 
 const validateReducerFunction = (fn) => {
     try {
-        if (!fn) throw new Error("reducer not found in src/js/containers/App/reducer")
-        if (typeof fn !== "function")
-            throw new Error("reducer should present in src/js/containers/App/reducer")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_REDUCER_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_REDUCER_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -39,11 +37,8 @@ const validateReducerFunction = (fn) => {
 
 const validateConfigFile = (obj) => {
     try {
-        if (!obj) throw new Error("config not found in config folder")
-        if (typeof obj !== "object")
-            throw new Error(
-                "config object should be exported from config folder inside your project root directory"
-            )
+        if (!obj) throw createError(ERROR_CODES.PREFLIGHT_CONFIG_MISSING)
+        if (typeof obj !== "object") throw createError(ERROR_CODES.PREFLIGHT_CONFIG_NOT_OBJECT)
         if (typeof obj === "object") {
             const requiredConfigKeys = {
                 NODE_SERVER_HOSTNAME: "",
@@ -57,7 +52,10 @@ const validateConfigFile = (obj) => {
                 ANALYZE_BUNDLE: "",
             }
             for (let key in requiredConfigKeys) {
-                if (!(key in obj)) throw new Error(`${key} key not found inside config.json`)
+                if (!(key in obj))
+                    throw createError(ERROR_CODES.PREFLIGHT_CONFIG_KEY_MISSING, {
+                        details: `${key} key not found inside config.json`,
+                    })
             }
         }
         return true
@@ -68,9 +66,8 @@ const validateConfigFile = (obj) => {
 
 const validatePackageJson = (obj) => {
     try {
-        if (!obj) throw new Error("package.json not found in the project")
-        if (typeof obj !== "object")
-            throw new Error("package.json should be defined in project root directory")
+        if (!obj) throw createError(ERROR_CODES.PREFLIGHT_PACKAGE_JSON_MISSING)
+        if (typeof obj !== "object") throw createError(ERROR_CODES.PREFLIGHT_PACKAGE_JSON_INVALID)
         return true
     } catch (e) {
         handleError(e)
@@ -79,9 +76,8 @@ const validatePackageJson = (obj) => {
 
 const validateModuleAlias = (obj) => {
     try {
-        if (!obj) throw new Error("moduleAliases not found in package.json file present in root directory.")
-        if (typeof obj !== "object")
-            throw new Error("moduleAliases named object should be exported from package.json")
+        if (!obj) throw createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_MISSING)
+        if (typeof obj !== "object") throw createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_NOT_OBJECT)
         if (typeof obj === "object") {
             const requiredModuleAliases = {
                 "@api": "api.js",
@@ -92,9 +88,11 @@ const validateModuleAlias = (obj) => {
                 "@routes": "src/js/routes/",
             }
             for (let key in requiredModuleAliases) {
-                if (key.includes("catalyst"))
-                    throw new Error(`Catalyst keyword is restricted for defining aliases`)
-                if (!(key in obj)) throw new Error(`${key} module alias not defined inside package.json`)
+                if (key.includes("catalyst")) throw createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_RESTRICTED)
+                if (!(key in obj))
+                    throw createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_KEY_MISSING, {
+                        details: `${key} module alias not defined inside package.json`,
+                    })
             }
         }
         return true
@@ -105,9 +103,8 @@ const validateModuleAlias = (obj) => {
 
 const validateConfigureStore = (fn) => {
     try {
-        if (!fn) throw new Error("configureStore not found in file src/js/store/index.js")
-        if (typeof fn !== "function")
-            throw new Error("configureStore should be function exported from src/js/store/index.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_CONFIGURE_STORE_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_CONFIGURE_STORE_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -116,9 +113,8 @@ const validateConfigureStore = (fn) => {
 
 const validateGetRoutes = (fn) => {
     try {
-        if (!fn) throw new Error("getRoutes not found in file src/js/routes/utils.js")
-        if (typeof fn !== "function")
-            throw new Error("getRoutes should be function exported from src/js/routers/index.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_GET_ROUTES_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_GET_ROUTES_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -127,9 +123,8 @@ const validateGetRoutes = (fn) => {
 
 const validateCustomDocument = (fn) => {
     try {
-        if (!fn) throw new Error("document not found in file server/document.js")
-        if (typeof fn !== "function")
-            throw new Error("document should be a react component exported from server/document.js")
+        if (!fn) throw createError(ERROR_CODES.PREFLIGHT_CUSTOM_DOCUMENT_MISSING)
+        if (typeof fn !== "function") throw createError(ERROR_CODES.PREFLIGHT_CUSTOM_DOCUMENT_NOT_FUNCTION)
         return true
     } catch (e) {
         handleError(e)
@@ -138,15 +133,35 @@ const validateCustomDocument = (fn) => {
 
 /**
  * Safely call a function, catching and logging any errors.
- * Used for user-defined hooks (onRouteMatch, onFetcherError, etc.)
- * that should never crash the SSR pipeline.
+ * Used for user-defined hooks (preServerInit, onRouteMatch, onFetcherError,
+ * onServerError, etc.) that should never crash the SSR pipeline.
  */
 const safeCall = (fn, ...args) => {
     if (typeof fn !== "function") return
     try {
         return fn(...args)
     } catch (e) {
-        console.error("Error in user hook:", e)
+        const wrapped = createError(ERROR_CODES.PROCESS_USER_HOOK_FAILED, { cause: e })
+        console.error(formatError(wrapped))
+    }
+}
+
+/**
+ * Same as safeCall, but names the specific hook (e.g. "preServerInit") in the
+ * error so it's identifiable rather than generic. Used at call sites that know
+ * which hook they're invoking.
+ */
+const safeCallNamed = (hookName, fn, ...args) => {
+    if (typeof fn !== "function") return
+    try {
+        return fn(...args)
+    } catch (e) {
+        const code = hookName === "preServerInit" ? ERROR_CODES.PROCESS_SERVER_INIT_FAILED : ERROR_CODES.PROCESS_USER_HOOK_FAILED
+        const wrapped = createError(code, {
+            details: `The "${hookName}" hook threw. See the cause below.`,
+            cause: e,
+        })
+        console.error(formatError(wrapped))
     }
 }
 
@@ -161,4 +176,5 @@ export {
     validatePreInitServer,
     validateMiddleware,
     safeCall,
+    safeCallNamed,
 }

--- a/skills/new-feature/SKILL.md
+++ b/skills/new-feature/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: new-feature
+description: Walk a contributor through shipping a new feature or fix in catalyst-core — tracking issue, branch, design proposal, implementation, docs, PR. Use when a contributor says a feature/fix is ready to start or is asking "what do I do next" for new work.
+---
+
+# New feature workflow (catalyst-core)
+
+This repo tracks 1.0 work as an Epic → Story → Task hierarchy on GitHub (see
+issue #329 for the current 1.0 epic). This skill walks a contributor through
+the same steps used to ship task #359 (unified error codes), so the workflow
+doesn't have to be reinvented each time.
+
+Go through the steps below **in order**, asking the user at each one rather
+than assuming. Do not skip a step because it seems obvious — the user may have
+context you don't (e.g. this might not belong under the current epic at all).
+
+## Step 1 — Locate or create the tracking issue
+
+Ask:
+- Does this already have a GitHub issue? If yes, get the number and read it.
+- If no: does it belong under the current 1.0 epic (#329)? If yes, which Story?
+  List the open stories (`gh issue view 329 --json body` or check the sub-issues
+  via the GraphQL `subIssues` field) and ask the user to pick one, or confirm
+  it's net-new/outside the epic.
+- Create the issue with a clear headline + description (see the #359–#368 issues
+  for the format: `## Description`, `## Acceptance criteria`, `## Parent`).
+- If it nests under a Story, link it as a native GitHub sub-issue via the
+  `addSubIssue` GraphQL mutation (see prior session history for the exact call
+  shape) — don't just mention the parent in text.
+- Assign the issue to the contributor.
+
+## Step 2 — Create the branch
+
+- Derive a `feature/<slug>` (or `fix/<slug>` for bug fixes) name from the issue title.
+- **Branch from `origin/main`**, not from whatever is currently checked out —
+  the current branch may have unrelated in-progress/uncommitted work that
+  shouldn't be inherited.
+- If the current working tree has uncommitted changes or is mid-work on another
+  branch, use `git worktree add ../catalyst-core-<slug> <branch>` instead of
+  switching branches in place, so the two efforts don't collide.
+
+## Step 3 — Proposal before code (gate)
+
+Before writing any implementation:
+- Post a design comment on the issue covering: what's being built, why this
+  approach over alternatives, what files/modules it touches, and a closing
+  section on **why this matters for the current release** (ties back to the
+  epic/story it gates, or explains why it doesn't gate anything if it's
+  independent work).
+- Do not start implementation until this is posted. If the user says the
+  change is trivial enough to skip (e.g. a one-line fix, a typo), that's a
+  valid reason to skip — but ask first, don't assume.
+
+## Step 4 — Implementation
+
+- Before writing new code, look for an existing pattern to follow rather than
+  inventing one. Examples already established in this repo:
+  - Error codes / registry pattern: `packages/catalyst-core/src/errors/`
+  - MCP tool pattern: `packages/catalyst-core/mcp_v2/tools/*.js` (each exports
+    `init(...)` + `handle_<name>`, registered in `mcp_v2/mcp.js`'s tool list and
+    dispatch map)
+  - Validator pattern: `packages/catalyst-core/src/scripts/validator.js` /
+    `src/server/utils/validator.js`
+- Watch for module-system boundaries: `src/native/` is CJS-only (see its local
+  `package.json` with `"type": "commonjs"`), while most of the rest of
+  `packages/catalyst-core/src` is ESM. Code crossing that boundary can't use a
+  plain `require()`/`import` across it under Node 20 — check before assuming
+  an import will resolve.
+- Verify changes actually work, not just that they parse. `node --check` only
+  catches syntax. For each call site touched, confirm the error/output that
+  surfaces actually names the right thing — don't rely on the happy-path test
+  alone.
+
+## Step 5 — Docs
+
+Ask whether this change needs:
+- An entry under `docs/content/` (user-facing framework docs), and/or
+- A new entry under the top-level `errors/<CATEGORY>/` folder, if it introduces
+  a new error code (see Step 4's registry pattern — docs are generated from
+  `packages/catalyst-core/src/errors/registry.js` via `generateDocs.js`, don't
+  hand-write them separately).
+
+## Step 6 — Pull request
+
+- Draft a PR description: summary, why, test plan, and a reference to the
+  issue number (`Closes #<n>`).
+- **Do not push or open the PR without explicit confirmation** — opening a PR
+  is a shared-visibility action, same as pushing or commenting on an issue on
+  behalf of the team.


### PR DESCRIPTION
## Summary

Implements unified error codes per RFC #155, scoped to `packages/catalyst-core`:

- `src/errors/{registry,index,generateDocs}.js` — 43 codes across `PREFLIGHT` (21), `PROCESS` (2), `BUNDLE`/`IOS`/`ANDROID` (upstream-wrapper codes, 1 each), `RUNTIME-NATIVE` (17)
- Top-level `errors/<CATEGORY>/<CODE>.md` + `errors/index.json`, generated from the registry (single source of truth, no hand-authored drift)
- `native/bridge/errors.js`, `scripts/validator.js`, `server/utils/validator.js`, `scripts/build.js`, `native/buildAppIos.js`, `native/buildAppAndroid.js` reconciled to throw/log via the shared codes instead of raw strings
- New `explain_error` MCP tool (`mcp_v2/tools/errors.js`) for code lookup, registered in `mcp_v2/mcp.js`
- Foreign errors (Vite/Rollup, Xcode/CocoaPods, Gradle) are wrapped with a generic per-stage code but never reinterpreted — the original upstream code/message always prints verbatim

## Deliberately out of scope for this PR

- **`CONFIG-xxx` and `RUNTIME-WEB-xxx` categories do not exist yet.** They'd require touching `server/expressServer.js` and `server/renderer/handler.jsx` (SSR error paths), which the approved plan scoped out of this task. My proposal comment on #359 mentioned these as part of the full RFC #155 taxonomy — only the categories with an actual call site to reconcile shipped here.
- **`native/bridge/WebBridge.js`** (JS-side dispatch: invalid interface, handler-not-registered, callback exceptions) still logs via raw `console.error`, not through the new registry. It sits right next to `bridge/errors.js` which *is* wired in, so it's a natural next step — filed as a follow-up rather than folded in here.
- **`packages/catalyst-ai` and `packages/create-catalyst-app`** have zero error-code coverage (confirmed via audit) — both are raw `throw new Error(string)` / `console.error` throughout. Out of scope for RFC #155 Phase 1 (which only mentions catalyst-core's own CLI/build/server/native surfaces); would need new category prefixes as separate follow-up work.
- **Native-side (Kotlin/Swift) exceptions are not serialized into codes before crossing the bridge.** `translateError()` can only sniff error strings that actually arrive from native; it doesn't change what native code sends. Changing that contract is out of RFC #155 Phase 1 entirely.
- **`safeCall`'s swallow-and-continue behavior for `preServerInit` is unchanged.** This PR makes the failing hook identifiable (`PROCESS-001` when it's specifically `preServerInit`, `PROCESS-002` for other hooks) but does not make startup halt on failure — that's #298, tracked separately.

## Known limitation

Every generated `docUrl` points at `blob/main/errors/...` — these 404 until this PR merges to `main`. Structurally correct, not yet resolvable.

## Test plan

- [x] `node --check` on all touched ESM files (native/bridge/errors.js is in a `type: commonjs`-marked subtree per its own `src/native/package.json` and can't be checked the same way — pre-existing condition, not introduced here — verified instead via `.mjs`-copy execution)
- [x] Generator produces 43 `errors/**/*.md` + `errors/index.json`, 1:1 with the registry
- [x] Triggered real validator failures (missing config key, missing/malformed moduleAliases) — confirmed distinct codes, correct messages, working GitHub doc links
- [x] Triggered `wrapForeignError` with both a real upstream string code (Rollup `PLUGIN_LOAD_ERROR`) and a bare numeric exit code — confirmed only the former is shown as an "upstream code" (the numeric exit-status fix was a review finding, since fixed)
- [x] Confirmed `safeCall` (generic) vs `safeCallNamed("preServerInit", ...)` produce distinct codes/messages
- [x] `explain_error` MCP tool tested against an owned code, a foreign code, and no code
- [ ] No new automated tests added (Story 3 covers test infra separately, not this task)

Closes #359.
