### PR TITLE
feat(errors): implement three output modes (default/verbose/debug)

### DIFF
--- a/errors/index.json
+++ b/errors/index.json
@@ -542,5 +542,37 @@
         "recoverable": true,
         "suggestedAction": "Check that the model is compatible with this browser/device, or use useCloudAI/useNativeAI instead.",
         "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/AI/AI-009.md"
+    },
+    "RUNTIME-WEB-001": {
+        "category": "RUNTIME-WEB",
+        "message": "Rendering failed on the server",
+        "details": "An error was thrown while streaming or rendering the document on the server. This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.",
+        "recoverable": true,
+        "suggestedAction": "See the cause above for the error thrown during rendering.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-WEB/RUNTIME-WEB-001.md"
+    },
+    "RUNTIME-WEB-002": {
+        "category": "RUNTIME-WEB",
+        "message": "serverFetcher failed",
+        "details": "An error was thrown while executing a route's serverFetcher function(s). This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.",
+        "recoverable": true,
+        "suggestedAction": "See the cause above for the error thrown inside serverFetcher.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-WEB/RUNTIME-WEB-002.md"
+    },
+    "RUNTIME-WEB-003": {
+        "category": "RUNTIME-WEB",
+        "message": "App.serverSideFunction failed",
+        "details": "An error was thrown while executing the app-level serverSideFunction hook. This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.",
+        "recoverable": true,
+        "suggestedAction": "See the cause above for the error thrown inside serverSideFunction.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-WEB/RUNTIME-WEB-003.md"
+    },
+    "RUNTIME-WEB-004": {
+        "category": "RUNTIME-WEB",
+        "message": "Failed to handle document request",
+        "details": "An unhandled error reached the top level of the SSR request handler. This may originate from app code, a third-party dependency, or catalyst-core itself — see the cause above for the actual error.",
+        "recoverable": false,
+        "suggestedAction": "See the cause above for the underlying error.",
+        "docUrl": "https://github.com/tata1mg/catalyst-core/blob/main/errors/RUNTIME-WEB/RUNTIME-WEB-004.md"
     }
 }

--- a/packages/catalyst-core/src/errors/index.js
+++ b/packages/catalyst-core/src/errors/index.js
@@ -1,3 +1,4 @@
+import pc from "ansis"
 import { ERROR_CODES, getDefinition, getDocUrl } from "./registry.js"
 
 export { ERROR_CODES, getDocUrl }
@@ -109,17 +110,7 @@ export function wrapProviderError(provider, status, bodyText) {
     })
 }
 
-/**
- * Format a CatalystError for terminal output. Foreign-wrapped errors always
- * show the original upstream message/code, never a paraphrase of it.
- *
- * Note: this prints the cause's *message* only, not its stack. Callers
- * logging a wrapped error to the console (see wrapSSRError call sites in
- * handler.jsx) should also log `err.cause` itself alongside this output so
- * the stack trace isn't lost — formatError is for the human-readable
- * summary, not a replacement for full error inspection.
- */
-export function formatError(err) {
+function formatDefault(err) {
     const lines = [`[${err.code}] ${err.message}`]
     if (err.cause) {
         const causeMessage = err.cause.message || String(err.cause)
@@ -134,4 +125,113 @@ export function formatError(err) {
         lines.push(`Docs: ${err.docUrl}`)
     }
     return lines.join("\n")
+}
+
+const BOX_WIDTH = 70
+
+function box(bodyLines) {
+    const top = pc.red(`┌${"─".repeat(BOX_WIDTH)}`)
+    const bottom = pc.red(`└${"─".repeat(BOX_WIDTH)}`)
+    const body = bodyLines.map((line) => (line === "" ? pc.red("│") : `${pc.red("│")} ${line}`))
+    return [top, ...body, bottom].join("\n")
+}
+
+function formatCauseChain(cause) {
+    const lines = []
+    let current = cause
+    let depth = 0
+    while (current) {
+        const prefix = depth === 0 ? "Caused by:" : `  ${"  ".repeat(depth - 1)}Caused by:`
+        lines.push(`${prefix} ${current.message || String(current)}`)
+        current = current.cause
+        depth += 1
+    }
+    return lines
+}
+
+/**
+ * Verbose output: boxed per RFC #155 §3.2 — code, timestamp, problem,
+ * suggested action, docs link. Owns its own coloring (the box border and
+ * text are colored as a unit here) rather than leaving callers to wrap the
+ * whole multi-line block in a color function themselves.
+ */
+function formatVerbose(err) {
+    const lines = [
+        pc.bold(`❌ ${err.message}`),
+        `Code: ${err.code}`,
+        `Category: ${err.category || "UNKNOWN"}`,
+        `Time: ${new Date().toISOString()}`,
+        "",
+    ]
+    if (err.cause) {
+        lines.push(`Problem: ${err.cause.message || String(err.cause)}`)
+        lines.push("")
+    } else if (err.details) {
+        lines.push(`Problem: ${err.details}`)
+        lines.push("")
+    }
+    if (err.suggestedAction) {
+        lines.push("Solution:", `  ${err.suggestedAction}`, "")
+    }
+    if (err.docUrl) {
+        lines.push(`Docs: ${err.docUrl}`)
+    }
+    return box(lines)
+}
+
+/**
+ * Debug output: verbose + full cause chain + stack trace + environment
+ * info. Environment gathering happens here (Node-side), not as module-level
+ * state, so errors/index.js stays free of os/process imports and safe to
+ * bundle into the browser (see formatError's mode parameter below).
+ */
+function formatDebug(err, env) {
+    const lines = [
+        pc.bold(`❌ ${err.message}`),
+        `Code: ${err.code}`,
+        `Category: ${err.category || "UNKNOWN"}`,
+        `Time: ${new Date().toISOString()}`,
+        "",
+    ]
+    if (err.cause) {
+        lines.push(...formatCauseChain(err.cause), "")
+    } else if (err.details) {
+        lines.push(`Problem: ${err.details}`, "")
+    }
+    if (err.suggestedAction) {
+        lines.push("Solution:", `  ${err.suggestedAction}`, "")
+    }
+    if (err.docUrl) {
+        lines.push(`Docs: ${err.docUrl}`, "")
+    }
+    if (env) {
+        lines.push("Environment:")
+        for (const [key, value] of Object.entries(env)) {
+            lines.push(`  ${key}: ${value}`)
+        }
+        lines.push("")
+    }
+    lines.push("Stack trace:")
+    const stack = err.cause?.stack || err.stack || "(no stack available)"
+    lines.push(...stack.split("\n").map((l) => `  ${l}`))
+    return box(lines)
+}
+
+/**
+ * Format a CatalystError for terminal output. Foreign-wrapped errors always
+ * show the original upstream message/code, never a paraphrase of it.
+ *
+ * `mode` is a parameter, not module-level state — WebBridge.js (browser) has
+ * no process.argv/TTY and keeps calling formatError(err) unchanged, getting
+ * "default". Node call sites resolve their own mode (see
+ * scripts/scriptUtils.js#resolveOutputMode) and pass it through explicitly.
+ *
+ * `env` (debug mode only) is gathered by the caller, not here — keeps this
+ * module free of os/process imports so it stays safe to bundle into the
+ * browser regardless of which mode a Node caller happens to request.
+ */
+export function formatError(err, mode = "default", env) {
+    if (mode === "debug") return formatDebug(err, env)
+    if (mode === "verbose") return formatVerbose(err)
+    return formatDefault(err)
 }

--- a/packages/catalyst-core/src/errors/registry.js
+++ b/packages/catalyst-core/src/errors/registry.js
@@ -533,7 +533,12 @@ export const ERROR_DEFINITIONS = {
 }
 
 export function getDefinition(code) {
-    return ERROR_DEFINITIONS[code] || ERROR_DEFINITIONS[ERROR_CODES.RUNTIME_NATIVE_INTERNAL_ERROR]
+    if (ERROR_DEFINITIONS[code]) return ERROR_DEFINITIONS[code]
+    // Fall back to a generic definition for unrecognized codes, but never
+    // inherit the fallback's own category — that would mislabel an unknown
+    // code as RUNTIME-NATIVE in verbose/debug output, which is misleading
+    // rather than merely imprecise.
+    return { ...ERROR_DEFINITIONS[ERROR_CODES.RUNTIME_NATIVE_INTERNAL_ERROR], category: "UNKNOWN" }
 }
 
 export function getDocUrl(code) {

--- a/packages/catalyst-core/src/native/buildAppAndroid.js
+++ b/packages/catalyst-core/src/native/buildAppAndroid.js
@@ -1,4 +1,5 @@
 const { createAndroidBuild, pwd } = require("./buildAndroid/index.js")
+const { formatBuildError } = require("./buildErrorFormat.js")
 
 const { WEBVIEW_CONFIG, BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
 
@@ -9,12 +10,7 @@ async function main() {
     try {
         await buildAndroidApp()
     } catch (error) {
-        // src/native is a CJS-only subtree (see src/native/package.json) and cannot
-        // synchronously require() the ESM errors/index.js module under Node 20, so
-        // we format inline here. Code ANDROID-000 = generic "upstream Gradle error"
-        // wrapper — see errors/ANDROID/ANDROID-000.md. Message was previously
-        // swallowed entirely; now preserved verbatim, not reinterpreted.
-        console.error(`[ANDROID-000] Build failed (upstream: Gradle)\n→ ${error.message}`)
+        console.error(formatBuildError({ code: "ANDROID-000", category: "ANDROID", upstreamName: "Gradle", error }))
         process.exit(1)
     }
     process.exit(0)

--- a/packages/catalyst-core/src/native/buildAppIos.js
+++ b/packages/catalyst-core/src/native/buildAppIos.js
@@ -2,6 +2,7 @@ const path = require("path")
 const { createIosBuild, pwd } = require("./buildIos/index.js")
 const { composeIosPlugins } = require("./pluginComposerIos.js")
 const { resolveInternalPluginsRoot, resolvePluginConfig } = require("./internalPluginUtils.js")
+const { formatBuildError } = require("./buildErrorFormat.js")
 
 const catalystCorePath = path.dirname(require.resolve("catalyst-core/package.json"))
 const { WEBVIEW_CONFIG, BUILD_OUTPUT_PATH } = require(`${process.cwd()}/config/config.json`)
@@ -33,12 +34,14 @@ async function main() {
         await syncPluginResources(pluginComposition)
         await buildForIOS(pluginComposition)
     } catch (error) {
-        // src/native is a CJS-only subtree (see src/native/package.json) and cannot
-        // synchronously require() the ESM errors/index.js module under Node 20, so
-        // we format inline here rather than reconstructing that module system boundary.
-        // Code IOS-000 = generic "upstream Xcode/CocoaPods toolchain error" wrapper —
-        // see errors/IOS/IOS-000.md. We never reinterpret the underlying message.
-        progress.log(`[IOS-000] Build failed (upstream: Xcode/CocoaPods)\n→ ${error.message}`, "error")
+        // progress.log() prefixes every call with an icon/color and does a
+        // single console.log per invocation — it's built for single-line
+        // status messages, not our multi-line boxed verbose/debug output
+        // (piping a box through it would prefix an icon onto every border
+        // line and break the box shape). Bypass it here and use plain
+        // console.error instead, matching buildAppAndroid.js; progress.log
+        // is unaffected everywhere else in this build.
+        console.error(formatBuildError({ code: "IOS-000", category: "IOS", upstreamName: "Xcode/CocoaPods", error }))
         process.exit(1)
     }
     process.exit(0)

--- a/packages/catalyst-core/src/native/buildErrorFormat.js
+++ b/packages/catalyst-core/src/native/buildErrorFormat.js
@@ -1,0 +1,50 @@
+const pc = require("ansis")
+
+// src/native is a CJS-only subtree (see src/native/package.json) and cannot
+// synchronously require() the ESM errors/index.js module under Node 20, so
+// output-mode formatting for buildAppAndroid.js/buildAppIos.js is
+// hand-rolled here rather than shared with errors/index.js's box/formatVerbose/
+// formatDebug — those two files are the only callers, and both native build
+// failure sites need the same minimal shape.
+
+function resolveOutputMode() {
+    if (process.argv.includes("--debug")) return "debug"
+    if (process.argv.includes("--verbose")) return "verbose"
+    return "default"
+}
+
+function box(bodyLines) {
+    const width = 70
+    const top = pc.red(`┌${"─".repeat(width)}`)
+    const bottom = pc.red(`└${"─".repeat(width)}`)
+    const body = bodyLines.map((line) => (line === "" ? pc.red("│") : `${pc.red("│")} ${line}`))
+    return [top, ...body, bottom].join("\n")
+}
+
+/**
+ * Format a native build failure for terminal output. `code`/`category`
+ * identify the generic upstream-toolchain wrapper (ANDROID-000/IOS-000 —
+ * see errors/ANDROID/ANDROID-000.md and errors/IOS/IOS-000.md); the
+ * upstream message is always shown verbatim, never reinterpreted.
+ */
+function formatBuildError({ code, category, upstreamName, error }) {
+    const mode = resolveOutputMode()
+    if (mode === "default") {
+        return `[${code}] Build failed (upstream: ${upstreamName})\n→ ${error.message}`
+    }
+    const lines = [
+        `❌ Build failed (upstream: ${upstreamName})`,
+        `Code: ${code}`,
+        `Category: ${category}`,
+        `Time: ${new Date().toISOString()}`,
+        "",
+        `Problem: ${error.message}`,
+    ]
+    if (mode === "debug") {
+        lines.push("", "Environment:", `  node: ${process.version}`, `  platform: ${process.platform}`)
+        lines.push("", "Stack trace:", ...(error.stack || "(no stack available)").split("\n").map((l) => `  ${l}`))
+    }
+    return box(lines)
+}
+
+module.exports = { resolveOutputMode, formatBuildError }

--- a/packages/catalyst-core/src/scripts/build.js
+++ b/packages/catalyst-core/src/scripts/build.js
@@ -1,6 +1,6 @@
 import path from "path"
 import { spawn } from "child_process"
-import { arrayToObject } from "./scriptUtils.js"
+import { arrayToObject, resolveOutputMode, getDebugEnvInfo } from "./scriptUtils.js"
 import { fileURLToPath } from "url"
 import { dirname } from "path"
 import { readFileSync, existsSync, rmSync } from "fs"
@@ -43,6 +43,7 @@ function runBuildStep(args, options) {
 async function build() {
     const commandLineArguments = process.argv.slice(2)
     const argumentsObject = arrayToObject(commandLineArguments)
+    const outputMode = resolveOutputMode(process.argv)
     const dirname = path.resolve(__dirname, "../../")
 
     // Read package.json
@@ -64,6 +65,7 @@ async function build() {
         VITE_BUILD_MODE: "true",
         APPLICATION: name || "catalyst_app",
         NODE_OPTIONS: `--loader ${loaderPath}`,
+        CATALYST_OUTPUT_MODE: outputMode,
         ...argumentsObject,
         filterKeys: JSON.stringify([
             "src_path",
@@ -96,7 +98,8 @@ async function build() {
         ])
     } catch (err) {
         console.error("❌ Build failed!")
-        console.error(formatError(wrapForeignError("BUNDLE", err)))
+        const debugEnv = outputMode === "debug" ? getDebugEnvInfo() : undefined
+        console.error(formatError(wrapForeignError("BUNDLE", err), outputMode, debugEnv))
         process.exit(1)
     }
 

--- a/packages/catalyst-core/src/scripts/scriptUtils.js
+++ b/packages/catalyst-core/src/scripts/scriptUtils.js
@@ -1,8 +1,12 @@
 import fs from "fs"
 import path from "path"
+import { fileURLToPath } from "url"
 import util from "node:util"
 import pkg from "ansis"
 const { gray, cyan } = pkg
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+let cachedCatalystCoreVersion
 
 // Function to get file size synchronously
 function getFileSizeSync(filePath) {
@@ -52,4 +56,45 @@ export function arrayToObject(array) {
         if (value) obj[key] = value
     })
     return obj
+}
+
+/**
+ * Resolve the output mode for error formatting from a bare boolean CLI flag
+ * (--debug/--verbose, matching the --inspect convention already used by
+ * serve.js — not arrayToObject, which requires --key=value and silently
+ * drops valueless flags) or an inherited CATALYST_OUTPUT_MODE env var, for
+ * scripts spawned as a child process (see serve.js/start.js forwarding it
+ * to expressServer.js). An explicit flag on argv wins over an inherited env
+ * value, so e.g. `catalyst serve --debug` overrides a parent that set
+ * CATALYST_OUTPUT_MODE=verbose.
+ */
+export function resolveOutputMode(argv = process.argv, env = process.env) {
+    if (argv.includes("--debug")) return "debug"
+    if (argv.includes("--verbose")) return "verbose"
+    if (env.CATALYST_OUTPUT_MODE === "debug" || env.CATALYST_OUTPUT_MODE === "verbose") {
+        return env.CATALYST_OUTPUT_MODE
+    }
+    return "default"
+}
+
+/**
+ * Environment info for debug-mode error output: catalyst-core's own
+ * installed version (read from this package's own package.json, not the
+ * consuming app's — so it reflects what's actually running, not just what
+ * the app's package.json range says), Node version, and platform.
+ */
+export function getDebugEnvInfo() {
+    if (cachedCatalystCoreVersion === undefined) {
+        try {
+            const pkgPath = path.resolve(__dirname, "../../package.json")
+            cachedCatalystCoreVersion = JSON.parse(fs.readFileSync(pkgPath, "utf-8")).version
+        } catch {
+            cachedCatalystCoreVersion = "unknown"
+        }
+    }
+    return {
+        node: process.version,
+        platform: process.platform,
+        catalystCore: cachedCatalystCoreVersion,
+    }
 }

--- a/packages/catalyst-core/src/scripts/serve.js
+++ b/packages/catalyst-core/src/scripts/serve.js
@@ -1,6 +1,6 @@
 import path from "path"
 import { spawnSync } from "child_process"
-import { arrayToObject } from "./scriptUtils.js"
+import { arrayToObject, resolveOutputMode } from "./scriptUtils.js"
 import { fileURLToPath } from "url"
 import { dirname } from "path"
 import { readFileSync } from "fs"
@@ -16,6 +16,7 @@ const preInitPath = path.resolve(__dirname, "preServerInit.js")
 function startProd() {
     const commandLineArguments = process.argv.slice(2)
     const argumentsObject = arrayToObject(commandLineArguments)
+    const outputMode = resolveOutputMode(process.argv)
     const dirname = path.resolve(__dirname, "../../")
 
     // Read package.json
@@ -37,6 +38,7 @@ function startProd() {
                 NODE_ENV: "production",
                 IS_DEV_COMMAND: false,
                 APPLICATION: name || "catalyst_app",
+                CATALYST_OUTPUT_MODE: outputMode,
                 ...argumentsObject,
                 filterKeys: JSON.stringify([
                     "src_path",

--- a/packages/catalyst-core/src/scripts/start.js
+++ b/packages/catalyst-core/src/scripts/start.js
@@ -1,6 +1,6 @@
 import path from "path"
 import { spawnSync } from "child_process"
-import { arrayToObject } from "./scriptUtils.js"
+import { arrayToObject, resolveOutputMode } from "./scriptUtils.js"
 import { fileURLToPath } from "url"
 import { dirname } from "path"
 import { readFileSync } from "fs"
@@ -16,6 +16,7 @@ const preInitPath = path.resolve(__dirname, "preServerInit.js")
 function start() {
     const commandLineArguments = process.argv.slice(2)
     const argumentsObject = arrayToObject(commandLineArguments)
+    const outputMode = resolveOutputMode(process.argv)
     const dirname = path.resolve(__dirname, "../../")
 
     // Read package.json
@@ -31,6 +32,7 @@ function start() {
             NODE_ENV: "development",
             IS_DEV_COMMAND: false,
             APPLICATION: name || "catalyst_app",
+            CATALYST_OUTPUT_MODE: outputMode,
             ...argumentsObject,
             filterKeys: JSON.stringify([
                 "src_path",

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -33,6 +33,21 @@ import createStore from "@catalyst/template/src/js/store/index.js"
 import { SsrRequestProvider } from "../../web-router/components/SsrRequestContext.jsx"
 import { getManifest, getAssetManifest } from "../manifestCache.js"
 import { wrapSSRError, formatError } from "../../errors/index.js"
+import { resolveOutputMode, getDebugEnvInfo } from "../../scripts/scriptUtils.js"
+
+// Resolved once at module load — spawned via serve.js/start.js, which
+// forward the mode as CATALYST_OUTPUT_MODE (no argv available at this
+// level; see scriptUtils.js#resolveOutputMode).
+const outputMode = resolveOutputMode(process.argv, process.env)
+// Debug mode's boxed output already embeds the full stack trace (see
+// errors/index.js#formatDebug), so only default/verbose need the original
+// error printed separately to avoid losing the stack.
+const logSSRError = (stage, error) => {
+    const wrapped = wrapSSRError(stage, error)
+    const debugEnv = outputMode === "debug" ? getDebugEnvInfo() : undefined
+    console.error(formatError(wrapped, outputMode, debugEnv))
+    if (outputMode !== "debug") console.error(error)
+}
 
 const DEFAULT_SAFE_AREA_INSETS = { top: 0, right: 0, bottom: 0, left: 0 }
 
@@ -300,8 +315,7 @@ const _renderMarkUp = async (
                 },
 
                 onError(error) {
-                    console.error(formatError(wrapSSRError("RENDER", error)))
-                    console.error(error)
+                    logSSRError("RENDER", error)
                     safeCall(onRenderError, { req, res, store, error })
                     cleanupSafeArea()
                     tail.destroy(error)
@@ -311,8 +325,7 @@ const _renderMarkUp = async (
         })
     } catch (error) {
         cleanupSafeArea()
-        console.error(formatError(wrapSSRError("RENDER", error)))
-        console.error(error)
+        logSSRError("RENDER", error)
         safeCall(onRenderError, { req, res, store, error })
         return Promise.reject(error)
     }
@@ -406,8 +419,7 @@ async function _handler(req, res) {
                     )
                 }
             } catch (error) {
-                console.error(formatError(wrapSSRError("FETCHER", error)))
-                console.error(error)
+                logSSRError("FETCHER", error)
                 safeCall(onFetcherError, { req, res, store, error })
 
                 if (res.headersSent) return
@@ -426,8 +438,7 @@ async function _handler(req, res) {
                 )
             }
         } catch (error) {
-            console.error(formatError(wrapSSRError("SERVER_SIDE_FUNCTION", error)))
-            console.error(error)
+            logSSRError("SERVER_SIDE_FUNCTION", error)
             safeCall(onAppServerSideError, { req, res, store, error })
 
             if (res.headersSent) return
@@ -446,8 +457,7 @@ async function _handler(req, res) {
             )
         }
     } catch (error) {
-        console.error(formatError(wrapSSRError("REQUEST_HANDLING", error)))
-        console.error(error)
+        logSSRError("REQUEST_HANDLING", error)
         safeCall(onRequestError, { req, res, error })
     }
 }

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -36,9 +36,10 @@ import { wrapSSRError, formatError } from "../../errors/index.js"
 import { resolveOutputMode, getDebugEnvInfo } from "../../scripts/scriptUtils.js"
 
 // Resolved once at module load — spawned via serve.js/start.js, which
-// forward the mode as CATALYST_OUTPUT_MODE (no argv available at this
-// level; see scriptUtils.js#resolveOutputMode).
-const outputMode = resolveOutputMode(process.argv, process.env)
+// forward the mode as CATALYST_OUTPUT_MODE. Passed an empty argv on purpose:
+// this process never sees the parent's CLI flags, so process.argv here would
+// never contain --debug/--verbose — only CATALYST_OUTPUT_MODE is real input.
+const outputMode = resolveOutputMode([], process.env)
 // Debug mode's boxed output already embeds the full stack trace (see
 // errors/index.js#formatDebug), so only default/verbose need the original
 // error printed separately to avoid losing the stack.

--- a/packages/catalyst-core/src/server/utils/validator.js
+++ b/packages/catalyst-core/src/server/utils/validator.js
@@ -4,9 +4,9 @@ import { resolveOutputMode, getDebugEnvInfo } from "../../scripts/scriptUtils.js
 
 // Resolved once at module load — this module runs inside expressServer.js,
 // spawned by serve.js/start.js which forward the mode via
-// CATALYST_OUTPUT_MODE (no argv available at this level; see
-// scriptUtils.js#resolveOutputMode).
-const outputMode = resolveOutputMode(process.argv, process.env)
+// CATALYST_OUTPUT_MODE. Passed an empty argv on purpose: this process never
+// sees the parent's CLI flags, so only CATALYST_OUTPUT_MODE is real input.
+const outputMode = resolveOutputMode([], process.env)
 
 const handleError = (e) => {
     const debugEnv = outputMode === "debug" ? getDebugEnvInfo() : undefined

--- a/packages/catalyst-core/src/server/utils/validator.js
+++ b/packages/catalyst-core/src/server/utils/validator.js
@@ -1,8 +1,20 @@
 import pc from "ansis"
 import { createError, formatError, ERROR_CODES } from "../../errors/index.js"
+import { resolveOutputMode, getDebugEnvInfo } from "../../scripts/scriptUtils.js"
+
+// Resolved once at module load — this module runs inside expressServer.js,
+// spawned by serve.js/start.js which forward the mode via
+// CATALYST_OUTPUT_MODE (no argv available at this level; see
+// scriptUtils.js#resolveOutputMode).
+const outputMode = resolveOutputMode(process.argv, process.env)
 
 const handleError = (e) => {
-    console.log(pc.red("Failed to start server: "), formatError(e))
+    const debugEnv = outputMode === "debug" ? getDebugEnvInfo() : undefined
+    if (outputMode === "default") {
+        console.log(pc.red("Failed to start server: "), formatError(e, outputMode))
+    } else {
+        console.log(formatError(e, outputMode, debugEnv))
+    }
 }
 
 const validatePreInitServer = (fn) => {
@@ -142,7 +154,8 @@ const safeCall = (fn, ...args) => {
         return fn(...args)
     } catch (e) {
         const wrapped = createError(ERROR_CODES.PROCESS_USER_HOOK_FAILED, { cause: e })
-        console.error(formatError(wrapped))
+        const debugEnv = outputMode === "debug" ? getDebugEnvInfo() : undefined
+        console.error(formatError(wrapped, outputMode, debugEnv))
     }
 }
 
@@ -161,7 +174,8 @@ const safeCallNamed = (hookName, fn, ...args) => {
             details: `The "${hookName}" hook threw. See the cause below.`,
             cause: e,
         })
-        console.error(formatError(wrapped))
+        const debugEnv = outputMode === "debug" ? getDebugEnvInfo() : undefined
+        console.error(formatError(wrapped, outputMode, debugEnv))
     }
 }
 

--- a/packages/create-catalyst-app/scripts/cli.cjs
+++ b/packages/create-catalyst-app/scripts/cli.cjs
@@ -9,7 +9,15 @@ const path = require("path")
 const fs = require("fs")
 var validate = require("validate-npm-package-name")
 const packageJson = require("../package.json")
-const { CCAError, createError, wrapForeignError, formatError } = require("./errors.cjs")
+const { CCAError, createError, wrapForeignError, formatError, resolveOutputMode, getDebugEnvInfo } = require("./errors.cjs")
+const outputMode = resolveOutputMode(process.argv)
+// Colored (red) prefix only applies in default mode — verbose/debug boxes
+// own their coloring internally (see errors.cjs#box).
+const printError = (err) => {
+    const debugEnv = outputMode === "debug" ? getDebugEnvInfo() : undefined
+    const formatted = formatError(err, outputMode, debugEnv)
+    console.error(outputMode === "default" ? red(formatted) : formatted)
+}
 const packageRoot = path.join(__dirname, "..")
 const executable = (command) => (process.platform === "win32" ? `${command}.cmd` : command)
 
@@ -67,27 +75,19 @@ const program = new Commander.Command()
             let isNameValid = validate(projectName)
             if (!isNameValid.validForNewPackages) {
                 const reasons = [...(isNameValid?.warnings || []), ...(isNameValid?.errors || [])]
-                console.error(
-                    red(
-                        formatError(
-                            createError("CCA-001", {
-                                details: reasons.length ? reasons.join("; ") : undefined,
-                            })
-                        )
-                    )
+                printError(
+                    createError("CCA-001", {
+                        details: reasons.length ? reasons.join("; ") : undefined,
+                    })
                 )
                 process.exit(1)
             }
             let projectPath = path.join(process.cwd(), projectName)
             if (fs.existsSync(projectPath)) {
-                console.error(
-                    red(
-                        formatError(
-                            createError("CCA-002", {
-                                message: `${projectName} already exists, try again.`,
-                            })
-                        )
-                    )
+                printError(
+                    createError("CCA-002", {
+                        message: `${projectName} already exists, try again.`,
+                    })
                 )
                 process.exit(1)
             }
@@ -171,7 +171,7 @@ const program = new Commander.Command()
                     }
                 } catch (error) {
                     const catalystError = error instanceof CCAError ? error : wrapForeignError(error)
-                    console.error(red(formatError(catalystError)))
+                    printError(catalystError)
                     process.exit(1)
                 } finally {
                     deleteDirectory(tempDir)
@@ -243,7 +243,7 @@ const program = new Commander.Command()
             }
         } catch (error) {
             const catalystError = error instanceof CCAError ? error : wrapForeignError(error)
-            console.error(red(formatError(catalystError)))
+            printError(catalystError)
             process.exit(1)
         }
     })
@@ -279,7 +279,7 @@ program
             runMcpSetup(mcpDir)
         } catch (error) {
             const catalystError = error instanceof CCAError ? error : createError("CCA-008", { cause: error })
-            console.error(red(formatError(catalystError)))
+            printError(catalystError)
             process.exit(1)
         }
     })

--- a/packages/create-catalyst-app/scripts/errors.cjs
+++ b/packages/create-catalyst-app/scripts/errors.cjs
@@ -1,3 +1,5 @@
+const pc = require("ansis")
+
 const REPO_BLOB_BASE = "https://github.com/tata1mg/catalyst-core/blob/main/errors"
 
 function docUrl(category, code) {
@@ -150,11 +152,7 @@ function wrapForeignError(err) {
     })
 }
 
-/**
- * Format a CCAError for terminal output. Foreign-wrapped errors always show
- * the original upstream message/code, never a paraphrase of it.
- */
-function formatError(err) {
+function formatDefault(err) {
     const lines = [`[${err.code}] ${err.message}`]
     if (err.cause) {
         const causeMessage = err.cause.message || String(err.cause)
@@ -171,6 +169,137 @@ function formatError(err) {
     return lines.join("\n")
 }
 
+const BOX_WIDTH = 70
+
+function box(bodyLines) {
+    const top = pc.red(`┌${"─".repeat(BOX_WIDTH)}`)
+    const bottom = pc.red(`└${"─".repeat(BOX_WIDTH)}`)
+    const body = bodyLines.map((line) => (line === "" ? pc.red("│") : `${pc.red("│")} ${line}`))
+    return [top, ...body, bottom].join("\n")
+}
+
+function formatCauseChain(cause) {
+    const lines = []
+    let current = cause
+    let depth = 0
+    while (current) {
+        const prefix = depth === 0 ? "Caused by:" : `  ${"  ".repeat(depth - 1)}Caused by:`
+        lines.push(`${prefix} ${current.message || String(current)}`)
+        current = current.cause
+        depth += 1
+    }
+    return lines
+}
+
+/**
+ * Verbose output: boxed per RFC #155 §3.2 — code, category, timestamp,
+ * problem, suggested action, docs link. Mirrors catalyst-core's
+ * errors/index.js#formatVerbose (kept as a separate CJS implementation
+ * since this package can't depend on catalyst-core's ESM module).
+ */
+function formatVerbose(err) {
+    const lines = [
+        pc.bold(`❌ ${err.message}`),
+        `Code: ${err.code}`,
+        `Category: ${err.category || "UNKNOWN"}`,
+        `Time: ${new Date().toISOString()}`,
+        "",
+    ]
+    if (err.cause) {
+        lines.push(`Problem: ${err.cause.message || String(err.cause)}`)
+        lines.push("")
+    } else if (err.details) {
+        lines.push(`Problem: ${err.details}`)
+        lines.push("")
+    }
+    if (err.suggestedAction) {
+        lines.push("Solution:", `  ${err.suggestedAction}`, "")
+    }
+    if (err.docUrl) {
+        lines.push(`Docs: ${err.docUrl}`)
+    }
+    return box(lines)
+}
+
+/**
+ * Debug output: verbose + full cause chain + stack trace + environment
+ * info. Mirrors catalyst-core's errors/index.js#formatDebug.
+ */
+function formatDebug(err, env) {
+    const lines = [
+        pc.bold(`❌ ${err.message}`),
+        `Code: ${err.code}`,
+        `Category: ${err.category || "UNKNOWN"}`,
+        `Time: ${new Date().toISOString()}`,
+        "",
+    ]
+    if (err.cause) {
+        lines.push(...formatCauseChain(err.cause), "")
+    } else if (err.details) {
+        lines.push(`Problem: ${err.details}`, "")
+    }
+    if (err.suggestedAction) {
+        lines.push("Solution:", `  ${err.suggestedAction}`, "")
+    }
+    if (err.docUrl) {
+        lines.push(`Docs: ${err.docUrl}`, "")
+    }
+    if (env) {
+        lines.push("Environment:")
+        for (const [key, value] of Object.entries(env)) {
+            lines.push(`  ${key}: ${value}`)
+        }
+        lines.push("")
+    }
+    lines.push("Stack trace:")
+    const stack = (err.cause && err.cause.stack) || err.stack || "(no stack available)"
+    lines.push(...stack.split("\n").map((l) => `  ${l}`))
+    return box(lines)
+}
+
+/**
+ * Format a CCAError for terminal output. Foreign-wrapped errors always show
+ * the original upstream message/code, never a paraphrase of it.
+ *
+ * `mode` mirrors catalyst-core's formatError(err, mode, env) signature —
+ * defaults to "default" so existing single-arg call sites are unaffected.
+ */
+function formatError(err, mode = "default", env) {
+    if (mode === "debug") return formatDebug(err, env)
+    if (mode === "verbose") return formatVerbose(err)
+    return formatDefault(err)
+}
+
+/**
+ * Resolve output mode from CLI args, mirroring catalyst-core's
+ * scripts/scriptUtils.js#resolveOutputMode (bare --verbose/--debug flags,
+ * not key=value pairs).
+ */
+function resolveOutputMode(argv) {
+    const args = argv || process.argv
+    if (args.includes("--debug")) return "debug"
+    if (args.includes("--verbose")) return "verbose"
+    return "default"
+}
+
+/**
+ * Environment info for debug-mode output: CCA's own installed version, Node
+ * version, and platform. Mirrors catalyst-core's scriptUtils.js#getDebugEnvInfo.
+ */
+function getDebugEnvInfo() {
+    let ccaVersion = "unknown"
+    try {
+        ccaVersion = require("../package.json").version
+    } catch {
+        // package.json not resolvable — leave as "unknown"
+    }
+    return {
+        node: process.version,
+        platform: process.platform,
+        createCatalystApp: ccaVersion,
+    }
+}
+
 module.exports = {
     ERROR_CODES,
     ERROR_DEFINITIONS,
@@ -178,5 +307,7 @@ module.exports = {
     createError,
     wrapForeignError,
     formatError,
+    resolveOutputMode,
+    getDebugEnvInfo,
     getDocUrl,
 }


### PR DESCRIPTION
## Summary

Closes #360. Implements the three RFC #155 §3.2 output modes (default/`--verbose`/`--debug`) across every module system in the codebase: catalyst-core (ESM), create-catalyst-app (CJS), and `src/native`'s CJS-only buildApp scripts.

## What changed

**ESM core** (`errors/index.js`, `scripts/scriptUtils.js`): `formatError(err, mode, env)` — mode is a parameter, not module state, so `WebBridge.js` (browser, no `process.argv`) is unaffected and keeps getting default-mode output. `resolveOutputMode(argv, env)` uses the existing `--inspect`-style bare-flag convention (`serve.js`), not `arrayToObject` (which drops valueless flags). Wired into `build.js`, `server/utils/validator.js`, `handler.jsx` (5 sites from #386/#391), with `serve.js`/`start.js` forwarding the resolved mode to the spawned `expressServer.js` child via `CATALYST_OUTPUT_MODE`.

**CCA** (`create-catalyst-app/scripts/errors.cjs`, `cli.cjs`): mirrors the ESM implementation in CJS. 5 genuine error call sites wired; the CCA-009 `.gitignore`-exists notice (informational, not an error) intentionally left at default-mode-only.

**Native** (`buildAppAndroid.js`/`buildAppIos.js`): neither called `formatError` before — hand-written single-line strings, since `src/native` is CJS-only and can't reach the ESM `errors/index.js`. Added a shared `src/native/buildErrorFormat.js` rather than duplicating the box/mode logic. iOS's error path bypasses `progress.log` (which prefixes every call with an icon/color, incompatible with a multi-line box) in favor of plain `console.error`, matching Android.

**Also fixed**: `registry.js#getDefinition()`'s fallback previously mislabeled unrecognized codes as `RUNTIME-NATIVE` — now surfaces as `Category: UNKNOWN`, motivated by the new `Category:` line added to verbose/debug output (not in the original RFC example, but genuinely useful and already-available data).

## Also in this stack (separate PRs, prerequisite work found along the way)

- #391 (was #387, closed/reopened after a branch restack — see below): `RUNTIME-WEB-xxx` category + `handler.jsx` SSR wiring
- #390: `picocolors` → `ansis` migration, needed because `picocolors` doesn't correctly re-apply color across `\n` line breaks in multi-line strings (this PR's boxed verbose/debug output)

## Branch restack note

This branch (and #386/#389 beneath it) was rebased from `story/6-error-handling` onto `feature/372-cca`, since CCA's `errors.cjs` (needed for this PR's CCA scope) didn't exist on the old base. GitHub refused to retarget PR #387's base in place once it detected a stack relationship, so #387 was closed and replaced by #391 with the corrected base. No PR content changed, only the base branch.

## Filed separately (found during verification, out of scope here)

- #392: pre-existing `ERR_REQUIRE_ESM` bug in `native/bridge/errors.js` during `catalyst build`'s offline manifest generation — reproduced identically on a clean `feature/372-cca` checkout with none of this stack's changes, confirmed not caused by this work.

## Test plan

- [x] All 3 modes manually verified against real `CatalystError`/`CCAError` instances (ESM + CJS), including multi-line cause chains and unknown-code category fallback
- [x] `resolveOutputMode` precedence tested: argv flag beats inherited env var, invalid env values ignored, all combinations
- [x] `ansis` multi-line color re-application confirmed working inside the box format
- [x] `catalyst buildApp` (no platform suffix) confirmed to forward `--verbose`/`--debug` to both native scripts via `bin/catalyst.js`'s `scriptArgs`
- [x] `npm pack --dry-run` on create-catalyst-app confirmed clean with the new `ansis` dependency
- [x] Ran `npm run test:example -- examples/useai --only web` against this branch — `start` (dev server) passes; `build`/`serve` fail on a pre-existing, unrelated bug (#392), confirmed via baseline comparison on `feature/372-cca` with none of this stack's changes
- [ ] eslint not run locally (no resolvable `eslint.config.js` from these directories) — CI is the first real lint gate
