### PR TITLE
feat(errors): add RUNTIME-WEB-xxx error category and wire handler.jsx SSR catch sites

### DIFF
--- a/errors/AI/AI-000.md
+++ b/errors/AI/AI-000.md
@@ -1,0 +1,19 @@
+# AI-000
+
+**Category:** AI
+
+## Message
+
+AI provider request failed
+
+## Details
+
+This is a wrapper around a non-2xx response or thrown error from the upstream AI provider (OpenAI/Gemini). See the printed upstream status/message for the actual cause — catalyst-ai does not reinterpret it.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Read the upstream provider error printed above and fix the underlying issue (auth, rate limit, invalid request).

--- a/errors/AI/AI-001.md
+++ b/errors/AI/AI-001.md
@@ -1,0 +1,19 @@
+# AI-001
+
+**Category:** AI
+
+## Message
+
+AI is disabled
+
+## Details
+
+AI_CONFIG.enabled is not set to true.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Set AI_CONFIG.enabled=true in your environment configuration.

--- a/errors/AI/AI-002.md
+++ b/errors/AI/AI-002.md
@@ -1,0 +1,19 @@
+# AI-002
+
+**Category:** AI
+
+## Message
+
+AI provider not configured
+
+## Details
+
+The requested provider is unknown, or has no apiKey configured in AI_CONFIG.providers.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Add the provider's apiKey to AI_CONFIG.providers, or use a configured provider.

--- a/errors/AI/AI-003.md
+++ b/errors/AI/AI-003.md
@@ -1,0 +1,19 @@
+# AI-003
+
+**Category:** AI
+
+## Message
+
+Invalid AI request body
+
+## Details
+
+The request body is missing a non-empty messages array, or no model could be resolved.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Pass a non-empty messages array, and either a model or a provider defaultModel.

--- a/errors/AI/AI-004.md
+++ b/errors/AI/AI-004.md
@@ -1,0 +1,19 @@
+# AI-004
+
+**Category:** AI
+
+## Message
+
+Native AI bridge unavailable
+
+## Details
+
+window.NativeBridge.initAI or window.WebBridge was not found when useNativeAI mounted.
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Update catalyst-core to >=0.2.0, add the native AI module, and call WebBridge.init() before mounting useNativeAI.

--- a/errors/AI/AI-005.md
+++ b/errors/AI/AI-005.md
@@ -1,0 +1,19 @@
+# AI-005
+
+**Category:** AI
+
+## Message
+
+Native AI stream not ready
+
+## Details
+
+generate() was called before the native side reported a ready stream URL (initAI has not fired ON_AI_READY yet).
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Wait for modelReady to become true before calling generate().

--- a/errors/AI/AI-006.md
+++ b/errors/AI/AI-006.md
@@ -1,0 +1,19 @@
+# AI-006
+
+**Category:** AI
+
+## Message
+
+Native AI request failed
+
+## Details
+
+The native AI HTTP endpoint returned a non-ok status or reported an error in its response body.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+See the cause above for the native-reported status/message.

--- a/errors/AI/AI-007.md
+++ b/errors/AI/AI-007.md
@@ -1,0 +1,19 @@
+# AI-007
+
+**Category:** AI
+
+## Message
+
+Native AI reported an error
+
+## Details
+
+The native platform invoked ON_AI_ERROR — a failure during model load, init, or inference on the native side, not an HTTP request made by this JS code.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+See the cause above for the native-reported message.

--- a/errors/AI/AI-008.md
+++ b/errors/AI/AI-008.md
@@ -1,0 +1,19 @@
+# AI-008
+
+**Category:** AI
+
+## Message
+
+Web AI worker unavailable
+
+## Details
+
+Constructing the module Worker for in-browser AI failed — module workers may be unsupported in this browser.
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Use a browser with module Worker support, or fall back to useCloudAI/useNativeAI.

--- a/errors/AI/AI-009.md
+++ b/errors/AI/AI-009.md
@@ -1,0 +1,19 @@
+# AI-009
+
+**Category:** AI
+
+## Message
+
+Web AI worker crashed
+
+## Details
+
+The in-browser AI worker threw during model load or generation (e.g. all device backends failed, or an uncaught exception). See the cause above for the worker's reported message.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.

--- a/errors/CCA/CCA-000.md
+++ b/errors/CCA/CCA-000.md
@@ -1,0 +1,19 @@
+# CCA-000
+
+**Category:** CCA
+
+## Message
+
+An upstream command failed
+
+## Details
+
+This wraps an error from npm, tar, or another upstream tool invoked by create-catalyst-app. See the printed upstream message for the actual cause.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Read the upstream error message printed above and fix the underlying issue.

--- a/errors/CCA/CCA-001.md
+++ b/errors/CCA/CCA-001.md
@@ -1,0 +1,19 @@
+# CCA-001
+
+**Category:** CCA
+
+## Message
+
+Invalid project name
+
+## Details
+
+The project name is not a valid npm package name.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Choose a project name that is a valid npm package name and try again.

--- a/errors/CCA/CCA-002.md
+++ b/errors/CCA/CCA-002.md
@@ -1,0 +1,19 @@
+# CCA-002
+
+**Category:** CCA
+
+## Message
+
+Target directory already exists
+
+## Details
+
+A file or directory with the project name already exists in the current directory.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Choose a different project name, or remove/rename the existing directory.

--- a/errors/CCA/CCA-003.md
+++ b/errors/CCA/CCA-003.md
@@ -1,0 +1,19 @@
+# CCA-003
+
+**Category:** CCA
+
+## Message
+
+Invalid language option
+
+## Details
+
+The --lang option must be "js" or "ts".
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Pass --lang js or --lang ts.

--- a/errors/CCA/CCA-004.md
+++ b/errors/CCA/CCA-004.md
@@ -1,0 +1,19 @@
+# CCA-004
+
+**Category:** CCA
+
+## Message
+
+Invalid state management option
+
+## Details
+
+The --state-management option must be "rtk", "redux", or "none".
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Pass a supported --state-management value.

--- a/errors/CCA/CCA-005.md
+++ b/errors/CCA/CCA-005.md
@@ -1,0 +1,19 @@
+# CCA-005
+
+**Category:** CCA
+
+## Message
+
+Invalid --yes option
+
+## Details
+
+The -y/--yes flag does not accept a non-boolean value.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Use -y or --yes with no value to accept defaults.

--- a/errors/CCA/CCA-006.md
+++ b/errors/CCA/CCA-006.md
@@ -1,0 +1,19 @@
+# CCA-006
+
+**Category:** CCA
+
+## Message
+
+Failed to pack create-catalyst-app
+
+## Details
+
+npm pack could not produce the tarball used to scaffold the new project.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Check your npm registry access/network connection and try again.

--- a/errors/CCA/CCA-007.md
+++ b/errors/CCA/CCA-007.md
@@ -1,0 +1,19 @@
+# CCA-007
+
+**Category:** CCA
+
+## Message
+
+Failed to extract template files
+
+## Details
+
+The packed tarball could not be extracted into the new project directory.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure the target directory is writable and try again.

--- a/errors/CCA/CCA-008.md
+++ b/errors/CCA/CCA-008.md
@@ -1,0 +1,19 @@
+# CCA-008
+
+**Category:** CCA
+
+## Message
+
+MCP server setup failed
+
+## Details
+
+Downloading, installing, or configuring the MCP server failed.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Check your network connection and re-run `catalyst-mcp` inside the project.

--- a/errors/CCA/CCA-009.md
+++ b/errors/CCA/CCA-009.md
@@ -1,0 +1,19 @@
+# CCA-009
+
+**Category:** CCA
+
+## Message
+
+.gitignore already exists
+
+## Details
+
+The scaffolded project already contains a .gitignore file.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Remove or rename the existing .gitignore before running again, or ignore this warning.

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-018.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-018.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-018
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Invalid callback interface
+
+## Details
+
+The native platform invoked WebBridge.callback() with an interface name that isn't recognized.
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Check the interface name against the registered NATIVE_CALLBACKS list; this usually indicates a native/JS version mismatch.

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-019.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-019.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-019
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+No handler registered for this bridge interface
+
+## Details
+
+The native platform called back on an interface that has no JS-side handler registered yet.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Ensure WebBridge.register() is called for this interface before the native call arrives.

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-020.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-020.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-020
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+A registered bridge callback handler threw
+
+## Details
+
+The JS handler registered for this native callback interface threw an error while processing the callback.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Fix the error thrown inside the registered handler (see the cause above).

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-021.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-021.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-021
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+Invalid bridge callback registration
+
+## Details
+
+WebBridge.register() was called with a non-function callback or an unrecognized interface name.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+Pass a function as the callback and a valid interface name from NATIVE_CALLBACKS.

--- a/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-022.md
+++ b/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-022.md
@@ -1,0 +1,19 @@
+# RUNTIME-NATIVE-022
+
+**Category:** RUNTIME-NATIVE
+
+## Message
+
+WebBridge could not be initialized
+
+## Details
+
+WebBridge.init() was called outside a browser environment (no `window` available).
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+Call WebBridge.init() in a browser environment, before using bridge features.

--- a/errors/RUNTIME-WEB/RUNTIME-WEB-001.md
+++ b/errors/RUNTIME-WEB/RUNTIME-WEB-001.md
@@ -1,0 +1,19 @@
+# RUNTIME-WEB-001
+
+**Category:** RUNTIME-WEB
+
+## Message
+
+Rendering failed on the server
+
+## Details
+
+An error was thrown while streaming or rendering the document on the server. This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+See the cause above for the error thrown during rendering.

--- a/errors/RUNTIME-WEB/RUNTIME-WEB-002.md
+++ b/errors/RUNTIME-WEB/RUNTIME-WEB-002.md
@@ -1,0 +1,19 @@
+# RUNTIME-WEB-002
+
+**Category:** RUNTIME-WEB
+
+## Message
+
+serverFetcher failed
+
+## Details
+
+An error was thrown while executing a route's serverFetcher function(s). This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+See the cause above for the error thrown inside serverFetcher.

--- a/errors/RUNTIME-WEB/RUNTIME-WEB-003.md
+++ b/errors/RUNTIME-WEB/RUNTIME-WEB-003.md
@@ -1,0 +1,19 @@
+# RUNTIME-WEB-003
+
+**Category:** RUNTIME-WEB
+
+## Message
+
+App.serverSideFunction failed
+
+## Details
+
+An error was thrown while executing the app-level serverSideFunction hook. This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.
+
+## Recoverable
+
+Yes — you can fix this and retry without restarting your workflow.
+
+## Suggested action
+
+See the cause above for the error thrown inside serverSideFunction.

--- a/errors/RUNTIME-WEB/RUNTIME-WEB-004.md
+++ b/errors/RUNTIME-WEB/RUNTIME-WEB-004.md
@@ -1,0 +1,19 @@
+# RUNTIME-WEB-004
+
+**Category:** RUNTIME-WEB
+
+## Message
+
+Failed to handle document request
+
+## Details
+
+An unhandled error reached the top level of the SSR request handler. This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.
+
+## Recoverable
+
+No — this typically requires investigating the underlying cause.
+
+## Suggested action
+
+See the cause above for the underlying error.

--- a/errors/index.json
+++ b/errors/index.json
@@ -462,5 +462,85 @@
         "recoverable": true,
         "suggestedAction": "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
         "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-009.md"
+    },
+    "CCA-000": {
+        "category": "CCA",
+        "message": "An upstream command failed",
+        "details": "This wraps an error from npm, tar, or another upstream tool invoked by create-catalyst-app. See the printed upstream message for the actual cause.",
+        "recoverable": true,
+        "suggestedAction": "Read the upstream error message printed above and fix the underlying issue.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-000.md"
+    },
+    "CCA-001": {
+        "category": "CCA",
+        "message": "Invalid project name",
+        "details": "The project name is not a valid npm package name.",
+        "recoverable": true,
+        "suggestedAction": "Choose a project name that is a valid npm package name and try again.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-001.md"
+    },
+    "CCA-002": {
+        "category": "CCA",
+        "message": "Target directory already exists",
+        "details": "A file or directory with the project name already exists in the current directory.",
+        "recoverable": true,
+        "suggestedAction": "Choose a different project name, or remove/rename the existing directory.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-002.md"
+    },
+    "CCA-003": {
+        "category": "CCA",
+        "message": "Invalid language option",
+        "details": "The --lang option must be \"js\" or \"ts\".",
+        "recoverable": true,
+        "suggestedAction": "Pass --lang js or --lang ts.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-003.md"
+    },
+    "CCA-004": {
+        "category": "CCA",
+        "message": "Invalid state management option",
+        "details": "The --state-management option must be \"rtk\", \"redux\", or \"none\".",
+        "recoverable": true,
+        "suggestedAction": "Pass a supported --state-management value.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-004.md"
+    },
+    "CCA-005": {
+        "category": "CCA",
+        "message": "Invalid --yes option",
+        "details": "The -y/--yes flag does not accept a non-boolean value.",
+        "recoverable": true,
+        "suggestedAction": "Use -y or --yes with no value to accept defaults.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-005.md"
+    },
+    "CCA-006": {
+        "category": "CCA",
+        "message": "Failed to pack create-catalyst-app",
+        "details": "npm pack could not produce the tarball used to scaffold the new project.",
+        "recoverable": true,
+        "suggestedAction": "Check your npm registry access/network connection and try again.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-006.md"
+    },
+    "CCA-007": {
+        "category": "CCA",
+        "message": "Failed to extract template files",
+        "details": "The packed tarball could not be extracted into the new project directory.",
+        "recoverable": true,
+        "suggestedAction": "Ensure the target directory is writable and try again.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-007.md"
+    },
+    "CCA-008": {
+        "category": "CCA",
+        "message": "MCP server setup failed",
+        "details": "Downloading, installing, or configuring the MCP server failed.",
+        "recoverable": true,
+        "suggestedAction": "Check your network connection and re-run `catalyst-mcp` inside the project.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-008.md"
+    },
+    "CCA-009": {
+        "category": "CCA",
+        "message": ".gitignore already exists",
+        "details": "The scaffolded project already contains a .gitignore file.",
+        "recoverable": true,
+        "suggestedAction": "Remove or rename the existing .gitignore before running again, or ignore this warning.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-009.md"
     }
 }

--- a/errors/index.json
+++ b/errors/index.json
@@ -382,5 +382,85 @@
         "recoverable": false,
         "suggestedAction": "Call WebBridge.init() in a browser environment, before using bridge features.",
         "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-022.md"
+    },
+    "AI-000": {
+        "category": "AI",
+        "message": "AI provider request failed",
+        "details": "This is a wrapper around a non-2xx response or thrown error from the upstream AI provider (OpenAI/Gemini). See the printed upstream status/message for the actual cause — catalyst-ai does not reinterpret it.",
+        "recoverable": true,
+        "suggestedAction": "Read the upstream provider error printed above and fix the underlying issue (auth, rate limit, invalid request).",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-000.md"
+    },
+    "AI-001": {
+        "category": "AI",
+        "message": "AI is disabled",
+        "details": "AI_CONFIG.enabled is not set to true.",
+        "recoverable": true,
+        "suggestedAction": "Set AI_CONFIG.enabled=true in your environment configuration.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-001.md"
+    },
+    "AI-002": {
+        "category": "AI",
+        "message": "AI provider not configured",
+        "details": "The requested provider is unknown, or has no apiKey configured in AI_CONFIG.providers.",
+        "recoverable": true,
+        "suggestedAction": "Add the provider's apiKey to AI_CONFIG.providers, or use a configured provider.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-002.md"
+    },
+    "AI-003": {
+        "category": "AI",
+        "message": "Invalid AI request body",
+        "details": "The request body is missing a non-empty messages array, or no model could be resolved.",
+        "recoverable": true,
+        "suggestedAction": "Pass a non-empty messages array, and either a model or a provider defaultModel.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-003.md"
+    },
+    "AI-004": {
+        "category": "AI",
+        "message": "Native AI bridge unavailable",
+        "details": "window.NativeBridge.initAI or window.WebBridge was not found when useNativeAI mounted.",
+        "recoverable": false,
+        "suggestedAction": "Update catalyst-core to >=0.2.0, add the native AI module, and call WebBridge.init() before mounting useNativeAI.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-004.md"
+    },
+    "AI-005": {
+        "category": "AI",
+        "message": "Native AI stream not ready",
+        "details": "generate() was called before the native side reported a ready stream URL (initAI has not fired ON_AI_READY yet).",
+        "recoverable": true,
+        "suggestedAction": "Wait for modelReady to become true before calling generate().",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-005.md"
+    },
+    "AI-006": {
+        "category": "AI",
+        "message": "Native AI request failed",
+        "details": "The native AI HTTP endpoint returned a non-ok status or reported an error in its response body.",
+        "recoverable": true,
+        "suggestedAction": "See the cause above for the native-reported status/message.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-006.md"
+    },
+    "AI-007": {
+        "category": "AI",
+        "message": "Native AI reported an error",
+        "details": "The native platform invoked ON_AI_ERROR — a failure during model load, init, or inference on the native side, not an HTTP request made by this JS code.",
+        "recoverable": true,
+        "suggestedAction": "See the cause above for the native-reported message.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-007.md"
+    },
+    "AI-008": {
+        "category": "AI",
+        "message": "Web AI worker unavailable",
+        "details": "Constructing the module Worker for in-browser AI failed — module workers may be unsupported in this browser.",
+        "recoverable": false,
+        "suggestedAction": "Use a browser with module Worker support, or fall back to useCloudAI/useNativeAI.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-008.md"
+    },
+    "AI-009": {
+        "category": "AI",
+        "message": "Web AI worker crashed",
+        "details": "The in-browser AI worker threw during model load or generation (e.g. all device backends failed, or an uncaught exception). See the cause above for the worker's reported message.",
+        "recoverable": true,
+        "suggestedAction": "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-009.md"
     }
 }

--- a/errors/index.json
+++ b/errors/index.json
@@ -1,4 +1,84 @@
 {
+    "CCA-000": {
+        "category": "CCA",
+        "message": "An upstream command failed",
+        "details": "This wraps an error from npm, tar, or another upstream tool invoked by create-catalyst-app. See the printed upstream message for the actual cause.",
+        "recoverable": true,
+        "suggestedAction": "Read the upstream error message printed above and fix the underlying issue.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-000.md"
+    },
+    "CCA-001": {
+        "category": "CCA",
+        "message": "Invalid project name",
+        "details": "The project name is not a valid npm package name.",
+        "recoverable": true,
+        "suggestedAction": "Choose a project name that is a valid npm package name and try again.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-001.md"
+    },
+    "CCA-002": {
+        "category": "CCA",
+        "message": "Target directory already exists",
+        "details": "A file or directory with the project name already exists in the current directory.",
+        "recoverable": true,
+        "suggestedAction": "Choose a different project name, or remove/rename the existing directory.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-002.md"
+    },
+    "CCA-003": {
+        "category": "CCA",
+        "message": "Invalid language option",
+        "details": "The --lang option must be \"js\" or \"ts\".",
+        "recoverable": true,
+        "suggestedAction": "Pass --lang js or --lang ts.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-003.md"
+    },
+    "CCA-004": {
+        "category": "CCA",
+        "message": "Invalid state management option",
+        "details": "The --state-management option must be \"rtk\", \"redux\", or \"none\".",
+        "recoverable": true,
+        "suggestedAction": "Pass a supported --state-management value.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-004.md"
+    },
+    "CCA-005": {
+        "category": "CCA",
+        "message": "Invalid --yes option",
+        "details": "The -y/--yes flag does not accept a non-boolean value.",
+        "recoverable": true,
+        "suggestedAction": "Use -y or --yes with no value to accept defaults.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-005.md"
+    },
+    "CCA-006": {
+        "category": "CCA",
+        "message": "Failed to pack create-catalyst-app",
+        "details": "npm pack could not produce the tarball used to scaffold the new project.",
+        "recoverable": true,
+        "suggestedAction": "Check your npm registry access/network connection and try again.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-006.md"
+    },
+    "CCA-007": {
+        "category": "CCA",
+        "message": "Failed to extract template files",
+        "details": "The packed tarball could not be extracted into the new project directory.",
+        "recoverable": true,
+        "suggestedAction": "Ensure the target directory is writable and try again.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-007.md"
+    },
+    "CCA-008": {
+        "category": "CCA",
+        "message": "MCP server setup failed",
+        "details": "Downloading, installing, or configuring the MCP server failed.",
+        "recoverable": true,
+        "suggestedAction": "Check your network connection and re-run `catalyst-mcp` inside the project.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-008.md"
+    },
+    "CCA-009": {
+        "category": "CCA",
+        "message": ".gitignore already exists",
+        "details": "The scaffolded project already contains a .gitignore file.",
+        "recoverable": true,
+        "suggestedAction": "Remove or rename the existing .gitignore before running again, or ignore this warning.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-009.md"
+    },
     "PREFLIGHT-001": {
         "category": "PREFLIGHT",
         "message": "config not found in config folder",
@@ -462,85 +542,5 @@
         "recoverable": true,
         "suggestedAction": "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
         "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-009.md"
-    },
-    "CCA-000": {
-        "category": "CCA",
-        "message": "An upstream command failed",
-        "details": "This wraps an error from npm, tar, or another upstream tool invoked by create-catalyst-app. See the printed upstream message for the actual cause.",
-        "recoverable": true,
-        "suggestedAction": "Read the upstream error message printed above and fix the underlying issue.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-000.md"
-    },
-    "CCA-001": {
-        "category": "CCA",
-        "message": "Invalid project name",
-        "details": "The project name is not a valid npm package name.",
-        "recoverable": true,
-        "suggestedAction": "Choose a project name that is a valid npm package name and try again.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-001.md"
-    },
-    "CCA-002": {
-        "category": "CCA",
-        "message": "Target directory already exists",
-        "details": "A file or directory with the project name already exists in the current directory.",
-        "recoverable": true,
-        "suggestedAction": "Choose a different project name, or remove/rename the existing directory.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-002.md"
-    },
-    "CCA-003": {
-        "category": "CCA",
-        "message": "Invalid language option",
-        "details": "The --lang option must be \"js\" or \"ts\".",
-        "recoverable": true,
-        "suggestedAction": "Pass --lang js or --lang ts.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-003.md"
-    },
-    "CCA-004": {
-        "category": "CCA",
-        "message": "Invalid state management option",
-        "details": "The --state-management option must be \"rtk\", \"redux\", or \"none\".",
-        "recoverable": true,
-        "suggestedAction": "Pass a supported --state-management value.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-004.md"
-    },
-    "CCA-005": {
-        "category": "CCA",
-        "message": "Invalid --yes option",
-        "details": "The -y/--yes flag does not accept a non-boolean value.",
-        "recoverable": true,
-        "suggestedAction": "Use -y or --yes with no value to accept defaults.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-005.md"
-    },
-    "CCA-006": {
-        "category": "CCA",
-        "message": "Failed to pack create-catalyst-app",
-        "details": "npm pack could not produce the tarball used to scaffold the new project.",
-        "recoverable": true,
-        "suggestedAction": "Check your npm registry access/network connection and try again.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-006.md"
-    },
-    "CCA-007": {
-        "category": "CCA",
-        "message": "Failed to extract template files",
-        "details": "The packed tarball could not be extracted into the new project directory.",
-        "recoverable": true,
-        "suggestedAction": "Ensure the target directory is writable and try again.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-007.md"
-    },
-    "CCA-008": {
-        "category": "CCA",
-        "message": "MCP server setup failed",
-        "details": "Downloading, installing, or configuring the MCP server failed.",
-        "recoverable": true,
-        "suggestedAction": "Check your network connection and re-run `catalyst-mcp` inside the project.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-008.md"
-    },
-    "CCA-009": {
-        "category": "CCA",
-        "message": ".gitignore already exists",
-        "details": "The scaffolded project already contains a .gitignore file.",
-        "recoverable": true,
-        "suggestedAction": "Remove or rename the existing .gitignore before running again, or ignore this warning.",
-        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/CCA/CCA-009.md"
     }
 }

--- a/errors/index.json
+++ b/errors/index.json
@@ -342,5 +342,45 @@
         "recoverable": true,
         "suggestedAction": "Close other camera apps and try again",
         "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-017.md"
+    },
+    "RUNTIME-NATIVE-018": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Invalid callback interface",
+        "details": "The native platform invoked WebBridge.callback() with an interface name that isn't recognized.",
+        "recoverable": false,
+        "suggestedAction": "Check the interface name against the registered NATIVE_CALLBACKS list; this usually indicates a native/JS version mismatch.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-018.md"
+    },
+    "RUNTIME-NATIVE-019": {
+        "category": "RUNTIME-NATIVE",
+        "message": "No handler registered for this bridge interface",
+        "details": "The native platform called back on an interface that has no JS-side handler registered yet.",
+        "recoverable": true,
+        "suggestedAction": "Ensure WebBridge.register() is called for this interface before the native call arrives.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-019.md"
+    },
+    "RUNTIME-NATIVE-020": {
+        "category": "RUNTIME-NATIVE",
+        "message": "A registered bridge callback handler threw",
+        "details": "The JS handler registered for this native callback interface threw an error while processing the callback.",
+        "recoverable": true,
+        "suggestedAction": "Fix the error thrown inside the registered handler (see the cause above).",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-020.md"
+    },
+    "RUNTIME-NATIVE-021": {
+        "category": "RUNTIME-NATIVE",
+        "message": "Invalid bridge callback registration",
+        "details": "WebBridge.register() was called with a non-function callback or an unrecognized interface name.",
+        "recoverable": true,
+        "suggestedAction": "Pass a function as the callback and a valid interface name from NATIVE_CALLBACKS.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-021.md"
+    },
+    "RUNTIME-NATIVE-022": {
+        "category": "RUNTIME-NATIVE",
+        "message": "WebBridge could not be initialized",
+        "details": "WebBridge.init() was called outside a browser environment (no `window` available).",
+        "recoverable": false,
+        "suggestedAction": "Call WebBridge.init() in a browser environment, before using bridge features.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-NATIVE/RUNTIME-NATIVE-022.md"
     }
 }

--- a/packages/catalyst-ai/src/route.js
+++ b/packages/catalyst-ai/src/route.js
@@ -2,6 +2,14 @@ const express = require("express")
 
 const router = express.Router()
 
+// catalyst-core/errors is ESM-only; route.js stays CJS (loaded via require.resolve
+// in expressServer.js), so we load it lazily via dynamic import and cache the module.
+let errorsModulePromise = null
+function loadErrors() {
+    if (!errorsModulePromise) errorsModulePromise = import("catalyst-core/errors")
+    return errorsModulePromise
+}
+
 // Hard ceiling on how long a single /stream request may run upstream — protects
 // against a hung provider connection holding a request open indefinitely.
 const STREAM_TIMEOUT_MS = 120_000
@@ -50,6 +58,13 @@ function sseHeaders(res) {
     res.setHeader("Connection", "keep-alive")
     res.setHeader("X-Accel-Buffering", "no")
     res.flushHeaders()
+}
+
+// Wraps a non-ok provider response as a CatalystError (AI-000) and throws it,
+// preserving the upstream status/body verbatim as `cause`.
+async function throwProviderError(provider, response) {
+    const { wrapProviderError } = await loadErrors()
+    throw wrapProviderError(provider, response.status, await response.text())
 }
 
 // ─── usage normalization ──────────────────────────────────────────────────────
@@ -134,7 +149,7 @@ async function openaiStream({ apiKey, model, messages, genConfig, conversationId
             body: JSON.stringify(body),
             signal,
         })
-        if (!response.ok) throw new Error(`OpenAI Responses API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("openai", response)
 
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
@@ -187,7 +202,7 @@ async function openaiStream({ apiKey, model, messages, genConfig, conversationId
             body: JSON.stringify(body),
             signal,
         })
-        if (!response.ok) throw new Error(`OpenAI API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("openai", response)
 
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
@@ -238,7 +253,7 @@ async function openaiGenerate({ apiKey, model, messages, genConfig, conversation
             headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
             body: JSON.stringify(body),
         })
-        if (!response.ok) throw new Error(`OpenAI Responses API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("openai", response)
         const data = await response.json()
         const output = data.output?.find((o) => o.type === "message")?.content?.find((c) => c.type === "output_text")?.text ?? ""
         return { output, conversationId: data.id ?? null, usage: normalizeOpenAIResponsesUsage(data.usage, model) }
@@ -257,7 +272,7 @@ async function openaiGenerate({ apiKey, model, messages, genConfig, conversation
             headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
             body: JSON.stringify(body),
         })
-        if (!response.ok) throw new Error(`OpenAI API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("openai", response)
         const data = await response.json()
         return { output: data.choices?.[0]?.message?.content ?? "", conversationId: null, usage: normalizeOpenAIChatUsage(data.usage, model) }
     }
@@ -309,7 +324,7 @@ async function geminiStream({ apiKey, model, messages, genConfig, conversationId
             body: JSON.stringify(body),
             signal,
         })
-        if (!response.ok) throw new Error(`Gemini Interactions API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("gemini", response)
 
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
@@ -361,7 +376,7 @@ async function geminiStream({ apiKey, model, messages, genConfig, conversationId
             body: JSON.stringify(body),
             signal,
         })
-        if (!response.ok) throw new Error(`Gemini API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("gemini", response)
 
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
@@ -418,7 +433,7 @@ async function geminiGenerate({ apiKey, model, messages, genConfig, conversation
             headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
             body: JSON.stringify(body),
         })
-        if (!response.ok) throw new Error(`Gemini Interactions API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("gemini", response)
         const data = await response.json()
         const text = data.steps?.find((s) => s.type === "model_output")?.content?.[0]?.text ?? ""
         return { output: text, conversationId: data.id ?? null, usage: normalizeGeminiInteractionUsage(data.usage, model) }
@@ -441,7 +456,7 @@ async function geminiGenerate({ apiKey, model, messages, genConfig, conversation
             headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
             body: JSON.stringify(body),
         })
-        if (!response.ok) throw new Error(`Gemini API error (${response.status}): ${await response.text()}`)
+        if (!response.ok) await throwProviderError("gemini", response)
         const data = await response.json()
         return { output: data.candidates?.[0]?.content?.parts?.[0]?.text ?? "", conversationId: null, usage: normalizeGeminiUsage(data.usageMetadata, model) }
     }
@@ -456,9 +471,20 @@ const PROVIDERS = {
 
 // ─── routes ───────────────────────────────────────────────────────────────────
 
+// Additive `code` field alongside the existing `{ error }` shape — does not
+// change the response contract, just gives clients an AI-xxx code to look up.
+async function sendCodedError(res, status, code, message) {
+    const { getDocUrl } = await loadErrors()
+    res.status(status).json({ error: message, code, docUrl: getDocUrl(code) })
+}
+
 // GET /ai/providers — returns list of configured provider ids, no keys exposed
-router.get("/providers", (req, res) => {
-    if (!isAIEnabled()) { res.status(403).json({ error: "AI is disabled. Set AI_CONFIG.enabled=true to enable." }); return }
+router.get("/providers", async (req, res) => {
+    if (!isAIEnabled()) {
+        const { ERROR_CODES } = await loadErrors()
+        await sendCodedError(res, 403, ERROR_CODES.AI_DISABLED, "AI is disabled. Set AI_CONFIG.enabled=true to enable.")
+        return
+    }
     const providers = Object.entries(getAIConfig()?.providers ?? {})
         .filter(([, cfg]) => cfg?.apiKey)
         .map(([id, cfg]) => ({ id, defaultModel: cfg.defaultModel ?? null }))
@@ -466,16 +492,26 @@ router.get("/providers", (req, res) => {
 })
 
 router.post("/:provider/stream", async (req, res) => {
-    if (!isAIEnabled()) { res.status(403).json({ error: "AI is disabled. Set AI_CONFIG.enabled=true to enable." }); return }
+    const { ERROR_CODES } = await loadErrors()
+    if (!isAIEnabled()) {
+        await sendCodedError(res, 403, ERROR_CODES.AI_DISABLED, "AI is disabled. Set AI_CONFIG.enabled=true to enable.")
+        return
+    }
     const { provider } = req.params
     const adapter = PROVIDERS[provider]
     if (!adapter) { res.status(404).json({ error: `Unknown provider: ${provider}` }); return }
 
     const cfg = getProviderConfig(provider)
-    if (!cfg) { res.status(404).json({ error: `Provider "${provider}" not configured` }); return }
+    if (!cfg) {
+        await sendCodedError(res, 404, ERROR_CODES.AI_PROVIDER_NOT_CONFIGURED, `Provider "${provider}" not configured`)
+        return
+    }
 
     const validationError = validateRequestBody(req, cfg)
-    if (validationError) { res.status(400).json({ error: validationError }); return }
+    if (validationError) {
+        await sendCodedError(res, 400, ERROR_CODES.AI_INVALID_REQUEST_BODY, validationError)
+        return
+    }
 
     const { messages, genConfig = {}, conversationId, model } = req.body
     const stateful = "conversationId" in req.body
@@ -503,9 +539,15 @@ router.post("/:provider/stream", async (req, res) => {
             signal: abortController.signal,
         })
     } catch (err) {
-        console.error("[catalyst-ai] %s stream error:", provider, err.message)
+        // err.code is only an AI-xxx string when err is a CatalystError. On the
+        // client-disconnect path (res "close" -> abortController.abort()) fetch
+        // rejects with a DOMException whose .code is the numeric legacy value 20 —
+        // attaching that as `code` would be a bogus registry lookup for callers.
+        const { CatalystError } = await loadErrors()
+        const code = err instanceof CatalystError ? err.code : undefined
+        console.error("[catalyst-ai] %s stream error:", provider, code ? `[${code}] ${err.message}` : err.message)
         if (!res.writableEnded) {
-            res.write(`data: ${JSON.stringify({ error: err.message })}\n\n`)
+            res.write(`data: ${JSON.stringify({ error: err.message, code })}\n\n`)
             res.end()
         }
     } finally {
@@ -514,16 +556,26 @@ router.post("/:provider/stream", async (req, res) => {
 })
 
 router.post("/:provider/generate", async (req, res) => {
-    if (!isAIEnabled()) { res.status(403).json({ error: "AI is disabled. Set AI_CONFIG.enabled=true to enable." }); return }
+    const { ERROR_CODES } = await loadErrors()
+    if (!isAIEnabled()) {
+        await sendCodedError(res, 403, ERROR_CODES.AI_DISABLED, "AI is disabled. Set AI_CONFIG.enabled=true to enable.")
+        return
+    }
     const { provider } = req.params
     const adapter = PROVIDERS[provider]
     if (!adapter) { res.status(404).json({ error: `Unknown provider: ${provider}` }); return }
 
     const cfg = getProviderConfig(provider)
-    if (!cfg) { res.status(404).json({ error: `Provider "${provider}" not configured` }); return }
+    if (!cfg) {
+        await sendCodedError(res, 404, ERROR_CODES.AI_PROVIDER_NOT_CONFIGURED, `Provider "${provider}" not configured`)
+        return
+    }
 
     const validationError = validateRequestBody(req, cfg)
-    if (validationError) { res.status(400).json({ error: validationError }); return }
+    if (validationError) {
+        await sendCodedError(res, 400, ERROR_CODES.AI_INVALID_REQUEST_BODY, validationError)
+        return
+    }
 
     const { messages, genConfig = {}, conversationId, model } = req.body
     const stateful = "conversationId" in req.body
@@ -534,8 +586,10 @@ router.post("/:provider/generate", async (req, res) => {
         const result = await adapter.generate({ apiKey: cfg.apiKey, model: resolvedModel, messages, genConfig, conversationId, stateful })
         res.json({ ...result, model: resolvedModel })
     } catch (err) {
-        console.error("[catalyst-ai] %s generate error:", provider, err.message)
-        res.status(500).json({ error: err.message })
+        const { CatalystError } = await loadErrors()
+        const code = err instanceof CatalystError ? err.code : undefined
+        console.error("[catalyst-ai] %s generate error:", provider, code ? `[${code}] ${err.message}` : err.message)
+        res.status(500).json({ error: err.message, code })
     }
 })
 

--- a/packages/catalyst-ai/src/useNativeAI.js
+++ b/packages/catalyst-ai/src/useNativeAI.js
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from "react"
 import { aggregateNativeSessionMetrics } from "./metrics.js"
+import { ERROR_CODES, createError } from "catalyst-core/errors"
 
 const ATTACHMENT_TAG_RE = /<tool:create_attachment\s+component='([^']+)'([^>]*)>([\s\S]*?)<\/tool:create_attachment>/g
 
@@ -57,14 +58,15 @@ export function useNativeAI({
         if (!enabled) return
 
         if (!window.NativeBridge?.initAI) {
-            setError(new Error(
-                "[catalyst-ai/useNativeAI] window.NativeBridge.initAI not found. " +
-                "Update catalyst-core to >=0.2.0 and add the android module to settings.gradle.kts."
-            ))
+            setError(createError(ERROR_CODES.AI_NATIVE_BRIDGE_UNAVAILABLE, {
+                message: "window.NativeBridge.initAI not found. Update catalyst-core to >=0.2.0 and add the android module to settings.gradle.kts.",
+            }))
             return
         }
         if (!window.WebBridge) {
-            setError(new Error("[catalyst-ai/useNativeAI] WebBridge not initialized — call WebBridge.init() before mounting useNativeAI"))
+            setError(createError(ERROR_CODES.AI_NATIVE_BRIDGE_UNAVAILABLE, {
+                message: "WebBridge not initialized — call WebBridge.init() before mounting useNativeAI.",
+            }))
             return
         }
 
@@ -76,14 +78,21 @@ export function useNativeAI({
                     setModelReady(true)
                     setNativeDownloadProgress(null)
                 }
-            } catch (_) {}
+            } catch (_) {
+                // Deliberately silent: a malformed ON_AI_READY payload just means this
+                // ready signal is skipped, not a user-facing failure — the native side
+                // will fire again or the missing modelReady state will surface on its own.
+            }
         }
 
         const onProgress = (data) => {
             try {
                 const parsed = typeof data === "string" ? JSON.parse(data) : data
                 setNativeDownloadProgress(parsed)
-            } catch (_) {}
+            } catch (_) {
+                // Deliberately silent: a malformed progress payload just means this
+                // progress tick is skipped, not a user-facing failure.
+            }
         }
 
         const onLog = (data) => {
@@ -91,17 +100,21 @@ export function useNativeAI({
                 const parsed = typeof data === "string" ? JSON.parse(data) : data
                 const msg = parsed?.message ?? String(data)
                 setNativeLogs((prev) => [...prev.slice(-99), msg])
-            } catch (_) {}
+            } catch (_) {
+                // Deliberately silent: a malformed log payload just means this
+                // log line is skipped, not a user-facing failure.
+            }
         }
 
         const onError = (data) => {
+            let msg
             try {
                 const parsed = typeof data === "string" ? JSON.parse(data) : data
-                const msg = parsed?.message ?? String(data)
-                setError(new Error(msg))
+                msg = parsed?.message ?? String(data)
             } catch (_) {
-                setError(new Error(String(data)))
+                msg = String(data)
             }
+            setError(createError(ERROR_CODES.AI_NATIVE_CALLBACK_ERROR, { message: msg }))
         }
 
         window.WebBridge.register(NATIVE_CALLBACKS.ON_AI_READY, onReady)
@@ -122,7 +135,7 @@ export function useNativeAI({
         async ({ messages, genConfig: callGenConfig = {} }) => {
             const url = nativeStreamUrlRef.current
             if (!url) {
-                setError(new Error("[catalyst-ai/useNativeAI] stream URL not ready — did initAI fire?"))
+                setError(createError(ERROR_CODES.AI_NATIVE_STREAM_NOT_READY))
                 return
             }
 
@@ -159,11 +172,17 @@ export function useNativeAI({
                         signal: controller.signal,
                     })
 
-                    if (!response.ok) throw new Error(`Native AI HTTP error: ${response.status}`)
+                    if (!response.ok) {
+                        throw createError(ERROR_CODES.AI_NATIVE_REQUEST_FAILED, {
+                            message: `Native AI HTTP error: ${response.status}`,
+                        })
+                    }
                     setLoading(false)
 
                     const data = await response.json()
-                    if (data.error) throw new Error(data.error)
+                    if (data.error) {
+                        throw createError(ERROR_CODES.AI_NATIVE_REQUEST_FAILED, { message: data.error })
+                    }
 
                     if (sessionMode === "stateful" && data.conversationId) {
                         conversationIdRef.current = data.conversationId
@@ -185,7 +204,11 @@ export function useNativeAI({
                     signal: controller.signal,
                 })
 
-                if (!response.ok) throw new Error(`Native AI HTTP error: ${response.status}`)
+                if (!response.ok) {
+                    throw createError(ERROR_CODES.AI_NATIVE_REQUEST_FAILED, {
+                        message: `Native AI HTTP error: ${response.status}`,
+                    })
+                }
 
                 setLoading(false)
                 setStreaming(true)
@@ -203,35 +226,43 @@ export function useNativeAI({
                         buffer = lines.pop() || ""
                         for (const line of lines) {
                             if (!line.startsWith("data: ")) continue
+                            // JSON.parse failure means a malformed/partial SSE chunk — skip it.
+                            // A parsed data.error is a real signal and must propagate to the
+                            // outer catch, not be swallowed here alongside parse failures.
+                            let data
                             try {
-                                const data = JSON.parse(line.slice(6))
-                                if (data.done) {
-                                    setStreaming(false)
-                                    const genMs = Math.round(performance.now() - t0)
-                                    const tps = tokenCount > 0 ? parseFloat((tokenCount / (genMs / 1000)).toFixed(1)) : 0
-                                    const streamMetrics = { device: "native", ttftMs, tps, totalTokens: tokenCount, genMs }
-                                    setMetrics(streamMetrics)
-                                    historyRef.current.push(streamMetrics)
-                                    return
+                                data = JSON.parse(line.slice(6))
+                            } catch (_) {
+                                continue
+                            }
+                            if (data.done) {
+                                setStreaming(false)
+                                const genMs = Math.round(performance.now() - t0)
+                                const tps = tokenCount > 0 ? parseFloat((tokenCount / (genMs / 1000)).toFixed(1)) : 0
+                                const streamMetrics = { device: "native", ttftMs, tps, totalTokens: tokenCount, genMs }
+                                setMetrics(streamMetrics)
+                                historyRef.current.push(streamMetrics)
+                                return
+                            }
+                            if (sessionMode === "stateful" && data.conversationId) {
+                                conversationIdRef.current = data.conversationId
+                            }
+                            if (typeof data.token === "string") {
+                                if (ttftMs === null) ttftMs = Math.round(performance.now() - t0)
+                                tokenCount++
+                                outputAccRef.current += data.token
+                                outputAccRef.current = outputAccRef.current.replace(ATTACHMENT_TAG_RE, parseAttachmentTag)
+                                if (!rafRef.current) {
+                                    const schedule = typeof requestAnimationFrame !== "undefined" ? requestAnimationFrame : (fn) => setTimeout(fn, 16)
+                                    rafRef.current = schedule(() => {
+                                        rafRef.current = null
+                                        setOutput(outputAccRef.current)
+                                    })
                                 }
-                                if (sessionMode === "stateful" && data.conversationId) {
-                                    conversationIdRef.current = data.conversationId
-                                }
-                                if (typeof data.token === "string") {
-                                    if (ttftMs === null) ttftMs = Math.round(performance.now() - t0)
-                                    tokenCount++
-                                    outputAccRef.current += data.token
-                                    outputAccRef.current = outputAccRef.current.replace(ATTACHMENT_TAG_RE, parseAttachmentTag)
-                                    if (!rafRef.current) {
-                                        const schedule = typeof requestAnimationFrame !== "undefined" ? requestAnimationFrame : (fn) => setTimeout(fn, 16)
-                                        rafRef.current = schedule(() => {
-                                            rafRef.current = null
-                                            setOutput(outputAccRef.current)
-                                        })
-                                    }
-                                }
-                                if (data.error) throw new Error(data.error)
-                            } catch (_) {}
+                            }
+                            if (data.error) {
+                                throw createError(ERROR_CODES.AI_NATIVE_REQUEST_FAILED, { message: data.error })
+                            }
                         }
                     }
                 } finally {

--- a/packages/catalyst-ai/src/useWebAI.js
+++ b/packages/catalyst-ai/src/useWebAI.js
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from "react"
 import { aggregateWebSessionMetrics } from "./metrics.js"
+import { ERROR_CODES, createError } from "catalyst-core/errors"
 
 const schedule = typeof requestAnimationFrame !== "undefined" ? requestAnimationFrame : (fn) => setTimeout(fn, 16)
 const cancelSchedule = typeof cancelAnimationFrame !== "undefined" ? cancelAnimationFrame : clearTimeout
@@ -244,7 +245,10 @@ export function useWebAI({
             try {
                 worker = new Worker(getWorkerBlobUrl(), { type: "module" })
             } catch (err) {
-                setError(new Error("[catalyst-ai/useWebAI] module worker unavailable: " + (err.message || String(err))))
+                setError(createError(ERROR_CODES.AI_WEB_WORKER_UNAVAILABLE, {
+                    message: "Constructing the module Worker failed: " + (err.message || String(err)),
+                    cause: err,
+                }))
                 setLoading(false)
                 return
             }
@@ -309,7 +313,7 @@ export function useWebAI({
                         break
                     case "error":
                         console.error("[catalyst-ai/useWebAI] worker error:", msg.message)
-                        setError(new Error(msg.message))
+                        setError(createError(ERROR_CODES.AI_WEB_WORKER_CRASHED, { message: msg.message }))
                         setStreaming(false)
                         setLoading(false)
                         worker.terminate()
@@ -320,7 +324,10 @@ export function useWebAI({
 
             worker.onerror = (e) => {
                 console.error("[catalyst-ai/useWebAI] worker uncaught error:", e)
-                setError(new Error(e.message || "Worker crashed"))
+                setError(createError(ERROR_CODES.AI_WEB_WORKER_CRASHED, {
+                    message: e.message || "Worker crashed",
+                    cause: e,
+                }))
                 setStreaming(false)
                 setLoading(false)
                 worker.terminate()

--- a/packages/catalyst-core/package.json
+++ b/packages/catalyst-core/package.json
@@ -24,6 +24,7 @@
         "./document": "./dist/server/renderer/document/index.jsx",
         "./WebBridge": "./dist/native/bridge/WebBridge.js",
         "./hooks": "./dist/native/bridge/hooks.js",
+        "./errors": "./dist/errors/index.js",
         "./sentry": "./dist/sentry.cjs",
         "./otel": "./dist/otel.js"
     },

--- a/packages/catalyst-core/src/errors/generateDocs.js
+++ b/packages/catalyst-core/src/errors/generateDocs.js
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync, readdirSync, rmSync, existsSync } from "fs"
+import { mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync, existsSync } from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
 import { ERROR_DEFINITIONS } from "./registry.js"
@@ -8,6 +8,7 @@ const __dirname = path.dirname(__filename)
 
 // packages/catalyst-core/src/errors -> repo root /errors
 const ERRORS_DIR = path.resolve(__dirname, "../../../../errors")
+const INDEX_PATH = path.join(ERRORS_DIR, "index.json")
 
 function renderMarkdown(code, def) {
     return `# ${code}
@@ -45,10 +46,27 @@ function clearGeneratedCategoryDirs() {
     }
 }
 
+// Other packages (e.g. create-catalyst-app) own their own categories and
+// merge their entries into this same index.json. Only clear/overwrite keys
+// for categories this registry itself defines, so a regen here never wipes
+// entries owned by another package's generator.
+function readExistingIndex() {
+    if (!existsSync(INDEX_PATH)) return {}
+    try {
+        return JSON.parse(readFileSync(INDEX_PATH, "utf8"))
+    } catch {
+        return {}
+    }
+}
+
 export function generateDocs() {
     clearGeneratedCategoryDirs()
 
-    const index = {}
+    const ownedCategories = new Set(Object.values(ERROR_DEFINITIONS).map((d) => d.category))
+    const index = readExistingIndex()
+    for (const code of Object.keys(index)) {
+        if (ownedCategories.has(index[code].category)) delete index[code]
+    }
 
     for (const [code, def] of Object.entries(ERROR_DEFINITIONS)) {
         const dir = path.join(ERRORS_DIR, def.category)
@@ -67,9 +85,9 @@ export function generateDocs() {
     }
 
     mkdirSync(ERRORS_DIR, { recursive: true })
-    writeFileSync(path.join(ERRORS_DIR, "index.json"), JSON.stringify(index, null, 4))
+    writeFileSync(INDEX_PATH, JSON.stringify(index, null, 4))
 
-    return { count: Object.keys(index).length, errorsDir: ERRORS_DIR }
+    return { count: Object.keys(ERROR_DEFINITIONS).length, errorsDir: ERRORS_DIR }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/catalyst-core/src/errors/index.js
+++ b/packages/catalyst-core/src/errors/index.js
@@ -1,6 +1,6 @@
 import { ERROR_CODES, getDefinition, getDocUrl } from "./registry.js"
 
-export { ERROR_CODES }
+export { ERROR_CODES, getDocUrl }
 
 export class CatalystError extends Error {
     constructor(code, { message, details, recoverable, suggestedAction, category, docUrl, cause } = {}) {
@@ -67,6 +67,22 @@ export function wrapForeignError(stage, err) {
         cause: err,
     })
     return wrapped
+}
+
+/**
+ * Wrap a failed AI provider HTTP response (OpenAI/Gemini). Unlike
+ * wrapForeignError (build toolchains, which carry a named err.code), provider
+ * failures are an HTTP status + response body — we preserve both verbatim
+ * as `cause` rather than reinterpreting them.
+ */
+export function wrapProviderError(provider, status, bodyText) {
+    const cause = new Error(`${provider} API error (${status}): ${bodyText}`)
+    cause.provider = provider
+    cause.status = status
+    return createError(ERROR_CODES.AI_UPSTREAM_ERROR, {
+        message: `AI provider request failed (upstream: ${provider} ${status})`,
+        cause,
+    })
 }
 
 /**

--- a/packages/catalyst-core/src/errors/index.js
+++ b/packages/catalyst-core/src/errors/index.js
@@ -69,6 +69,30 @@ export function wrapForeignError(stage, err) {
     return wrapped
 }
 
+const SSR_STAGE_CODE = {
+    RENDER: ERROR_CODES.RUNTIME_WEB_RENDER_FAILED,
+    FETCHER: ERROR_CODES.RUNTIME_WEB_FETCHER_FAILED,
+    SERVER_SIDE_FUNCTION: ERROR_CODES.RUNTIME_WEB_SERVER_SIDE_FUNCTION_FAILED,
+    REQUEST_HANDLING: ERROR_CODES.RUNTIME_WEB_REQUEST_HANDLING_FAILED,
+}
+
+/**
+ * Wrap an error caught during SSR (handler.jsx). Unlike wrapForeignError's
+ * build-stage wrapping, the caught error here could originate from the
+ * user's app code, a third-party dependency, or catalyst-core's own
+ * pipeline — there is no way to tell from the caught error object which.
+ * So, like the BUNDLE/IOS/ANDROID wrappers, we never reinterpret it: we
+ * attach a stage-specific code that identifies *where* in the SSR pipeline
+ * the failure happened, and preserve the original error as `cause`.
+ */
+export function wrapSSRError(stage, err) {
+    const code = SSR_STAGE_CODE[stage]
+    if (!code) {
+        throw new Error(`wrapSSRError: unknown stage "${stage}"`)
+    }
+    return createError(code, { cause: err })
+}
+
 /**
  * Wrap a failed AI provider HTTP response (OpenAI/Gemini). Unlike
  * wrapForeignError (build toolchains, which carry a named err.code), provider
@@ -88,6 +112,12 @@ export function wrapProviderError(provider, status, bodyText) {
 /**
  * Format a CatalystError for terminal output. Foreign-wrapped errors always
  * show the original upstream message/code, never a paraphrase of it.
+ *
+ * Note: this prints the cause's *message* only, not its stack. Callers
+ * logging a wrapped error to the console (see wrapSSRError call sites in
+ * handler.jsx) should also log `err.cause` itself alongside this output so
+ * the stack trace isn't lost — formatError is for the human-readable
+ * summary, not a replacement for full error inspection.
  */
 export function formatError(err) {
     const lines = [`[${err.code}] ${err.message}`]

--- a/packages/catalyst-core/src/errors/registry.js
+++ b/packages/catalyst-core/src/errors/registry.js
@@ -58,6 +58,11 @@ export const ERROR_CODES = {
     RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION: "RUNTIME-NATIVE-021",
     RUNTIME_NATIVE_BRIDGE_INIT_FAILED: "RUNTIME-NATIVE-022",
 
+    RUNTIME_WEB_RENDER_FAILED: "RUNTIME-WEB-001",
+    RUNTIME_WEB_FETCHER_FAILED: "RUNTIME-WEB-002",
+    RUNTIME_WEB_SERVER_SIDE_FUNCTION_FAILED: "RUNTIME-WEB-003",
+    RUNTIME_WEB_REQUEST_HANDLING_FAILED: "RUNTIME-WEB-004",
+
     AI_UPSTREAM_ERROR: "AI-000",
     AI_DISABLED: "AI-001",
     AI_PROVIDER_NOT_CONFIGURED: "AI-002",
@@ -491,6 +496,39 @@ export const ERROR_DEFINITIONS = {
             "The in-browser AI worker threw during model load or generation (e.g. all device backends failed, or an uncaught exception). See the cause above for the worker's reported message.",
         recoverable: true,
         suggestedAction: "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
+    },
+
+    [ERROR_CODES.RUNTIME_WEB_RENDER_FAILED]: {
+        category: "RUNTIME-WEB",
+        defaultMessage: "Rendering failed on the server",
+        defaultDetails:
+            "An error was thrown while streaming or rendering the document on the server. This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.",
+        recoverable: true,
+        suggestedAction: "See the cause above for the error thrown during rendering.",
+    },
+    [ERROR_CODES.RUNTIME_WEB_FETCHER_FAILED]: {
+        category: "RUNTIME-WEB",
+        defaultMessage: "serverFetcher failed",
+        defaultDetails:
+            "An error was thrown while executing a route's serverFetcher function(s). This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.",
+        recoverable: true,
+        suggestedAction: "See the cause above for the error thrown inside serverFetcher.",
+    },
+    [ERROR_CODES.RUNTIME_WEB_SERVER_SIDE_FUNCTION_FAILED]: {
+        category: "RUNTIME-WEB",
+        defaultMessage: "App.serverSideFunction failed",
+        defaultDetails:
+            "An error was thrown while executing the app-level serverSideFunction hook. This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.",
+        recoverable: true,
+        suggestedAction: "See the cause above for the error thrown inside serverSideFunction.",
+    },
+    [ERROR_CODES.RUNTIME_WEB_REQUEST_HANDLING_FAILED]: {
+        category: "RUNTIME-WEB",
+        defaultMessage: "Failed to handle document request",
+        defaultDetails:
+            "An unhandled error reached the top level of the SSR request handler. This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.",
+        recoverable: false,
+        suggestedAction: "See the cause above for the underlying error.",
     },
 }
 

--- a/packages/catalyst-core/src/errors/registry.js
+++ b/packages/catalyst-core/src/errors/registry.js
@@ -57,6 +57,17 @@ export const ERROR_CODES = {
     RUNTIME_NATIVE_BRIDGE_HANDLER_THREW: "RUNTIME-NATIVE-020",
     RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION: "RUNTIME-NATIVE-021",
     RUNTIME_NATIVE_BRIDGE_INIT_FAILED: "RUNTIME-NATIVE-022",
+
+    AI_UPSTREAM_ERROR: "AI-000",
+    AI_DISABLED: "AI-001",
+    AI_PROVIDER_NOT_CONFIGURED: "AI-002",
+    AI_INVALID_REQUEST_BODY: "AI-003",
+    AI_NATIVE_BRIDGE_UNAVAILABLE: "AI-004",
+    AI_NATIVE_STREAM_NOT_READY: "AI-005",
+    AI_NATIVE_REQUEST_FAILED: "AI-006",
+    AI_NATIVE_CALLBACK_ERROR: "AI-007",
+    AI_WEB_WORKER_UNAVAILABLE: "AI-008",
+    AI_WEB_WORKER_CRASHED: "AI-009",
 }
 
 // One entry per catalyst-owned code. Foreign/wrapped errors (see wrapForeignError)
@@ -406,6 +417,80 @@ export const ERROR_DEFINITIONS = {
         defaultDetails: "WebBridge.init() was called outside a browser environment (no `window` available).",
         recoverable: false,
         suggestedAction: "Call WebBridge.init() in a browser environment, before using bridge features.",
+    },
+
+    [ERROR_CODES.AI_UPSTREAM_ERROR]: {
+        category: "AI",
+        defaultMessage: "AI provider request failed",
+        defaultDetails:
+            "This is a wrapper around a non-2xx response or thrown error from the upstream AI provider (OpenAI/Gemini). See the printed upstream status/message for the actual cause — catalyst-ai does not reinterpret it.",
+        recoverable: true,
+        suggestedAction: "Read the upstream provider error printed above and fix the underlying issue (auth, rate limit, invalid request).",
+    },
+    [ERROR_CODES.AI_DISABLED]: {
+        category: "AI",
+        defaultMessage: "AI is disabled",
+        defaultDetails: "AI_CONFIG.enabled is not set to true.",
+        recoverable: true,
+        suggestedAction: "Set AI_CONFIG.enabled=true in your environment configuration.",
+    },
+    [ERROR_CODES.AI_PROVIDER_NOT_CONFIGURED]: {
+        category: "AI",
+        defaultMessage: "AI provider not configured",
+        defaultDetails: "The requested provider is unknown, or has no apiKey configured in AI_CONFIG.providers.",
+        recoverable: true,
+        suggestedAction: "Add the provider's apiKey to AI_CONFIG.providers, or use a configured provider.",
+    },
+    [ERROR_CODES.AI_INVALID_REQUEST_BODY]: {
+        category: "AI",
+        defaultMessage: "Invalid AI request body",
+        defaultDetails: "The request body is missing a non-empty messages array, or no model could be resolved.",
+        recoverable: true,
+        suggestedAction: "Pass a non-empty messages array, and either a model or a provider defaultModel.",
+    },
+    [ERROR_CODES.AI_NATIVE_BRIDGE_UNAVAILABLE]: {
+        category: "AI",
+        defaultMessage: "Native AI bridge unavailable",
+        defaultDetails: "window.NativeBridge.initAI or window.WebBridge was not found when useNativeAI mounted.",
+        recoverable: false,
+        suggestedAction: "Update catalyst-core to >=0.2.0, add the native AI module, and call WebBridge.init() before mounting useNativeAI.",
+    },
+    [ERROR_CODES.AI_NATIVE_STREAM_NOT_READY]: {
+        category: "AI",
+        defaultMessage: "Native AI stream not ready",
+        defaultDetails: "generate() was called before the native side reported a ready stream URL (initAI has not fired ON_AI_READY yet).",
+        recoverable: true,
+        suggestedAction: "Wait for modelReady to become true before calling generate().",
+    },
+    [ERROR_CODES.AI_NATIVE_REQUEST_FAILED]: {
+        category: "AI",
+        defaultMessage: "Native AI request failed",
+        defaultDetails: "The native AI HTTP endpoint returned a non-ok status or reported an error in its response body.",
+        recoverable: true,
+        suggestedAction: "See the cause above for the native-reported status/message.",
+    },
+    [ERROR_CODES.AI_NATIVE_CALLBACK_ERROR]: {
+        category: "AI",
+        defaultMessage: "Native AI reported an error",
+        defaultDetails:
+            "The native platform invoked ON_AI_ERROR — a failure during model load, init, or inference on the native side, not an HTTP request made by this JS code.",
+        recoverable: true,
+        suggestedAction: "See the cause above for the native-reported message.",
+    },
+    [ERROR_CODES.AI_WEB_WORKER_UNAVAILABLE]: {
+        category: "AI",
+        defaultMessage: "Web AI worker unavailable",
+        defaultDetails: "Constructing the module Worker for in-browser AI failed — module workers may be unsupported in this browser.",
+        recoverable: false,
+        suggestedAction: "Use a browser with module Worker support, or fall back to useCloudAI/useNativeAI.",
+    },
+    [ERROR_CODES.AI_WEB_WORKER_CRASHED]: {
+        category: "AI",
+        defaultMessage: "Web AI worker crashed",
+        defaultDetails:
+            "The in-browser AI worker threw during model load or generation (e.g. all device backends failed, or an uncaught exception). See the cause above for the worker's reported message.",
+        recoverable: true,
+        suggestedAction: "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
     },
 }
 

--- a/packages/catalyst-core/src/errors/registry.js
+++ b/packages/catalyst-core/src/errors/registry.js
@@ -51,6 +51,12 @@ export const ERROR_CODES = {
     RUNTIME_NATIVE_INTERNAL_ERROR: "RUNTIME-NATIVE-015",
     RUNTIME_NATIVE_CAMERA_UNAVAILABLE: "RUNTIME-NATIVE-016",
     RUNTIME_NATIVE_CAMERA_IN_USE: "RUNTIME-NATIVE-017",
+
+    RUNTIME_NATIVE_BRIDGE_INVALID_CALLBACK: "RUNTIME-NATIVE-018",
+    RUNTIME_NATIVE_BRIDGE_HANDLER_NOT_REGISTERED: "RUNTIME-NATIVE-019",
+    RUNTIME_NATIVE_BRIDGE_HANDLER_THREW: "RUNTIME-NATIVE-020",
+    RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION: "RUNTIME-NATIVE-021",
+    RUNTIME_NATIVE_BRIDGE_INIT_FAILED: "RUNTIME-NATIVE-022",
 }
 
 // One entry per catalyst-owned code. Foreign/wrapped errors (see wrapForeignError)
@@ -364,6 +370,42 @@ export const ERROR_DEFINITIONS = {
         defaultDetails: "Camera is being used by another application",
         recoverable: true,
         suggestedAction: "Close other camera apps and try again",
+    },
+
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_CALLBACK]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Invalid callback interface",
+        defaultDetails: "The native platform invoked WebBridge.callback() with an interface name that isn't recognized.",
+        recoverable: false,
+        suggestedAction: "Check the interface name against the registered NATIVE_CALLBACKS list; this usually indicates a native/JS version mismatch.",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_NOT_REGISTERED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "No handler registered for this bridge interface",
+        defaultDetails: "The native platform called back on an interface that has no JS-side handler registered yet.",
+        recoverable: true,
+        suggestedAction: "Ensure WebBridge.register() is called for this interface before the native call arrives.",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_THREW]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "A registered bridge callback handler threw",
+        defaultDetails: "The JS handler registered for this native callback interface threw an error while processing the callback.",
+        recoverable: true,
+        suggestedAction: "Fix the error thrown inside the registered handler (see the cause above).",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "Invalid bridge callback registration",
+        defaultDetails: "WebBridge.register() was called with a non-function callback or an unrecognized interface name.",
+        recoverable: true,
+        suggestedAction: "Pass a function as the callback and a valid interface name from NATIVE_CALLBACKS.",
+    },
+    [ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INIT_FAILED]: {
+        category: "RUNTIME-NATIVE",
+        defaultMessage: "WebBridge could not be initialized",
+        defaultDetails: "WebBridge.init() was called outside a browser environment (no `window` available).",
+        recoverable: false,
+        suggestedAction: "Call WebBridge.init() in a browser environment, before using bridge features.",
     },
 }
 

--- a/packages/catalyst-core/src/native/bridge/WebBridge.js
+++ b/packages/catalyst-core/src/native/bridge/WebBridge.js
@@ -7,6 +7,7 @@ import {
 import nativeBridge from "./utils/NativeBridge.js"
 import CameraUtils from "./utils/CameraUtils.js"
 import pluginBridge from "../plugin-bridge/PluginBridge.js"
+import { createError, formatError, ERROR_CODES } from "../../errors/index.js"
 
 const DEVICE_INFO_PLUGIN = {
     pluginId: "io.catalyst.device_info",
@@ -87,11 +88,20 @@ class WebBridge {
      */
     static init = () => {
         if (typeof window === "undefined") {
-            console.error("🌉 WebBridge cannot be initialized outside the browser!")
+            console.error(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INIT_FAILED, {
+                        details: "WebBridge.init() was called outside a browser environment (no `window`).",
+                    })
+                )
+            )
             return null
         }
 
         if (window.WebBridge) {
+            // Not a failure — the bridge is already up and working, just return it.
+            // No code here: RUNTIME-NATIVE-022 means init genuinely failed, which
+            // this path is not.
             console.warn("🌉 WebBridge already initialized!")
             return window.WebBridge
         }
@@ -122,13 +132,25 @@ class WebBridge {
 
         // Validate interface
         if (!isValidCallback(interfaceName)) {
-            console.error(`🌉 Invalid callback interface: ${interfaceName}`)
+            console.error(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_CALLBACK, {
+                        details: `Received "${interfaceName}", which is not in the registered NATIVE_CALLBACKS list.`,
+                    })
+                )
+            )
             console.log("🌉 Available callbacks:", ALL_CALLBACKS)
             return
         }
 
         if (!this.handlers.has(interfaceName)) {
-            console.warn(`🌉 No handler registered for interface: ${interfaceName}`)
+            console.warn(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_NOT_REGISTERED, {
+                        details: `No handler registered for interface "${interfaceName}".`,
+                    })
+                )
+            )
             return
         }
 
@@ -136,7 +158,11 @@ class WebBridge {
             const handler = this.handlers.get(interfaceName)
             handler(data)
         } catch (error) {
-            console.error(`🌉 Error executing callback for ${interfaceName}:`, error)
+            const wrapped = createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_HANDLER_THREW, {
+                details: `The handler registered for "${interfaceName}" threw.`,
+                cause: error,
+            })
+            console.error(formatError(wrapped))
 
             // In development, provide more helpful error info
             if (process.env.NODE_ENV === "development") {
@@ -158,13 +184,25 @@ class WebBridge {
     register = (interfaceName, callback) => {
         // Validate callback function
         if (typeof callback !== "function") {
-            console.error("🌉 Callback must be a function!")
+            console.error(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION, {
+                        details: `register("${interfaceName}", ...) was called with a non-function callback (got ${typeof callback}).`,
+                    })
+                )
+            )
             return false
         }
 
         // Validate interface name
         if (!isValidCallback(interfaceName)) {
-            console.error(`🌉 Invalid callback interface: ${interfaceName}`)
+            console.error(
+                formatError(
+                    createError(ERROR_CODES.RUNTIME_NATIVE_BRIDGE_INVALID_REGISTRATION, {
+                        details: `register() was called with "${interfaceName}", which is not a valid callback interface.`,
+                    })
+                )
+            )
             console.log("🌉 Available callback interfaces:", ALL_CALLBACKS)
             return false
         }

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -32,6 +32,7 @@ import { getRoutes } from "@catalyst/template/src/js/routes/utils"
 import createStore from "@catalyst/template/src/js/store/index.js"
 import { SsrRequestProvider } from "../../web-router/components/SsrRequestContext.jsx"
 import { getManifest, getAssetManifest } from "../manifestCache.js"
+import { wrapSSRError, formatError } from "../../errors/index.js"
 
 const DEFAULT_SAFE_AREA_INSETS = { top: 0, right: 0, bottom: 0, left: 0 }
 
@@ -299,7 +300,8 @@ const _renderMarkUp = async (
                 },
 
                 onError(error) {
-                    console.error("Error in renderToPipeableStream:", error)
+                    console.error(formatError(wrapSSRError("RENDER", error)))
+                    console.error(error)
                     safeCall(onRenderError, { req, res, store, error })
                     cleanupSafeArea()
                     tail.destroy(error)
@@ -309,7 +311,8 @@ const _renderMarkUp = async (
         })
     } catch (error) {
         cleanupSafeArea()
-        console.error("Error in rendering document on server:", error)
+        console.error(formatError(wrapSSRError("RENDER", error)))
+        console.error(error)
         safeCall(onRenderError, { req, res, store, error })
         return Promise.reject(error)
     }
@@ -403,7 +406,8 @@ async function _handler(req, res) {
                     )
                 }
             } catch (error) {
-                console.error("Error in executing serverFetcher functions:", error)
+                console.error(formatError(wrapSSRError("FETCHER", error)))
+                console.error(error)
                 safeCall(onFetcherError, { req, res, store, error })
 
                 if (res.headersSent) return
@@ -422,7 +426,8 @@ async function _handler(req, res) {
                 )
             }
         } catch (error) {
-            console.error("Error in executing serverSideFunction inside App:", error)
+            console.error(formatError(wrapSSRError("SERVER_SIDE_FUNCTION", error)))
+            console.error(error)
             safeCall(onAppServerSideError, { req, res, store, error })
 
             if (res.headersSent) return
@@ -441,7 +446,8 @@ async function _handler(req, res) {
             )
         }
     } catch (error) {
-        console.error("Error in handling document request:", error)
+        console.error(formatError(wrapSSRError("REQUEST_HANDLING", error)))
+        console.error(error)
         safeCall(onRequestError, { req, res, error })
     }
 }

--- a/packages/create-catalyst-app/scripts/cli.cjs
+++ b/packages/create-catalyst-app/scripts/cli.cjs
@@ -9,6 +9,7 @@ const path = require("path")
 const fs = require("fs")
 var validate = require("validate-npm-package-name")
 const packageJson = require("../package.json")
+const { createError, wrapForeignError, formatError } = require("./errors.cjs")
 const packageRoot = path.join(__dirname, "..")
 const executable = (command) => (process.platform === "win32" ? `${command}.cmd` : command)
 
@@ -65,13 +66,29 @@ const program = new Commander.Command()
             const projectName = config.folderName || (await promptProjectName())
             let isNameValid = validate(projectName)
             if (!isNameValid.validForNewPackages) {
-                isNameValid?.warnings?.forEach?.((item) => console.log(red(item)))
-                isNameValid?.errors?.forEach?.((item) => console.log(red(item)))
+                const reasons = [...(isNameValid?.warnings || []), ...(isNameValid?.errors || [])]
+                console.error(
+                    red(
+                        formatError(
+                            createError("CCA-001", {
+                                details: reasons.length ? reasons.join("; ") : undefined,
+                            })
+                        )
+                    )
+                )
                 process.exit(1)
             }
             let projectPath = path.join(process.cwd(), projectName)
             if (fs.existsSync(projectPath)) {
-                console.log(red(`${projectName} already exists, try again.`))
+                console.error(
+                    red(
+                        formatError(
+                            createError("CCA-002", {
+                                message: `${projectName} already exists, try again.`,
+                            })
+                        )
+                    )
+                )
                 process.exit(1)
             }
             const projectDescription = config.description || (await promptDescription())
@@ -153,7 +170,8 @@ const program = new Commander.Command()
                         runMcpSetup(newMcpDir, path.join(process.cwd(), projectName))
                     }
                 } catch (error) {
-                    console.error(`Error: ${error.message}`)
+                    const catalystError = error.code && error.code.startsWith("CCA-") ? error : wrapForeignError(error)
+                    console.error(red(formatError(catalystError)))
                     process.exit(1)
                 } finally {
                     deleteDirectory(tempDir)
@@ -184,8 +202,7 @@ const program = new Commander.Command()
 
                     return tarballFilePath
                 } catch (error) {
-                    console.error(`Error packing npm package: ${error.message}`)
-                    throw error
+                    throw createError("CCA-006", { cause: error })
                 }
             }
 
@@ -219,13 +236,14 @@ const program = new Commander.Command()
                         },
                     })
                 } catch (e) {
-                    console.log("An error occurred", e)
+                    throw createError("CCA-007", { cause: e })
                 }
 
                 console.log(cyan(`Run cd ${projectName} && npm start to get started.`))
             }
         } catch (error) {
-            console.error(red("An error occurred:"), error.message)
+            const catalystError = error.code && error.code.startsWith("CCA-") ? error : wrapForeignError(error)
+            console.error(red(formatError(catalystError)))
             process.exit(1)
         }
     })
@@ -260,7 +278,8 @@ program
 
             runMcpSetup(mcpDir)
         } catch (error) {
-            console.error(red("An error occurred:"), error.message)
+            const catalystError = error.code && error.code.startsWith("CCA-") ? error : createError("CCA-008", { cause: error })
+            console.error(red(formatError(catalystError)))
             process.exit(1)
         }
     })
@@ -388,16 +407,16 @@ async function promptMcp() {
 function validateOptions(cmd) {
     // Validate language option
     if (cmd.lang && !["js", "ts"].includes(cmd.lang.toLowerCase())) {
-        throw new Error('Invalid language option. Use "js" or "ts".')
+        throw createError("CCA-003")
     }
 
     // Validate state management option
     if (cmd.stateManagement && !["rtk", "redux", "none"].includes(cmd.stateManagement.toLowerCase())) {
-        throw new Error('Invalid state management option. Use "rtk", "redux", or "none".')
+        throw createError("CCA-004")
     }
 
     if (cmd.yes && typeof cmd.yes !== "boolean") {
-        throw new Error('Invalid option for "yes". Use "-y" or "--yes" to accept defaults.')
+        throw createError("CCA-005")
     }
 }
 
@@ -422,7 +441,7 @@ function createGitignore(projectName) {
     const gitignorePath = `${process.cwd()}${path.sep}${projectName}${path.sep}.gitignore`
 
     if (fs.existsSync(gitignorePath)) {
-        console.log(".gitignore already exists. Please rename or remove it before running the script.")
+        console.log(cyan(formatError(createError("CCA-009"))))
         return
     }
 

--- a/packages/create-catalyst-app/scripts/cli.cjs
+++ b/packages/create-catalyst-app/scripts/cli.cjs
@@ -9,7 +9,7 @@ const path = require("path")
 const fs = require("fs")
 var validate = require("validate-npm-package-name")
 const packageJson = require("../package.json")
-const { createError, wrapForeignError, formatError } = require("./errors.cjs")
+const { CCAError, createError, wrapForeignError, formatError } = require("./errors.cjs")
 const packageRoot = path.join(__dirname, "..")
 const executable = (command) => (process.platform === "win32" ? `${command}.cmd` : command)
 
@@ -170,7 +170,7 @@ const program = new Commander.Command()
                         runMcpSetup(newMcpDir, path.join(process.cwd(), projectName))
                     }
                 } catch (error) {
-                    const catalystError = error.code && error.code.startsWith("CCA-") ? error : wrapForeignError(error)
+                    const catalystError = error instanceof CCAError ? error : wrapForeignError(error)
                     console.error(red(formatError(catalystError)))
                     process.exit(1)
                 } finally {
@@ -242,7 +242,7 @@ const program = new Commander.Command()
                 console.log(cyan(`Run cd ${projectName} && npm start to get started.`))
             }
         } catch (error) {
-            const catalystError = error.code && error.code.startsWith("CCA-") ? error : wrapForeignError(error)
+            const catalystError = error instanceof CCAError ? error : wrapForeignError(error)
             console.error(red(formatError(catalystError)))
             process.exit(1)
         }
@@ -278,7 +278,7 @@ program
 
             runMcpSetup(mcpDir)
         } catch (error) {
-            const catalystError = error.code && error.code.startsWith("CCA-") ? error : createError("CCA-008", { cause: error })
+            const catalystError = error instanceof CCAError ? error : createError("CCA-008", { cause: error })
             console.error(red(formatError(catalystError)))
             process.exit(1)
         }

--- a/packages/create-catalyst-app/scripts/errors.cjs
+++ b/packages/create-catalyst-app/scripts/errors.cjs
@@ -1,0 +1,182 @@
+const REPO_BLOB_BASE = "https://github.com/tata1mg/catalyst-core/blob/main/errors"
+
+function docUrl(category, code) {
+    return `${REPO_BLOB_BASE}/${category}/${code}.md`
+}
+
+const ERROR_CODES = {
+    CCA_UPSTREAM_ERROR: "CCA-000",
+    CCA_INVALID_NAME: "CCA-001",
+    CCA_DIRECTORY_EXISTS: "CCA-002",
+    CCA_INVALID_LANGUAGE_OPTION: "CCA-003",
+    CCA_INVALID_STATE_MANAGEMENT_OPTION: "CCA-004",
+    CCA_INVALID_YES_OPTION: "CCA-005",
+    CCA_PACK_FAILED: "CCA-006",
+    CCA_EXTRACTION_FAILED: "CCA-007",
+    CCA_MCP_SETUP_FAILED: "CCA-008",
+    CCA_GITIGNORE_EXISTS: "CCA-009",
+}
+
+// One entry per CCA-owned code, including the CCA-000 wrapper used by
+// wrapForeignError. Foreign errors themselves are never reinterpreted —
+// their original message/code always surfaces via `cause`.
+const ERROR_DEFINITIONS = {
+    [ERROR_CODES.CCA_UPSTREAM_ERROR]: {
+        category: "CCA",
+        defaultMessage: "An upstream command failed",
+        defaultDetails:
+            "This wraps an error from npm, tar, or another upstream tool invoked by create-catalyst-app. See the printed upstream message for the actual cause.",
+        recoverable: true,
+        suggestedAction: "Read the upstream error message printed above and fix the underlying issue.",
+    },
+    [ERROR_CODES.CCA_INVALID_NAME]: {
+        category: "CCA",
+        defaultMessage: "Invalid project name",
+        defaultDetails: "The project name is not a valid npm package name.",
+        recoverable: true,
+        suggestedAction: "Choose a project name that is a valid npm package name and try again.",
+    },
+    [ERROR_CODES.CCA_DIRECTORY_EXISTS]: {
+        category: "CCA",
+        defaultMessage: "Target directory already exists",
+        defaultDetails: "A file or directory with the project name already exists in the current directory.",
+        recoverable: true,
+        suggestedAction: "Choose a different project name, or remove/rename the existing directory.",
+    },
+    [ERROR_CODES.CCA_INVALID_LANGUAGE_OPTION]: {
+        category: "CCA",
+        defaultMessage: "Invalid language option",
+        defaultDetails: 'The --lang option must be "js" or "ts".',
+        recoverable: true,
+        suggestedAction: 'Pass --lang js or --lang ts.',
+    },
+    [ERROR_CODES.CCA_INVALID_STATE_MANAGEMENT_OPTION]: {
+        category: "CCA",
+        defaultMessage: "Invalid state management option",
+        defaultDetails: 'The --state-management option must be "rtk", "redux", or "none".',
+        recoverable: true,
+        suggestedAction: "Pass a supported --state-management value.",
+    },
+    [ERROR_CODES.CCA_INVALID_YES_OPTION]: {
+        category: "CCA",
+        defaultMessage: "Invalid --yes option",
+        defaultDetails: "The -y/--yes flag does not accept a non-boolean value.",
+        recoverable: true,
+        suggestedAction: "Use -y or --yes with no value to accept defaults.",
+    },
+    [ERROR_CODES.CCA_PACK_FAILED]: {
+        category: "CCA",
+        defaultMessage: "Failed to pack create-catalyst-app",
+        defaultDetails: "npm pack could not produce the tarball used to scaffold the new project.",
+        recoverable: true,
+        suggestedAction: "Check your npm registry access/network connection and try again.",
+    },
+    [ERROR_CODES.CCA_EXTRACTION_FAILED]: {
+        category: "CCA",
+        defaultMessage: "Failed to extract template files",
+        defaultDetails: "The packed tarball could not be extracted into the new project directory.",
+        recoverable: true,
+        suggestedAction: "Ensure the target directory is writable and try again.",
+    },
+    [ERROR_CODES.CCA_MCP_SETUP_FAILED]: {
+        category: "CCA",
+        defaultMessage: "MCP server setup failed",
+        defaultDetails: "Downloading, installing, or configuring the MCP server failed.",
+        recoverable: true,
+        suggestedAction: "Check your network connection and re-run `catalyst-mcp` inside the project.",
+    },
+    [ERROR_CODES.CCA_GITIGNORE_EXISTS]: {
+        category: "CCA",
+        defaultMessage: ".gitignore already exists",
+        defaultDetails: "The scaffolded project already contains a .gitignore file.",
+        recoverable: true,
+        suggestedAction: "Remove or rename the existing .gitignore before running again, or ignore this warning.",
+    },
+}
+
+function getDefinition(code) {
+    return ERROR_DEFINITIONS[code] || ERROR_DEFINITIONS[ERROR_CODES.CCA_INVALID_NAME]
+}
+
+function getDocUrl(code) {
+    const def = ERROR_DEFINITIONS[code]
+    if (!def) return null
+    return docUrl(def.category, code)
+}
+
+class CCAError extends Error {
+    constructor(code, { message, details, recoverable, suggestedAction, category, docUrl, cause } = {}) {
+        super(message)
+        this.name = "CCAError"
+        this.code = code
+        this.category = category
+        this.details = details
+        this.recoverable = recoverable
+        this.suggestedAction = suggestedAction
+        this.docUrl = docUrl
+        if (cause !== undefined) this.cause = cause
+    }
+}
+
+/**
+ * Create a CCAError for a code we own, using the registry defaults
+ * unless overridden.
+ */
+function createError(code, overrides = {}) {
+    const def = getDefinition(code)
+    return new CCAError(code, {
+        category: def.category,
+        message: overrides.message || def.defaultMessage,
+        details: overrides.details || def.defaultDetails,
+        recoverable: overrides.recoverable ?? def.recoverable,
+        suggestedAction: overrides.suggestedAction || def.suggestedAction,
+        docUrl: getDocUrl(code),
+        cause: overrides.cause,
+    })
+}
+
+/**
+ * Wrap a foreign error (npm/tar/git/network) that already carries its own
+ * message. We do not replace or reinterpret it — we attach the generic
+ * CCA-000 wrapper code and preserve the original as `cause`, so the
+ * upstream message is always what gets shown to the user.
+ */
+function wrapForeignError(err) {
+    const hasNamedCode = err && typeof err.code === "string"
+    const upstreamCode = hasNamedCode ? ` ${err.code}` : ""
+    return createError(ERROR_CODES.CCA_UPSTREAM_ERROR, {
+        message: `An upstream command failed (upstream:${upstreamCode})`,
+        cause: err,
+    })
+}
+
+/**
+ * Format a CCAError for terminal output. Foreign-wrapped errors always show
+ * the original upstream message/code, never a paraphrase of it.
+ */
+function formatError(err) {
+    const lines = [`[${err.code}] ${err.message}`]
+    if (err.cause) {
+        const causeMessage = err.cause.message || String(err.cause)
+        lines.push(`→ ${causeMessage}`)
+    } else if (err.details) {
+        lines.push(err.details)
+    }
+    if (err.suggestedAction) {
+        lines.push(`Suggested action: ${err.suggestedAction}`)
+    }
+    if (err.docUrl) {
+        lines.push(`Docs: ${err.docUrl}`)
+    }
+    return lines.join("\n")
+}
+
+module.exports = {
+    ERROR_CODES,
+    ERROR_DEFINITIONS,
+    CCAError,
+    createError,
+    wrapForeignError,
+    formatError,
+    getDocUrl,
+}

--- a/packages/create-catalyst-app/scripts/errors.cjs
+++ b/packages/create-catalyst-app/scripts/errors.cjs
@@ -95,12 +95,12 @@ const ERROR_DEFINITIONS = {
 }
 
 function getDefinition(code) {
-    return ERROR_DEFINITIONS[code] || ERROR_DEFINITIONS[ERROR_CODES.CCA_INVALID_NAME]
+    return ERROR_DEFINITIONS[code] || ERROR_DEFINITIONS[ERROR_CODES.CCA_UPSTREAM_ERROR]
 }
 
 function getDocUrl(code) {
     const def = ERROR_DEFINITIONS[code]
-    if (!def) return null
+    if (!def) return docUrl(getDefinition(code).category, ERROR_CODES.CCA_UPSTREAM_ERROR)
     return docUrl(def.category, code)
 }
 

--- a/packages/create-catalyst-app/scripts/generateDocs.cjs
+++ b/packages/create-catalyst-app/scripts/generateDocs.cjs
@@ -1,0 +1,83 @@
+const { mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync, existsSync } = require("fs")
+const path = require("path")
+const { ERROR_DEFINITIONS } = require("./errors.cjs")
+
+// packages/create-catalyst-app/scripts -> repo root /errors
+const ERRORS_DIR = path.resolve(__dirname, "../../../errors")
+const INDEX_PATH = path.join(ERRORS_DIR, "index.json")
+
+function renderMarkdown(code, def) {
+    return `# ${code}
+
+**Category:** ${def.category}
+
+## Message
+
+${def.defaultMessage}
+
+## Details
+
+${def.defaultDetails}
+
+## Recoverable
+
+${def.recoverable ? "Yes — you can fix this and retry without restarting your workflow." : "No — this typically requires investigating the underlying cause."}
+
+## Suggested action
+
+${def.suggestedAction}
+`
+}
+
+function clearGeneratedCategoryDirs() {
+    const dir = path.join(ERRORS_DIR, "CCA")
+    if (!existsSync(dir)) return
+    for (const file of readdirSync(dir)) {
+        if (file.endsWith(".md")) rmSync(path.join(dir, file))
+    }
+}
+
+function readExistingIndex() {
+    if (!existsSync(INDEX_PATH)) return {}
+    try {
+        return JSON.parse(readFileSync(INDEX_PATH, "utf8"))
+    } catch {
+        return {}
+    }
+}
+
+function generateDocs() {
+    clearGeneratedCategoryDirs()
+
+    // Merge into the shared errors/index.json rather than overwriting it —
+    // catalyst-core's own generateDocs.js owns every other category.
+    const index = readExistingIndex()
+
+    for (const [code, def] of Object.entries(ERROR_DEFINITIONS)) {
+        const dir = path.join(ERRORS_DIR, def.category)
+        mkdirSync(dir, { recursive: true })
+        const filePath = path.join(dir, `${code}.md`)
+        writeFileSync(filePath, renderMarkdown(code, def))
+
+        index[code] = {
+            category: def.category,
+            message: def.defaultMessage,
+            details: def.defaultDetails,
+            recoverable: def.recoverable,
+            suggestedAction: def.suggestedAction,
+            docUrl: `https://github.com/tata1mg/catalyst-core/blob/main/errors/${def.category}/${code}.md`,
+        }
+    }
+
+    mkdirSync(ERRORS_DIR, { recursive: true })
+    writeFileSync(INDEX_PATH, JSON.stringify(index, null, 4))
+
+    return { count: Object.keys(ERROR_DEFINITIONS).length, errorsDir: ERRORS_DIR }
+}
+
+if (require.main === module) {
+    const { count, errorsDir } = generateDocs()
+    console.log(`Generated ${count} error doc(s) and merged into index.json in ${errorsDir}`)
+}
+
+module.exports = { generateDocs }


### PR DESCRIPTION
## Summary

Closes #386. Adds the `RUNTIME-WEB-xxx` error category (promised in the RFC #155 discussion but never built) and wires all 5 raw `console.error` sites in `handler.jsx`'s SSR request handler into the error registry.

This closes a gap found while checking `examples/` apps: any error thrown during SSR — the user's own code, a third-party npm library, or catalyst-core's own pipeline — was previously logged as a raw, unformatted error with no code, no docs link, and no consistent structure.

## Design notes

- `RUNTIME-WEB-001..004` map to render / fetcher / serverSideFunction / request-handling stages. All 4 are origin-unknown wrappers (we can't tell from the caught error whether it's app code, a dependency, or catalyst-core) — see the amendment comment on #386 for the full reasoning, including why this deviates from the `-000`/`-001+` numbering convention used by `BUNDLE`/`IOS`/`ANDROID`/`AI`.
- New `wrapSSRError(stage, err)` helper added alongside (not replacing) `wrapForeignError`, since the build-stage model (one code, hardcoded "Build failed" message) didn't fit SSR's 4 distinct stages with no named upstream tool.
- Unchanged: HTTP status/response behavior at each catch site, and the error object passed to `safeCall(onRenderError/onFetcherError/onAppServerSideError/onRequestError, ...)` — hooks still receive the original unwrapped error.
- Stack traces preserved via a second `console.error(error)` call per site rather than embedding the stack in `formatError`'s output (tested the combined-arg form first — Node appends the inspected Error onto the same line as the "Docs:" line, which reads badly).

## Not included

`errors/index.json` is **not** regenerated in this PR. It's a full-overwrite artifact built from whatever `ERROR_DEFINITIONS` are visible on the branch that regenerates it — this branch doesn't have the AI/CCA/bridge codes from #370/#371/#372 (they're on `feature/372-cca`, stacked separately). Regenerating here would produce a partial index that could clobber their entries at merge time. **Needs a regenerate pass (`node packages/catalyst-core/src/errors/generateDocs.js`) after this and the #370/#371/#372 stack are both merged into `story/6-error-handling`.**

## Note

Could not run `eslint` locally from this directory (no resolvable `eslint.config.js` from `packages/catalyst-core`) — CI is the first real lint gate for this change. Diff is otherwise mechanical (5 line substitutions + 1 import in `handler.jsx`, additive-only registry entries).

## Test plan

- [x] `node --check` on modified `.js` files
- [x] Manual test: `wrapSSRError` + `formatError` produce expected `[CODE] message / → cause / suggested action / docs` output, `cause` preserved as reference to original error
- [x] Confirmed two-call `console.error` split prints formatted block and stack trace on separate lines
- [x] `generateDocs.js` run locally — confirmed additive-only diff on `errors/RUNTIME-WEB/*.md`, no other categories touched
- [ ] Regenerate `errors/index.json` after merge (see above)
