### PR TITLE
feat(errors): add AI-xxx error category for packages/catalyst-ai

### DIFF
--- a/errors/AI/AI-000.md
+++ b/errors/AI/AI-000.md
@@ -1,0 +1,19 @@
+# AI-000
+
+**Category:** AI
+
+## Message
+
+AI provider request failed
+
+## Details
+
+This is a wrapper around a non-2xx response or thrown error from the upstream AI provider (OpenAI/Gemini). See the printed upstream status/message for the actual cause — catalyst-ai does not reinterpret it.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Read the upstream provider error printed above and fix the underlying issue (auth, rate limit, invalid request).

--- a/errors/AI/AI-001.md
+++ b/errors/AI/AI-001.md
@@ -1,0 +1,19 @@
+# AI-001
+
+**Category:** AI
+
+## Message
+
+AI is disabled
+
+## Details
+
+AI_CONFIG.enabled is not set to true.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Set AI_CONFIG.enabled=true in your environment configuration.

--- a/errors/AI/AI-002.md
+++ b/errors/AI/AI-002.md
@@ -1,0 +1,19 @@
+# AI-002
+
+**Category:** AI
+
+## Message
+
+AI provider not configured
+
+## Details
+
+The requested provider is unknown, or has no apiKey configured in AI_CONFIG.providers.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Add the provider's apiKey to AI_CONFIG.providers, or use a configured provider.

--- a/errors/AI/AI-003.md
+++ b/errors/AI/AI-003.md
@@ -1,0 +1,19 @@
+# AI-003
+
+**Category:** AI
+
+## Message
+
+Invalid AI request body
+
+## Details
+
+The request body is missing a non-empty messages array, or no model could be resolved.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Pass a non-empty messages array, and either a model or a provider defaultModel.

--- a/errors/AI/AI-004.md
+++ b/errors/AI/AI-004.md
@@ -1,0 +1,19 @@
+# AI-004
+
+**Category:** AI
+
+## Message
+
+Native AI bridge unavailable
+
+## Details
+
+window.NativeBridge.initAI or window.WebBridge was not found when useNativeAI mounted.
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Update catalyst-core to >=0.2.0, add the native AI module, and call WebBridge.init() before mounting useNativeAI.

--- a/errors/AI/AI-005.md
+++ b/errors/AI/AI-005.md
@@ -1,0 +1,19 @@
+# AI-005
+
+**Category:** AI
+
+## Message
+
+Native AI stream not ready
+
+## Details
+
+generate() was called before the native side reported a ready stream URL (initAI has not fired ON_AI_READY yet).
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Wait for modelReady to become true before calling generate().

--- a/errors/AI/AI-006.md
+++ b/errors/AI/AI-006.md
@@ -1,0 +1,19 @@
+# AI-006
+
+**Category:** AI
+
+## Message
+
+Native AI request failed
+
+## Details
+
+The native AI HTTP endpoint returned a non-ok status or reported an error in its response body.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+See the cause above for the native-reported status/message.

--- a/errors/AI/AI-007.md
+++ b/errors/AI/AI-007.md
@@ -1,0 +1,19 @@
+# AI-007
+
+**Category:** AI
+
+## Message
+
+Native AI reported an error
+
+## Details
+
+The native platform invoked ON_AI_ERROR — a failure during model load, init, or inference on the native side, not an HTTP request made by this JS code.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+See the cause above for the native-reported message.

--- a/errors/AI/AI-008.md
+++ b/errors/AI/AI-008.md
@@ -1,0 +1,19 @@
+# AI-008
+
+**Category:** AI
+
+## Message
+
+Web AI worker unavailable
+
+## Details
+
+Constructing the module Worker for in-browser AI failed — module workers may be unsupported in this browser.
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Use a browser with module Worker support, or fall back to useCloudAI/useNativeAI.

--- a/errors/AI/AI-009.md
+++ b/errors/AI/AI-009.md
@@ -1,0 +1,19 @@
+# AI-009
+
+**Category:** AI
+
+## Message
+
+Web AI worker crashed
+
+## Details
+
+The in-browser AI worker threw during model load or generation (e.g. all device backends failed, or an uncaught exception). See the cause above for the worker's reported message.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.

--- a/errors/index.json
+++ b/errors/index.json
@@ -339,5 +339,85 @@
         "recoverable": false,
         "suggestedAction": "Call WebBridge.init() in a browser environment, before using bridge features.",
         "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-022.md"
+    },
+    "AI-000": {
+        "category": "AI",
+        "message": "AI provider request failed",
+        "details": "This is a wrapper around a non-2xx response or thrown error from the upstream AI provider (OpenAI/Gemini). See the printed upstream status/message for the actual cause — catalyst-ai does not reinterpret it.",
+        "recoverable": true,
+        "suggestedAction": "Read the upstream provider error printed above and fix the underlying issue (auth, rate limit, invalid request).",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-000.md"
+    },
+    "AI-001": {
+        "category": "AI",
+        "message": "AI is disabled",
+        "details": "AI_CONFIG.enabled is not set to true.",
+        "recoverable": true,
+        "suggestedAction": "Set AI_CONFIG.enabled=true in your environment configuration.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-001.md"
+    },
+    "AI-002": {
+        "category": "AI",
+        "message": "AI provider not configured",
+        "details": "The requested provider is unknown, or has no apiKey configured in AI_CONFIG.providers.",
+        "recoverable": true,
+        "suggestedAction": "Add the provider's apiKey to AI_CONFIG.providers, or use a configured provider.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-002.md"
+    },
+    "AI-003": {
+        "category": "AI",
+        "message": "Invalid AI request body",
+        "details": "The request body is missing a non-empty messages array, or no model could be resolved.",
+        "recoverable": true,
+        "suggestedAction": "Pass a non-empty messages array, and either a model or a provider defaultModel.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-003.md"
+    },
+    "AI-004": {
+        "category": "AI",
+        "message": "Native AI bridge unavailable",
+        "details": "window.NativeBridge.initAI or window.WebBridge was not found when useNativeAI mounted.",
+        "recoverable": false,
+        "suggestedAction": "Update catalyst-core to >=0.2.0, add the native AI module, and call WebBridge.init() before mounting useNativeAI.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-004.md"
+    },
+    "AI-005": {
+        "category": "AI",
+        "message": "Native AI stream not ready",
+        "details": "generate() was called before the native side reported a ready stream URL (initAI has not fired ON_AI_READY yet).",
+        "recoverable": true,
+        "suggestedAction": "Wait for modelReady to become true before calling generate().",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-005.md"
+    },
+    "AI-006": {
+        "category": "AI",
+        "message": "Native AI request failed",
+        "details": "The native AI HTTP endpoint returned a non-ok status or reported an error in its response body.",
+        "recoverable": true,
+        "suggestedAction": "See the cause above for the native-reported status/message.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-006.md"
+    },
+    "AI-007": {
+        "category": "AI",
+        "message": "Native AI reported an error",
+        "details": "The native platform invoked ON_AI_ERROR — a failure during model load, init, or inference on the native side, not an HTTP request made by this JS code.",
+        "recoverable": true,
+        "suggestedAction": "See the cause above for the native-reported message.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-007.md"
+    },
+    "AI-008": {
+        "category": "AI",
+        "message": "Web AI worker unavailable",
+        "details": "Constructing the module Worker for in-browser AI failed — module workers may be unsupported in this browser.",
+        "recoverable": false,
+        "suggestedAction": "Use a browser with module Worker support, or fall back to useCloudAI/useNativeAI.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-008.md"
+    },
+    "AI-009": {
+        "category": "AI",
+        "message": "Web AI worker crashed",
+        "details": "The in-browser AI worker threw during model load or generation (e.g. all device backends failed, or an uncaught exception). See the cause above for the worker's reported message.",
+        "recoverable": true,
+        "suggestedAction": "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-009.md"
     }
 }

--- a/errors/index.json
+++ b/errors/index.json
@@ -382,5 +382,85 @@
         "recoverable": false,
         "suggestedAction": "Call WebBridge.init() in a browser environment, before using bridge features.",
         "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-022.md"
+    },
+    "AI-000": {
+        "category": "AI",
+        "message": "AI provider request failed",
+        "details": "This is a wrapper around a non-2xx response or thrown error from the upstream AI provider (OpenAI/Gemini). See the printed upstream status/message for the actual cause — catalyst-ai does not reinterpret it.",
+        "recoverable": true,
+        "suggestedAction": "Read the upstream provider error printed above and fix the underlying issue (auth, rate limit, invalid request).",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-000.md"
+    },
+    "AI-001": {
+        "category": "AI",
+        "message": "AI is disabled",
+        "details": "AI_CONFIG.enabled is not set to true.",
+        "recoverable": true,
+        "suggestedAction": "Set AI_CONFIG.enabled=true in your environment configuration.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-001.md"
+    },
+    "AI-002": {
+        "category": "AI",
+        "message": "AI provider not configured",
+        "details": "The requested provider is unknown, or has no apiKey configured in AI_CONFIG.providers.",
+        "recoverable": true,
+        "suggestedAction": "Add the provider's apiKey to AI_CONFIG.providers, or use a configured provider.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-002.md"
+    },
+    "AI-003": {
+        "category": "AI",
+        "message": "Invalid AI request body",
+        "details": "The request body is missing a non-empty messages array, or no model could be resolved.",
+        "recoverable": true,
+        "suggestedAction": "Pass a non-empty messages array, and either a model or a provider defaultModel.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-003.md"
+    },
+    "AI-004": {
+        "category": "AI",
+        "message": "Native AI bridge unavailable",
+        "details": "window.NativeBridge.initAI or window.WebBridge was not found when useNativeAI mounted.",
+        "recoverable": false,
+        "suggestedAction": "Update catalyst-core to >=0.2.0, add the native AI module, and call WebBridge.init() before mounting useNativeAI.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-004.md"
+    },
+    "AI-005": {
+        "category": "AI",
+        "message": "Native AI stream not ready",
+        "details": "generate() was called before the native side reported a ready stream URL (initAI has not fired ON_AI_READY yet).",
+        "recoverable": true,
+        "suggestedAction": "Wait for modelReady to become true before calling generate().",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-005.md"
+    },
+    "AI-006": {
+        "category": "AI",
+        "message": "Native AI request failed",
+        "details": "The native AI HTTP endpoint returned a non-ok status or reported an error in its response body.",
+        "recoverable": true,
+        "suggestedAction": "See the cause above for the native-reported status/message.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-006.md"
+    },
+    "AI-007": {
+        "category": "AI",
+        "message": "Native AI reported an error",
+        "details": "The native platform invoked ON_AI_ERROR — a failure during model load, init, or inference on the native side, not an HTTP request made by this JS code.",
+        "recoverable": true,
+        "suggestedAction": "See the cause above for the native-reported message.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-007.md"
+    },
+    "AI-008": {
+        "category": "AI",
+        "message": "Web AI worker unavailable",
+        "details": "Constructing the module Worker for in-browser AI failed — module workers may be unsupported in this browser.",
+        "recoverable": false,
+        "suggestedAction": "Use a browser with module Worker support, or fall back to useCloudAI/useNativeAI.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-008.md"
+    },
+    "AI-009": {
+        "category": "AI",
+        "message": "Web AI worker crashed",
+        "details": "The in-browser AI worker threw during model load or generation (e.g. all device backends failed, or an uncaught exception). See the cause above for the worker's reported message.",
+        "recoverable": true,
+        "suggestedAction": "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-009.md"
     }
 }

--- a/packages/catalyst-ai/src/route.js
+++ b/packages/catalyst-ai/src/route.js
@@ -2,6 +2,14 @@ const express = require("express")
 
 const router = express.Router()
 
+// catalyst-core/errors is ESM-only; route.js stays CJS (loaded via require.resolve
+// in expressServer.js), so we load it lazily via dynamic import and cache the module.
+let errorsModulePromise = null
+function loadErrors() {
+    if (!errorsModulePromise) errorsModulePromise = import("catalyst-core/errors")
+    return errorsModulePromise
+}
+
 // Hard ceiling on how long a single /stream request may run upstream — protects
 // against a hung provider connection holding a request open indefinitely.
 const STREAM_TIMEOUT_MS = 120_000
@@ -50,6 +58,13 @@ function sseHeaders(res) {
     res.setHeader("Connection", "keep-alive")
     res.setHeader("X-Accel-Buffering", "no")
     res.flushHeaders()
+}
+
+// Wraps a non-ok provider response as a CatalystError (AI-000) and throws it,
+// preserving the upstream status/body verbatim as `cause`.
+async function throwProviderError(provider, response) {
+    const { wrapProviderError } = await loadErrors()
+    throw wrapProviderError(provider, response.status, await response.text())
 }
 
 // ─── usage normalization ──────────────────────────────────────────────────────
@@ -134,7 +149,7 @@ async function openaiStream({ apiKey, model, messages, genConfig, conversationId
             body: JSON.stringify(body),
             signal,
         })
-        if (!response.ok) throw new Error(`OpenAI Responses API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("openai", response)
 
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
@@ -187,7 +202,7 @@ async function openaiStream({ apiKey, model, messages, genConfig, conversationId
             body: JSON.stringify(body),
             signal,
         })
-        if (!response.ok) throw new Error(`OpenAI API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("openai", response)
 
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
@@ -238,7 +253,7 @@ async function openaiGenerate({ apiKey, model, messages, genConfig, conversation
             headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
             body: JSON.stringify(body),
         })
-        if (!response.ok) throw new Error(`OpenAI Responses API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("openai", response)
         const data = await response.json()
         const output = data.output?.find((o) => o.type === "message")?.content?.find((c) => c.type === "output_text")?.text ?? ""
         return { output, conversationId: data.id ?? null, usage: normalizeOpenAIResponsesUsage(data.usage, model) }
@@ -257,7 +272,7 @@ async function openaiGenerate({ apiKey, model, messages, genConfig, conversation
             headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
             body: JSON.stringify(body),
         })
-        if (!response.ok) throw new Error(`OpenAI API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("openai", response)
         const data = await response.json()
         return { output: data.choices?.[0]?.message?.content ?? "", conversationId: null, usage: normalizeOpenAIChatUsage(data.usage, model) }
     }
@@ -309,7 +324,7 @@ async function geminiStream({ apiKey, model, messages, genConfig, conversationId
             body: JSON.stringify(body),
             signal,
         })
-        if (!response.ok) throw new Error(`Gemini Interactions API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("gemini", response)
 
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
@@ -361,7 +376,7 @@ async function geminiStream({ apiKey, model, messages, genConfig, conversationId
             body: JSON.stringify(body),
             signal,
         })
-        if (!response.ok) throw new Error(`Gemini API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("gemini", response)
 
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
@@ -418,7 +433,7 @@ async function geminiGenerate({ apiKey, model, messages, genConfig, conversation
             headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
             body: JSON.stringify(body),
         })
-        if (!response.ok) throw new Error(`Gemini Interactions API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("gemini", response)
         const data = await response.json()
         const text = data.steps?.find((s) => s.type === "model_output")?.content?.[0]?.text ?? ""
         return { output: text, conversationId: data.id ?? null, usage: normalizeGeminiInteractionUsage(data.usage, model) }
@@ -441,7 +456,7 @@ async function geminiGenerate({ apiKey, model, messages, genConfig, conversation
             headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
             body: JSON.stringify(body),
         })
-        if (!response.ok) throw new Error(`Gemini API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("gemini", response)
         const data = await response.json()
         return { output: data.candidates?.[0]?.content?.parts?.[0]?.text ?? "", conversationId: null, usage: normalizeGeminiUsage(data.usageMetadata, model) }
     }
@@ -456,9 +471,20 @@ const PROVIDERS = {
 
 // ─── routes ───────────────────────────────────────────────────────────────────
 
+// Additive `code` field alongside the existing `{ error }` shape — does not
+// change the response contract, just gives clients an AI-xxx code to look up.
+async function sendCodedError(res, status, code, message) {
+    const { getDocUrl } = await loadErrors()
+    res.status(status).json({ error: message, code, docUrl: getDocUrl(code) })
+}
+
 // GET /ai/providers — returns list of configured provider ids, no keys exposed
-router.get("/providers", (req, res) => {
-    if (!isAIEnabled()) { res.status(403).json({ error: "AI is disabled. Set AI_CONFIG.enabled=true to enable." }); return }
+router.get("/providers", async (req, res) => {
+    if (!isAIEnabled()) {
+        const { ERROR_CODES } = await loadErrors()
+        await sendCodedError(res, 403, ERROR_CODES.AI_DISABLED, "AI is disabled. Set AI_CONFIG.enabled=true to enable.")
+        return
+    }
     const providers = Object.entries(getAIConfig()?.providers ?? {})
         .filter(([, cfg]) => cfg?.apiKey)
         .map(([id, cfg]) => ({ id, defaultModel: cfg.defaultModel ?? null }))
@@ -466,16 +492,26 @@ router.get("/providers", (req, res) => {
 })
 
 router.post("/:provider/stream", async (req, res) => {
-    if (!isAIEnabled()) { res.status(403).json({ error: "AI is disabled. Set AI_CONFIG.enabled=true to enable." }); return }
+    const { ERROR_CODES } = await loadErrors()
+    if (!isAIEnabled()) {
+        await sendCodedError(res, 403, ERROR_CODES.AI_DISABLED, "AI is disabled. Set AI_CONFIG.enabled=true to enable.")
+        return
+    }
     const { provider } = req.params
     const adapter = PROVIDERS[provider]
     if (!adapter) { res.status(404).json({ error: `Unknown provider: ${provider}` }); return }
 
     const cfg = getProviderConfig(provider)
-    if (!cfg) { res.status(404).json({ error: `Provider "${provider}" not configured` }); return }
+    if (!cfg) {
+        await sendCodedError(res, 404, ERROR_CODES.AI_PROVIDER_NOT_CONFIGURED, `Provider "${provider}" not configured`)
+        return
+    }
 
     const validationError = validateRequestBody(req, cfg)
-    if (validationError) { res.status(400).json({ error: validationError }); return }
+    if (validationError) {
+        await sendCodedError(res, 400, ERROR_CODES.AI_INVALID_REQUEST_BODY, validationError)
+        return
+    }
 
     const { messages, genConfig = {}, conversationId, model } = req.body
     const stateful = "conversationId" in req.body
@@ -503,9 +539,15 @@ router.post("/:provider/stream", async (req, res) => {
             signal: abortController.signal,
         })
     } catch (err) {
-        console.error("[catalyst-ai] %s stream error:", provider, err.message)
+        // err.code is only an AI-xxx string when err is a CatalystError. On the
+        // client-disconnect path (res "close" -> abortController.abort()) fetch
+        // rejects with a DOMException whose .code is the numeric legacy value 20 —
+        // attaching that as `code` would be a bogus registry lookup for callers.
+        const { CatalystError } = await loadErrors()
+        const code = err instanceof CatalystError ? err.code : undefined
+        console.error("[catalyst-ai] %s stream error:", provider, code ? `[${code}] ${err.message}` : err.message)
         if (!res.writableEnded) {
-            res.write(`data: ${JSON.stringify({ error: err.message })}\n\n`)
+            res.write(`data: ${JSON.stringify({ error: err.message, code })}\n\n`)
             res.end()
         }
     } finally {
@@ -514,16 +556,26 @@ router.post("/:provider/stream", async (req, res) => {
 })
 
 router.post("/:provider/generate", async (req, res) => {
-    if (!isAIEnabled()) { res.status(403).json({ error: "AI is disabled. Set AI_CONFIG.enabled=true to enable." }); return }
+    const { ERROR_CODES } = await loadErrors()
+    if (!isAIEnabled()) {
+        await sendCodedError(res, 403, ERROR_CODES.AI_DISABLED, "AI is disabled. Set AI_CONFIG.enabled=true to enable.")
+        return
+    }
     const { provider } = req.params
     const adapter = PROVIDERS[provider]
     if (!adapter) { res.status(404).json({ error: `Unknown provider: ${provider}` }); return }
 
     const cfg = getProviderConfig(provider)
-    if (!cfg) { res.status(404).json({ error: `Provider "${provider}" not configured` }); return }
+    if (!cfg) {
+        await sendCodedError(res, 404, ERROR_CODES.AI_PROVIDER_NOT_CONFIGURED, `Provider "${provider}" not configured`)
+        return
+    }
 
     const validationError = validateRequestBody(req, cfg)
-    if (validationError) { res.status(400).json({ error: validationError }); return }
+    if (validationError) {
+        await sendCodedError(res, 400, ERROR_CODES.AI_INVALID_REQUEST_BODY, validationError)
+        return
+    }
 
     const { messages, genConfig = {}, conversationId, model } = req.body
     const stateful = "conversationId" in req.body
@@ -534,8 +586,10 @@ router.post("/:provider/generate", async (req, res) => {
         const result = await adapter.generate({ apiKey: cfg.apiKey, model: resolvedModel, messages, genConfig, conversationId, stateful })
         res.json({ ...result, model: resolvedModel })
     } catch (err) {
-        console.error("[catalyst-ai] %s generate error:", provider, err.message)
-        res.status(500).json({ error: err.message })
+        const { CatalystError } = await loadErrors()
+        const code = err instanceof CatalystError ? err.code : undefined
+        console.error("[catalyst-ai] %s generate error:", provider, code ? `[${code}] ${err.message}` : err.message)
+        res.status(500).json({ error: err.message, code })
     }
 })
 

--- a/packages/catalyst-ai/src/useNativeAI.js
+++ b/packages/catalyst-ai/src/useNativeAI.js
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from "react"
 import { aggregateNativeSessionMetrics } from "./metrics.js"
+import { ERROR_CODES, createError } from "catalyst-core/errors"
 
 const ATTACHMENT_TAG_RE = /<tool:create_attachment\s+component='([^']+)'([^>]*)>([\s\S]*?)<\/tool:create_attachment>/g
 
@@ -57,14 +58,15 @@ export function useNativeAI({
         if (!enabled) return
 
         if (!window.NativeBridge?.initAI) {
-            setError(new Error(
-                "[catalyst-ai/useNativeAI] window.NativeBridge.initAI not found. " +
-                "Update catalyst-core to >=0.2.0 and add the android module to settings.gradle.kts."
-            ))
+            setError(createError(ERROR_CODES.AI_NATIVE_BRIDGE_UNAVAILABLE, {
+                message: "window.NativeBridge.initAI not found. Update catalyst-core to >=0.2.0 and add the android module to settings.gradle.kts.",
+            }))
             return
         }
         if (!window.WebBridge) {
-            setError(new Error("[catalyst-ai/useNativeAI] WebBridge not initialized — call WebBridge.init() before mounting useNativeAI"))
+            setError(createError(ERROR_CODES.AI_NATIVE_BRIDGE_UNAVAILABLE, {
+                message: "WebBridge not initialized — call WebBridge.init() before mounting useNativeAI.",
+            }))
             return
         }
 
@@ -76,14 +78,21 @@ export function useNativeAI({
                     setModelReady(true)
                     setNativeDownloadProgress(null)
                 }
-            } catch (_) {}
+            } catch (_) {
+                // Deliberately silent: a malformed ON_AI_READY payload just means this
+                // ready signal is skipped, not a user-facing failure — the native side
+                // will fire again or the missing modelReady state will surface on its own.
+            }
         }
 
         const onProgress = (data) => {
             try {
                 const parsed = typeof data === "string" ? JSON.parse(data) : data
                 setNativeDownloadProgress(parsed)
-            } catch (_) {}
+            } catch (_) {
+                // Deliberately silent: a malformed progress payload just means this
+                // progress tick is skipped, not a user-facing failure.
+            }
         }
 
         const onLog = (data) => {
@@ -91,17 +100,21 @@ export function useNativeAI({
                 const parsed = typeof data === "string" ? JSON.parse(data) : data
                 const msg = parsed?.message ?? String(data)
                 setNativeLogs((prev) => [...prev.slice(-99), msg])
-            } catch (_) {}
+            } catch (_) {
+                // Deliberately silent: a malformed log payload just means this
+                // log line is skipped, not a user-facing failure.
+            }
         }
 
         const onError = (data) => {
+            let msg
             try {
                 const parsed = typeof data === "string" ? JSON.parse(data) : data
-                const msg = parsed?.message ?? String(data)
-                setError(new Error(msg))
+                msg = parsed?.message ?? String(data)
             } catch (_) {
-                setError(new Error(String(data)))
+                msg = String(data)
             }
+            setError(createError(ERROR_CODES.AI_NATIVE_CALLBACK_ERROR, { message: msg }))
         }
 
         window.WebBridge.register(NATIVE_CALLBACKS.ON_AI_READY, onReady)
@@ -122,7 +135,7 @@ export function useNativeAI({
         async ({ messages, genConfig: callGenConfig = {} }) => {
             const url = nativeStreamUrlRef.current
             if (!url) {
-                setError(new Error("[catalyst-ai/useNativeAI] stream URL not ready — did initAI fire?"))
+                setError(createError(ERROR_CODES.AI_NATIVE_STREAM_NOT_READY))
                 return
             }
 
@@ -159,11 +172,17 @@ export function useNativeAI({
                         signal: controller.signal,
                     })
 
-                    if (!response.ok) throw new Error(`Native AI HTTP error: ${response.status}`)
+                    if (!response.ok) {
+                        throw createError(ERROR_CODES.AI_NATIVE_REQUEST_FAILED, {
+                            message: `Native AI HTTP error: ${response.status}`,
+                        })
+                    }
                     setLoading(false)
 
                     const data = await response.json()
-                    if (data.error) throw new Error(data.error)
+                    if (data.error) {
+                        throw createError(ERROR_CODES.AI_NATIVE_REQUEST_FAILED, { message: data.error })
+                    }
 
                     if (sessionMode === "stateful" && data.conversationId) {
                         conversationIdRef.current = data.conversationId
@@ -185,7 +204,11 @@ export function useNativeAI({
                     signal: controller.signal,
                 })
 
-                if (!response.ok) throw new Error(`Native AI HTTP error: ${response.status}`)
+                if (!response.ok) {
+                    throw createError(ERROR_CODES.AI_NATIVE_REQUEST_FAILED, {
+                        message: `Native AI HTTP error: ${response.status}`,
+                    })
+                }
 
                 setLoading(false)
                 setStreaming(true)
@@ -203,35 +226,43 @@ export function useNativeAI({
                         buffer = lines.pop() || ""
                         for (const line of lines) {
                             if (!line.startsWith("data: ")) continue
+                            // JSON.parse failure means a malformed/partial SSE chunk — skip it.
+                            // A parsed data.error is a real signal and must propagate to the
+                            // outer catch, not be swallowed here alongside parse failures.
+                            let data
                             try {
-                                const data = JSON.parse(line.slice(6))
-                                if (data.done) {
-                                    setStreaming(false)
-                                    const genMs = Math.round(performance.now() - t0)
-                                    const tps = tokenCount > 0 ? parseFloat((tokenCount / (genMs / 1000)).toFixed(1)) : 0
-                                    const streamMetrics = { device: "native", ttftMs, tps, totalTokens: tokenCount, genMs }
-                                    setMetrics(streamMetrics)
-                                    historyRef.current.push(streamMetrics)
-                                    return
+                                data = JSON.parse(line.slice(6))
+                            } catch (_) {
+                                continue
+                            }
+                            if (data.done) {
+                                setStreaming(false)
+                                const genMs = Math.round(performance.now() - t0)
+                                const tps = tokenCount > 0 ? parseFloat((tokenCount / (genMs / 1000)).toFixed(1)) : 0
+                                const streamMetrics = { device: "native", ttftMs, tps, totalTokens: tokenCount, genMs }
+                                setMetrics(streamMetrics)
+                                historyRef.current.push(streamMetrics)
+                                return
+                            }
+                            if (sessionMode === "stateful" && data.conversationId) {
+                                conversationIdRef.current = data.conversationId
+                            }
+                            if (typeof data.token === "string") {
+                                if (ttftMs === null) ttftMs = Math.round(performance.now() - t0)
+                                tokenCount++
+                                outputAccRef.current += data.token
+                                outputAccRef.current = outputAccRef.current.replace(ATTACHMENT_TAG_RE, parseAttachmentTag)
+                                if (!rafRef.current) {
+                                    const schedule = typeof requestAnimationFrame !== "undefined" ? requestAnimationFrame : (fn) => setTimeout(fn, 16)
+                                    rafRef.current = schedule(() => {
+                                        rafRef.current = null
+                                        setOutput(outputAccRef.current)
+                                    })
                                 }
-                                if (sessionMode === "stateful" && data.conversationId) {
-                                    conversationIdRef.current = data.conversationId
-                                }
-                                if (typeof data.token === "string") {
-                                    if (ttftMs === null) ttftMs = Math.round(performance.now() - t0)
-                                    tokenCount++
-                                    outputAccRef.current += data.token
-                                    outputAccRef.current = outputAccRef.current.replace(ATTACHMENT_TAG_RE, parseAttachmentTag)
-                                    if (!rafRef.current) {
-                                        const schedule = typeof requestAnimationFrame !== "undefined" ? requestAnimationFrame : (fn) => setTimeout(fn, 16)
-                                        rafRef.current = schedule(() => {
-                                            rafRef.current = null
-                                            setOutput(outputAccRef.current)
-                                        })
-                                    }
-                                }
-                                if (data.error) throw new Error(data.error)
-                            } catch (_) {}
+                            }
+                            if (data.error) {
+                                throw createError(ERROR_CODES.AI_NATIVE_REQUEST_FAILED, { message: data.error })
+                            }
                         }
                     }
                 } finally {

--- a/packages/catalyst-ai/src/useWebAI.js
+++ b/packages/catalyst-ai/src/useWebAI.js
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from "react"
 import { aggregateWebSessionMetrics } from "./metrics.js"
+import { ERROR_CODES, createError } from "catalyst-core/errors"
 
 const schedule = typeof requestAnimationFrame !== "undefined" ? requestAnimationFrame : (fn) => setTimeout(fn, 16)
 const cancelSchedule = typeof cancelAnimationFrame !== "undefined" ? cancelAnimationFrame : clearTimeout
@@ -244,7 +245,10 @@ export function useWebAI({
             try {
                 worker = new Worker(getWorkerBlobUrl(), { type: "module" })
             } catch (err) {
-                setError(new Error("[catalyst-ai/useWebAI] module worker unavailable: " + (err.message || String(err))))
+                setError(createError(ERROR_CODES.AI_WEB_WORKER_UNAVAILABLE, {
+                    message: "Constructing the module Worker failed: " + (err.message || String(err)),
+                    cause: err,
+                }))
                 setLoading(false)
                 return
             }
@@ -309,7 +313,7 @@ export function useWebAI({
                         break
                     case "error":
                         console.error("[catalyst-ai/useWebAI] worker error:", msg.message)
-                        setError(new Error(msg.message))
+                        setError(createError(ERROR_CODES.AI_WEB_WORKER_CRASHED, { message: msg.message }))
                         setStreaming(false)
                         setLoading(false)
                         worker.terminate()
@@ -320,7 +324,10 @@ export function useWebAI({
 
             worker.onerror = (e) => {
                 console.error("[catalyst-ai/useWebAI] worker uncaught error:", e)
-                setError(new Error(e.message || "Worker crashed"))
+                setError(createError(ERROR_CODES.AI_WEB_WORKER_CRASHED, {
+                    message: e.message || "Worker crashed",
+                    cause: e,
+                }))
                 setStreaming(false)
                 setLoading(false)
                 worker.terminate()

--- a/packages/catalyst-ai/src/useWebAI.js
+++ b/packages/catalyst-ai/src/useWebAI.js
@@ -245,10 +245,7 @@ export function useWebAI({
             try {
                 worker = new Worker(getWorkerBlobUrl(), { type: "module" })
             } catch (err) {
-                setError(createError(ERROR_CODES.AI_WEB_WORKER_UNAVAILABLE, {
-                    message: "Constructing the module Worker failed: " + (err.message || String(err)),
-                    cause: err,
-                }))
+                setError(createError(ERROR_CODES.AI_WEB_WORKER_UNAVAILABLE, { cause: err }))
                 setLoading(false)
                 return
             }

--- a/packages/catalyst-core/package.json
+++ b/packages/catalyst-core/package.json
@@ -24,6 +24,7 @@
         "./document": "./dist/server/renderer/document/index.jsx",
         "./WebBridge": "./dist/native/bridge/WebBridge.js",
         "./hooks": "./dist/native/bridge/hooks.js",
+        "./errors": "./dist/errors/index.js",
         "./sentry": "./dist/sentry.cjs",
         "./otel": "./dist/otel.js"
     },

--- a/packages/catalyst-core/src/errors/index.js
+++ b/packages/catalyst-core/src/errors/index.js
@@ -1,6 +1,6 @@
 import { ERROR_CODES, getDefinition, getDocUrl } from "./registry.js"
 
-export { ERROR_CODES }
+export { ERROR_CODES, getDocUrl }
 
 export class CatalystError extends Error {
     constructor(code, { message, details, recoverable, suggestedAction, category, docUrl, cause } = {}) {
@@ -67,6 +67,22 @@ export function wrapForeignError(stage, err) {
         cause: err,
     })
     return wrapped
+}
+
+/**
+ * Wrap a failed AI provider HTTP response (OpenAI/Gemini). Unlike
+ * wrapForeignError (build toolchains, which carry a named err.code), provider
+ * failures are an HTTP status + response body — we preserve both verbatim
+ * as `cause` rather than reinterpreting them.
+ */
+export function wrapProviderError(provider, status, bodyText) {
+    const cause = new Error(`${provider} API error (${status}): ${bodyText}`)
+    cause.provider = provider
+    cause.status = status
+    return createError(ERROR_CODES.AI_UPSTREAM_ERROR, {
+        message: `AI provider request failed (upstream: ${provider} ${status})`,
+        cause,
+    })
 }
 
 /**

--- a/packages/catalyst-core/src/errors/index.js
+++ b/packages/catalyst-core/src/errors/index.js
@@ -1,3 +1,11 @@
+/**
+ * The "catalyst-core/errors" subpath export exists so catalyst's own
+ * packages (catalyst-ai, create-catalyst-app, etc.) can share this
+ * registry/CatalystError shape instead of each defining their own. It is
+ * not a recommendation for app code to throw CatalystError instead of
+ * Error — apps should keep using plain Error unless they're specifically
+ * interoperating with catalyst's own error codes.
+ */
 import { ERROR_CODES, getDefinition, getDocUrl } from "./registry.js"
 
 export { ERROR_CODES, getDocUrl }

--- a/packages/catalyst-core/src/errors/index.js
+++ b/packages/catalyst-core/src/errors/index.js
@@ -1,6 +1,6 @@
 import { ERROR_CODES, getDefinition, getDocUrl } from "./registry.js"
 
-export { ERROR_CODES }
+export { ERROR_CODES, getDocUrl }
 
 export class CatalystError extends Error {
     constructor(code, { message, details, suggestedAction, category, docUrl, cause } = {}) {
@@ -65,6 +65,22 @@ export function wrapForeignError(stage, err) {
         cause: err,
     })
     return wrapped
+}
+
+/**
+ * Wrap a failed AI provider HTTP response (OpenAI/Gemini). Unlike
+ * wrapForeignError (build toolchains, which carry a named err.code), provider
+ * failures are an HTTP status + response body — we preserve both verbatim
+ * as `cause` rather than reinterpreting them.
+ */
+export function wrapProviderError(provider, status, bodyText) {
+    const cause = new Error(`${provider} API error (${status}): ${bodyText}`)
+    cause.provider = provider
+    cause.status = status
+    return createError(ERROR_CODES.AI_UPSTREAM_ERROR, {
+        message: `AI provider request failed (upstream: ${provider} ${status})`,
+        cause,
+    })
 }
 
 /**

--- a/packages/catalyst-core/src/errors/registry.js
+++ b/packages/catalyst-core/src/errors/registry.js
@@ -53,6 +53,17 @@ export const ERROR_CODES = {
     RUNTIME_NATIVE_BRIDGE_HANDLER_THREW: "RUNTIME-NATIVE-020",
     RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION: "RUNTIME-NATIVE-021",
     RUNTIME_NATIVE_BRIDGE_INIT_FAILED: "RUNTIME-NATIVE-022",
+
+    AI_UPSTREAM_ERROR: "AI-000",
+    AI_DISABLED: "AI-001",
+    AI_PROVIDER_NOT_CONFIGURED: "AI-002",
+    AI_INVALID_REQUEST_BODY: "AI-003",
+    AI_NATIVE_BRIDGE_UNAVAILABLE: "AI-004",
+    AI_NATIVE_STREAM_NOT_READY: "AI-005",
+    AI_NATIVE_REQUEST_FAILED: "AI-006",
+    AI_NATIVE_CALLBACK_ERROR: "AI-007",
+    AI_WEB_WORKER_UNAVAILABLE: "AI-008",
+    AI_WEB_WORKER_CRASHED: "AI-009",
 }
 
 // One entry per catalyst-owned code. Foreign/wrapped errors (see wrapForeignError)
@@ -360,6 +371,80 @@ export const ERROR_DEFINITIONS = {
         defaultDetails: "WebBridge.init() was called outside a browser environment (no `window` available).",
         recoverable: false,
         suggestedAction: "Call WebBridge.init() in a browser environment, before using bridge features.",
+    },
+
+    [ERROR_CODES.AI_UPSTREAM_ERROR]: {
+        category: "AI",
+        defaultMessage: "AI provider request failed",
+        defaultDetails:
+            "This is a wrapper around a non-2xx response or thrown error from the upstream AI provider (OpenAI/Gemini). See the printed upstream status/message for the actual cause — catalyst-ai does not reinterpret it.",
+        recoverable: true,
+        suggestedAction: "Read the upstream provider error printed above and fix the underlying issue (auth, rate limit, invalid request).",
+    },
+    [ERROR_CODES.AI_DISABLED]: {
+        category: "AI",
+        defaultMessage: "AI is disabled",
+        defaultDetails: "AI_CONFIG.enabled is not set to true.",
+        recoverable: true,
+        suggestedAction: "Set AI_CONFIG.enabled=true in your environment configuration.",
+    },
+    [ERROR_CODES.AI_PROVIDER_NOT_CONFIGURED]: {
+        category: "AI",
+        defaultMessage: "AI provider not configured",
+        defaultDetails: "The requested provider is unknown, or has no apiKey configured in AI_CONFIG.providers.",
+        recoverable: true,
+        suggestedAction: "Add the provider's apiKey to AI_CONFIG.providers, or use a configured provider.",
+    },
+    [ERROR_CODES.AI_INVALID_REQUEST_BODY]: {
+        category: "AI",
+        defaultMessage: "Invalid AI request body",
+        defaultDetails: "The request body is missing a non-empty messages array, or no model could be resolved.",
+        recoverable: true,
+        suggestedAction: "Pass a non-empty messages array, and either a model or a provider defaultModel.",
+    },
+    [ERROR_CODES.AI_NATIVE_BRIDGE_UNAVAILABLE]: {
+        category: "AI",
+        defaultMessage: "Native AI bridge unavailable",
+        defaultDetails: "window.NativeBridge.initAI or window.WebBridge was not found when useNativeAI mounted.",
+        recoverable: false,
+        suggestedAction: "Update catalyst-core to >=0.2.0, add the native AI module, and call WebBridge.init() before mounting useNativeAI.",
+    },
+    [ERROR_CODES.AI_NATIVE_STREAM_NOT_READY]: {
+        category: "AI",
+        defaultMessage: "Native AI stream not ready",
+        defaultDetails: "generate() was called before the native side reported a ready stream URL (initAI has not fired ON_AI_READY yet).",
+        recoverable: true,
+        suggestedAction: "Wait for modelReady to become true before calling generate().",
+    },
+    [ERROR_CODES.AI_NATIVE_REQUEST_FAILED]: {
+        category: "AI",
+        defaultMessage: "Native AI request failed",
+        defaultDetails: "The native AI HTTP endpoint returned a non-ok status or reported an error in its response body.",
+        recoverable: true,
+        suggestedAction: "See the cause above for the native-reported status/message.",
+    },
+    [ERROR_CODES.AI_NATIVE_CALLBACK_ERROR]: {
+        category: "AI",
+        defaultMessage: "Native AI reported an error",
+        defaultDetails:
+            "The native platform invoked ON_AI_ERROR — a failure during model load, init, or inference on the native side, not an HTTP request made by this JS code.",
+        recoverable: true,
+        suggestedAction: "See the cause above for the native-reported message.",
+    },
+    [ERROR_CODES.AI_WEB_WORKER_UNAVAILABLE]: {
+        category: "AI",
+        defaultMessage: "Web AI worker unavailable",
+        defaultDetails: "Constructing the module Worker for in-browser AI failed — module workers may be unsupported in this browser.",
+        recoverable: false,
+        suggestedAction: "Use a browser with module Worker support, or fall back to useCloudAI/useNativeAI.",
+    },
+    [ERROR_CODES.AI_WEB_WORKER_CRASHED]: {
+        category: "AI",
+        defaultMessage: "Web AI worker crashed",
+        defaultDetails:
+            "The in-browser AI worker threw during model load or generation (e.g. all device backends failed, or an uncaught exception). See the cause above for the worker's reported message.",
+        recoverable: true,
+        suggestedAction: "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
     },
 }
 

--- a/packages/catalyst-core/src/errors/registry.js
+++ b/packages/catalyst-core/src/errors/registry.js
@@ -57,6 +57,17 @@ export const ERROR_CODES = {
     RUNTIME_NATIVE_BRIDGE_HANDLER_THREW: "RUNTIME-NATIVE-020",
     RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION: "RUNTIME-NATIVE-021",
     RUNTIME_NATIVE_BRIDGE_INIT_FAILED: "RUNTIME-NATIVE-022",
+
+    AI_UPSTREAM_ERROR: "AI-000",
+    AI_DISABLED: "AI-001",
+    AI_PROVIDER_NOT_CONFIGURED: "AI-002",
+    AI_INVALID_REQUEST_BODY: "AI-003",
+    AI_NATIVE_BRIDGE_UNAVAILABLE: "AI-004",
+    AI_NATIVE_STREAM_NOT_READY: "AI-005",
+    AI_NATIVE_REQUEST_FAILED: "AI-006",
+    AI_NATIVE_CALLBACK_ERROR: "AI-007",
+    AI_WEB_WORKER_UNAVAILABLE: "AI-008",
+    AI_WEB_WORKER_CRASHED: "AI-009",
 }
 
 // One entry per catalyst-owned code. Foreign/wrapped errors (see wrapForeignError)
@@ -406,6 +417,80 @@ export const ERROR_DEFINITIONS = {
         defaultDetails: "WebBridge.init() was called outside a browser environment (no `window` available).",
         recoverable: false,
         suggestedAction: "Call WebBridge.init() in a browser environment, before using bridge features.",
+    },
+
+    [ERROR_CODES.AI_UPSTREAM_ERROR]: {
+        category: "AI",
+        defaultMessage: "AI provider request failed",
+        defaultDetails:
+            "This is a wrapper around a non-2xx response or thrown error from the upstream AI provider (OpenAI/Gemini). See the printed upstream status/message for the actual cause — catalyst-ai does not reinterpret it.",
+        recoverable: true,
+        suggestedAction: "Read the upstream provider error printed above and fix the underlying issue (auth, rate limit, invalid request).",
+    },
+    [ERROR_CODES.AI_DISABLED]: {
+        category: "AI",
+        defaultMessage: "AI is disabled",
+        defaultDetails: "AI_CONFIG.enabled is not set to true.",
+        recoverable: true,
+        suggestedAction: "Set AI_CONFIG.enabled=true in your environment configuration.",
+    },
+    [ERROR_CODES.AI_PROVIDER_NOT_CONFIGURED]: {
+        category: "AI",
+        defaultMessage: "AI provider not configured",
+        defaultDetails: "The requested provider is unknown, or has no apiKey configured in AI_CONFIG.providers.",
+        recoverable: true,
+        suggestedAction: "Add the provider's apiKey to AI_CONFIG.providers, or use a configured provider.",
+    },
+    [ERROR_CODES.AI_INVALID_REQUEST_BODY]: {
+        category: "AI",
+        defaultMessage: "Invalid AI request body",
+        defaultDetails: "The request body is missing a non-empty messages array, or no model could be resolved.",
+        recoverable: true,
+        suggestedAction: "Pass a non-empty messages array, and either a model or a provider defaultModel.",
+    },
+    [ERROR_CODES.AI_NATIVE_BRIDGE_UNAVAILABLE]: {
+        category: "AI",
+        defaultMessage: "Native AI bridge unavailable",
+        defaultDetails: "window.NativeBridge.initAI or window.WebBridge was not found when useNativeAI mounted.",
+        recoverable: false,
+        suggestedAction: "Update catalyst-core to >=0.2.0, add the native AI module, and call WebBridge.init() before mounting useNativeAI.",
+    },
+    [ERROR_CODES.AI_NATIVE_STREAM_NOT_READY]: {
+        category: "AI",
+        defaultMessage: "Native AI stream not ready",
+        defaultDetails: "generate() was called before the native side reported a ready stream URL (initAI has not fired ON_AI_READY yet).",
+        recoverable: true,
+        suggestedAction: "Wait for modelReady to become true before calling generate().",
+    },
+    [ERROR_CODES.AI_NATIVE_REQUEST_FAILED]: {
+        category: "AI",
+        defaultMessage: "Native AI request failed",
+        defaultDetails: "The native AI HTTP endpoint returned a non-ok status or reported an error in its response body.",
+        recoverable: true,
+        suggestedAction: "See the cause above for the native-reported status/message.",
+    },
+    [ERROR_CODES.AI_NATIVE_CALLBACK_ERROR]: {
+        category: "AI",
+        defaultMessage: "Native AI reported an error",
+        defaultDetails:
+            "The native platform invoked ON_AI_ERROR — a failure during model load, init, or inference on the native side, not an HTTP request made by this JS code.",
+        recoverable: true,
+        suggestedAction: "See the cause above for the native-reported message.",
+    },
+    [ERROR_CODES.AI_WEB_WORKER_UNAVAILABLE]: {
+        category: "AI",
+        defaultMessage: "Web AI worker unavailable",
+        defaultDetails: "Constructing the module Worker for in-browser AI failed — module workers may be unsupported in this browser.",
+        recoverable: false,
+        suggestedAction: "Use a browser with module Worker support, or fall back to useCloudAI/useNativeAI.",
+    },
+    [ERROR_CODES.AI_WEB_WORKER_CRASHED]: {
+        category: "AI",
+        defaultMessage: "Web AI worker crashed",
+        defaultDetails:
+            "The in-browser AI worker threw during model load or generation (e.g. all device backends failed, or an uncaught exception). See the cause above for the worker's reported message.",
+        recoverable: true,
+        suggestedAction: "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
     },
 }
 


### PR DESCRIPTION
Closes #371.

## Summary

Adds `AI-xxx` error codes for `packages/catalyst-ai`, per the design proposed and amended on #371:
- `AI-000` — foreign-wrapper for OpenAI/Gemini non-2xx responses (`wrapProviderError`, same pattern as `wrapForeignError` for build toolchains)
- `AI-001`..`AI-009` — catalyst-ai-owned codes for disabled/not-configured/invalid-body (route.js), native bridge/HTTP failures (`useNativeAI.js`), and worker failures (`useWebAI.js`)

Full rationale and 3 divergences from the original proposal are documented on #371.

## Notable fixes bundled in (found while implementing, same class as bugs caught on #359/#370)

- `useNativeAI.js`: `if (data.error) throw new Error(data.error)` inside the streaming SSE loop was nested inside a `catch (_) {}` meant only for `JSON.parse` failures on malformed chunks — the intentional throw was being swallowed and never reached `setError`. Same bug existed in the non-streaming path (masked there since it wasn't nested in a try/catch, but grouped fix for consistency).
- `errors/index.js` imported `getDocUrl` from `registry.js` but never re-exported it.

## Cross-package dependency note (flagging for review, touches Story 4 / API-freeze surface)

This adds a new export, `catalyst-core/errors` (resolves to `dist/errors/index.js`, built by the existing `prepare` script — no new build step). `catalyst-ai` depends on `catalyst-core: ">=0.3.0-0"`, and `route.js` — including the previously-standalone `/providers` endpoint — now resolves this export on every request path.

`packages/catalyst-ai/scripts/check-peer.js` currently only checks that `catalyst-core` resolves at all, not that it's new enough to expose `./errors`. Against an older catalyst-core this would fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` inside the route handler's own catch block, producing a rejection rather than a clean response. Not fixed in this PR (version-gating `check-peer.js` felt like a separate decision) — flagging for maintainer input on whether it should block merge.

## Stack

```
feature/371-catalyst-ai   (this PR)
        ↓
feature/370-webbridge     (#373, → story/6-error-handling, awaiting review)
        ↓
story/6-error-handling
        ↓
main
```

Targets `feature/370-webbridge` since it depends on #370's registry additions, which haven't landed on the story branch yet.
