### PR TITLE
feat(bridge): wire WebBridge.js dispatch errors into error registry

### DIFF
--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-018.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-018.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-018
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Invalid callback interface
+
+## Details
+
+The native platform invoked WebBridge.callback() with an interface name that isn't recognized.
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Check the interface name against the registered NATIVE_CALLBACKS list; this usually indicates a native/JS version mismatch.

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-019.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-019.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-019
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+No handler registered for this bridge interface
+
+## Details
+
+The native platform called back on an interface that has no JS-side handler registered yet.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure WebBridge.register() is called for this interface before the native call arrives.

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-019.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-019.md
@@ -8,7 +8,7 @@ No handler registered for this bridge interface
 
 ## Details
 
-The native platform called back on an interface that has no JS-side handler registered yet.
+Native sent a callback for this interface, but your webview hasn't registered a handler for it yet.
 
 ## Recoverable
 
@@ -16,4 +16,4 @@ Yes — you can fix this and retry without restarting your workflow.
 
 ## Suggested action
 
-Ensure WebBridge.register() is called for this interface before the native call arrives.
+Call WebBridge.register() for this interface before native calls arrive.

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-020.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-020.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-020
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+A registered bridge callback handler threw
+
+## Details
+
+The JS handler registered for this native callback interface threw an error while processing the callback.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Fix the error thrown inside the registered handler (see the cause above).

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-021.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-021.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-021
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Invalid bridge callback registration
+
+## Details
+
+WebBridge.register() was called with a non-function callback or an unrecognized interface name.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Pass a function as the callback and a valid interface name from NATIVE_CALLBACKS.

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-022.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-022.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-022
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+WebBridge could not be initialized
+
+## Details
+
+WebBridge.init() was called outside a browser environment (no `window` available).
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Call WebBridge.init() in a browser environment, before using bridge features.

--- a/errors/index.json
+++ b/errors/index.json
@@ -354,9 +354,9 @@
     "RUNTIME-NATIVE-019": {
         "category": "RUNTIME-NATIVE",
         "message": "No handler registered for this bridge interface",
-        "details": "The native platform called back on an interface that has no JS-side handler registered yet.",
+        "details": "Native sent a callback for this interface, but your webview hasn't registered a handler for it yet.",
         "recoverable": true,
-        "suggestedAction": "Ensure WebBridge.register() is called for this interface before the native call arrives.",
+        "suggestedAction": "Call WebBridge.register() for this interface before native calls arrive.",
         "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-019.md"
     },
     "RUNTIME-NATIVE-020": {

--- a/errors/index.json
+++ b/errors/index.json
@@ -342,5 +342,45 @@
         "recoverable": true,
         "suggestedAction": "Close other camera apps and try again",
         "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-017.md"
+    },
+    "RUNTIME-NATIVE-018": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Invalid callback interface",
+        "details": "The native platform invoked WebBridge.callback() with an interface name that isn't recognized.",
+        "recoverable": false,
+        "suggestedAction": "Check the interface name against the registered NATIVE_CALLBACKS list; this usually indicates a native/JS version mismatch.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-018.md"
+    },
+    "RUNTIME-NATIVE-019": {
+        "category": "RUNTIME-NATIVE",
+        "message": "No handler registered for this bridge interface",
+        "details": "The native platform called back on an interface that has no JS-side handler registered yet.",
+        "recoverable": true,
+        "suggestedAction": "Ensure WebBridge.register() is called for this interface before the native call arrives.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-019.md"
+    },
+    "RUNTIME-NATIVE-020": {
+        "category": "RUNTIME-NATIVE",
+        "message": "A registered bridge callback handler threw",
+        "details": "The JS handler registered for this native callback interface threw an error while processing the callback.",
+        "recoverable": true,
+        "suggestedAction": "Fix the error thrown inside the registered handler (see the cause above).",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-020.md"
+    },
+    "RUNTIME-NATIVE-021": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Invalid bridge callback registration",
+        "details": "WebBridge.register() was called with a non-function callback or an unrecognized interface name.",
+        "recoverable": true,
+        "suggestedAction": "Pass a function as the callback and a valid interface name from NATIVE_CALLBACKS.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-021.md"
+    },
+    "RUNTIME-NATIVE-022": {
+        "category": "RUNTIME-NATIVE",
+        "message": "WebBridge could not be initialized",
+        "details": "WebBridge.init() was called outside a browser environment (no `window` available).",
+        "recoverable": false,
+        "suggestedAction": "Call WebBridge.init() in a browser environment, before using bridge features.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-022.md"
     }
 }

--- a/packages/catalyst-core/src/errors/registry.js
+++ b/packages/catalyst-core/src/errors/registry.js
@@ -382,9 +382,10 @@ export const ERROR_DEFINITIONS = {
     [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_NOT_REGISTERED]: {
         category: "RUNTIME-NATIVE",
         defaultMessage: "No handler registered for this bridge interface",
-        defaultDetails: "The native platform called back on an interface that has no JS-side handler registered yet.",
+        defaultDetails:
+            "Native sent a callback for this interface, but your webview hasn't registered a handler for it yet.",
         recoverable: true,
-        suggestedAction: "Ensure WebBridge.register() is called for this interface before the native call arrives.",
+        suggestedAction: "Call WebBridge.register() for this interface before native calls arrive.",
     },
     [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_THREW]: {
         category: "RUNTIME-NATIVE",

--- a/packages/catalyst-core/src/errors/registry.js
+++ b/packages/catalyst-core/src/errors/registry.js
@@ -51,6 +51,12 @@ export const ERROR_CODES = {
     RUNTIME_NATIVE_INTERNAL_ERROR: "RUNTIME-NATIVE-015",
     RUNTIME_NATIVE_CAMERA_UNAVAILABLE: "RUNTIME-NATIVE-016",
     RUNTIME_NATIVE_CAMERA_IN_USE: "RUNTIME-NATIVE-017",
+
+    RUNTIME_NATIVE_BRIDGE_INVALID_CALLBACK: "RUNTIME-NATIVE-018",
+    RUNTIME_NATIVE_BRIDGE_HANDLER_NOT_REGISTERED: "RUNTIME-NATIVE-019",
+    RUNTIME_NATIVE_BRIDGE_HANDLER_THREW: "RUNTIME-NATIVE-020",
+    RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION: "RUNTIME-NATIVE-021",
+    RUNTIME_NATIVE_BRIDGE_INIT_FAILED: "RUNTIME-NATIVE-022",
 }
 
 // One entry per catalyst-owned code. Foreign/wrapped errors (see wrapForeignError)
@@ -364,6 +370,42 @@ export const ERROR_DEFINITIONS = {
         defaultDetails: "Camera is being used by another application",
         recoverable: true,
         suggestedAction: "Close other camera apps and try again",
+    },
+
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_CALLBACK]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Invalid callback interface",
+        defaultDetails: "The native platform invoked WebBridge.callback() with an interface name that isn't recognized.",
+        recoverable: false,
+        suggestedAction: "Check the interface name against the registered NATIVE_CALLBACKS list; this usually indicates a native/JS version mismatch.",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_NOT_REGISTERED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "No handler registered for this bridge interface",
+        defaultDetails: "The native platform called back on an interface that has no JS-side handler registered yet.",
+        recoverable: true,
+        suggestedAction: "Ensure WebBridge.register() is called for this interface before the native call arrives.",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_THREW]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "A registered bridge callback handler threw",
+        defaultDetails: "The JS handler registered for this native callback interface threw an error while processing the callback.",
+        recoverable: true,
+        suggestedAction: "Fix the error thrown inside the registered handler (see the cause above).",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Invalid bridge callback registration",
+        defaultDetails: "WebBridge.register() was called with a non-function callback or an unrecognized interface name.",
+        recoverable: true,
+        suggestedAction: "Pass a function as the callback and a valid interface name from NATIVE_CALLBACKS.",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INIT_FAILED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "WebBridge could not be initialized",
+        defaultDetails: "WebBridge.init() was called outside a browser environment (no `window` available).",
+        recoverable: false,
+        suggestedAction: "Call WebBridge.init() in a browser environment, before using bridge features.",
     },
 }
 

--- a/packages/catalyst-core/src/native/bridge/WebBridge.js
+++ b/packages/catalyst-core/src/native/bridge/WebBridge.js
@@ -7,6 +7,7 @@ import {
 import nativeBridge from "./utils/NativeBridge.js"
 import CameraUtils from "./utils/CameraUtils.js"
 import pluginBridge from "../plugin-bridge/PluginBridge.js"
+import { createError, formatError, ERROR_CODES } from "../../errors/index.js"
 
 const DEVICE_INFO_PLUGIN = {
     pluginId: "io.catalyst.device_info",
@@ -87,11 +88,20 @@ class WebBridge {
      */
     static init = () => {
         if (typeof window === "undefined") {
-            console.error("🌉 WebBridge cannot be initialized outside the browser!")
+            console.error(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INIT_FAILED, {
+                        details: "WebBridge.init() was called outside a browser environment (no `window`).",
+                    })
+                )
+            )
             return null
         }
 
         if (window.WebBridge) {
+            // Not a failure — the bridge is already up and working, just return it.
+            // No code here: RUNTIME-NATIVE-022 means init genuinely failed, which
+            // this path is not.
             console.warn("🌉 WebBridge already initialized!")
             return window.WebBridge
         }
@@ -122,13 +132,25 @@ class WebBridge {
 
         // Validate interface
         if (!isValidCallback(interfaceName)) {
-            console.error(`🌉 Invalid callback interface: ${interfaceName}`)
+            console.error(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_CALLBACK, {
+                        details: `Received "${interfaceName}", which is not in the registered NATIVE_CALLBACKS list.`,
+                    })
+                )
+            )
             console.log("🌉 Available callbacks:", ALL_CALLBACKS)
             return
         }
 
         if (!this.handlers.has(interfaceName)) {
-            console.warn(`🌉 No handler registered for interface: ${interfaceName}`)
+            console.warn(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_NOT_REGISTERED, {
+                        details: `No handler registered for interface "${interfaceName}".`,
+                    })
+                )
+            )
             return
         }
 
@@ -136,7 +158,11 @@ class WebBridge {
             const handler = this.handlers.get(interfaceName)
             handler(data)
         } catch (error) {
-            console.error(`🌉 Error executing callback for ${interfaceName}:`, error)
+            const wrapped = createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_THREW, {
+                details: `The handler registered for "${interfaceName}" threw.`,
+                cause: error,
+            })
+            console.error(formatError(wrapped))
 
             // In development, provide more helpful error info
             if (process.env.NODE_ENV === "development") {
@@ -158,13 +184,25 @@ class WebBridge {
     register = (interfaceName, callback) => {
         // Validate callback function
         if (typeof callback !== "function") {
-            console.error("🌉 Callback must be a function!")
+            console.error(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION, {
+                        details: `register("${interfaceName}", ...) was called with a non-function callback (got ${typeof callback}).`,
+                    })
+                )
+            )
             return false
         }
 
         // Validate interface name
         if (!isValidCallback(interfaceName)) {
-            console.error(`🌉 Invalid callback interface: ${interfaceName}`)
+            console.error(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION, {
+                        details: `register() was called with "${interfaceName}", which is not a valid callback interface.`,
+                    })
+                )
+            )
             console.log("🌉 Available callback interfaces:", ALL_CALLBACKS)
             return false
         }


### PR DESCRIPTION
## Summary

Wires `WebBridge.js` (JS-side bridge dispatch layer) into the error registry introduced in #359, per the proposal posted on #370.

Adds 5 new codes:
- `RUNTIME-NATIVE-018` — invalid callback interface
- `RUNTIME-NATIVE-019` — no handler registered for interface
- `RUNTIME-NATIVE-020` — registered handler threw
- `RUNTIME-NATIVE-021` — invalid `register()` call (non-function or invalid interface)
- `RUNTIME-NATIVE-022` — `WebBridge.init()` called outside a browser (genuine failure only)

## Scope

Only the pure-logging paths in `WebBridge.js` (`callback`, `register`, `unregister`'s valid case, `static init`) are wired in. The Promise-rejecting paths (`requestHapticFeedback`, `getDeviceInfoFromLegacyBridge`, `getDeviceInfoFromPluginBridge`, `getDeviceInfo`) are **not touched** — `shouldFallbackToLegacyDeviceInfo` pattern-matches specific error codes/messages from those rejections to decide whether to retry via the legacy bridge, and recoding them into catalyst codes risks breaking that fallback logic. This is flagged as an explicit, deliberate scope boundary, not an oversight.

`unregister()`'s "not registered, nothing to unregister" case is left as plain text — it's a benign no-op, not an error condition.

## Review finding fixed before commit

Initial version used the same code (`RUNTIME-NATIVE-022`) for both "init failed" and "already initialized" in `static init()`. The second case isn't a failure — the bridge is already up and working — so using the same code there produced a message that contradicted its own details ("could not be initialized" / "returning the existing instance"). Fixed: the already-initialized path stays a plain `console.warn`, no code; `RUNTIME-NATIVE-022` now means only the genuine no-`window` failure.

## Known limitation

`docUrl` links point at `blob/main/errors/...`. These stay dead not just until this PR merges, but until `story/6-error-handling` itself merges to `main` — a longer tail than a single-PR merge would imply, since this PR only targets the story branch.

## Test plan

- [x] Verified all 6 `ERROR_CODES.*` references in `WebBridge.js` resolve to real registry entries (no silent fallback to a generic code)
- [x] Loaded the actual (unmodified) `WebBridge.js` file in an isolated ESM harness with browser globals shimmed, and exercised: invalid callback interface, no handler registered, handler-threw (cause preserved), invalid register() with non-function, invalid register() with bad interface name, init() first-call vs already-initialized
- [x] Confirmed already-initialized `init()` no longer prints a code (fixed per above)
- [x] Regenerated `errors/**/*.md` + `errors/index.json`, 48 codes total (was 43 after #359)

Closes #370.
