### PR TITLE
fix(vite): detect CommonJS by parsing, not by matching source text

### DIFF
--- a/.release-meta.json
+++ b/.release-meta.json
@@ -3,12 +3,12 @@
   "packages": {
     "catalyst-core": {
       "publish": true,
-      "version": "0.3.0-beta.3"
+      "version": "0.3.0-beta.4"
     },
     "create-catalyst-app": {
       "publish": true,
-      "version": "0.3.0-beta.3",
-      "templateCatalystCoreVersion": "0.3.0-beta.3"
+      "version": "0.3.0-beta.4",
+      "templateCatalystCoreVersion": "0.3.0-beta.4"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8903,7 +8903,7 @@
             }
         },
         "packages/catalyst-core": {
-            "version": "0.3.0-beta.3",
+            "version": "0.3.0-beta.4",
             "license": "MIT",
             "dependencies": {
                 "@vitejs/plugin-react": "^4.4.1",
@@ -9101,7 +9101,7 @@
             "license": "MIT"
         },
         "packages/create-catalyst-app": {
-            "version": "0.3.0-beta.3",
+            "version": "0.3.0-beta.4",
             "license": "MIT",
             "dependencies": {
                 "commander": "^8.2.0",

--- a/packages/catalyst-core/package.json
+++ b/packages/catalyst-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "catalyst-core",
-    "version": "0.3.0-beta.3",
+    "version": "0.3.0-beta.4",
     "type": "module",
     "main": "./dist/index.jsx",
     "description": "Web framework that provides great performance out of the box",

--- a/packages/catalyst-core/src/vite/node-loader.mjs
+++ b/packages/catalyst-core/src/vite/node-loader.mjs
@@ -308,8 +308,36 @@ function isValidExportName(name) {
 // Loader-scoped require for discovering CJS exports
 const loaderRequire = createRequire(import.meta.url)
 
-const CJS_PATTERN = /\b(module\.exports\b|exports\.\w+\s*=)/
 const REQUIRE_CALL_PATTERN = /\brequire\s*\(/
+
+/**
+ * Decide whether a source file is really CommonJS by parsing it, not by
+ * regex-matching the raw text.
+ *
+ * A regex like /module\.exports\b/ cannot tell code from text, so any file that
+ * merely *mentions* module.exports inside a string, comment or template literal
+ * was misclassified as CJS. When such a file was real ESM with its own
+ * `export default`, the CJS shim appended a second one and Node failed the
+ * module with "Duplicate export of 'default'". Docs sites hit this constantly:
+ * a Markdown page documenting a CJS config compiles into a string literal in
+ * the bundled ESM output. Do not reintroduce source-regex detection.
+ *
+ * esbuild parses properly and lowers CJS itself, so a file it wraps in its
+ * __commonJS helper had no ESM syntax of its own — that is the CJS signal.
+ */
+function isCjsSource(source, filePath) {
+    try {
+        const { code } = transformSync(source, {
+            loader: "jsx",
+            format: "esm",
+            sourcefile: filePath,
+            target: "node20",
+        })
+        return /\bvar __commonJS =/.test(code)
+    } catch {
+        return false
+    }
+}
 
 // Shim __dirname and __filename for ESM app files (these globals only exist in CJS)
 const createDirnameShim = (source) => {
@@ -396,7 +424,7 @@ export async function load(url, context, defaultLoad) {
         // We can't use createRequire here because the file lives in a "type":"module"
         // package — Node's CJS require refuses to load it. Instead, we wrap the
         // source inline so that `module.exports` becomes the default export.
-        if (CJS_PATTERN.test(source)) {
+        if (isCjsSource(source, filePath)) {
             const shimmed = [
                 createRequireShim(source),
                 createDirnameShim(source),

--- a/packages/create-catalyst-app/package.json
+++ b/packages/create-catalyst-app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "create-catalyst-app",
     "bin": "scripts/cli.cjs",
-    "version": "0.3.0-beta.3",
+    "version": "0.3.0-beta.4",
     "description": "cli package to scaffold Catalyst application",
     "repository": {
         "type": "git",

--- a/packages/create-catalyst-app/templates/none-js/package.json
+++ b/packages/create-catalyst-app/templates/none-js/package.json
@@ -22,7 +22,7 @@
         "@routes": "src/js/routes/"
     },
     "dependencies": {
-        "catalyst-core": "0.3.0-beta.3",
+        "catalyst-core": "0.3.0-beta.4",
         "react": "19.0.0",
         "react-dom": "19.0.0"
     },

--- a/packages/create-catalyst-app/templates/none-ts/package.json
+++ b/packages/create-catalyst-app/templates/none-ts/package.json
@@ -23,7 +23,7 @@
         "@routes": "src/js/routes/"
     },
     "dependencies": {
-        "catalyst-core": "0.3.0-beta.3",
+        "catalyst-core": "0.3.0-beta.4",
         "react": "19.0.0",
         "react-dom": "19.0.0"
     },

--- a/packages/create-catalyst-app/templates/redux-js/package.json
+++ b/packages/create-catalyst-app/templates/redux-js/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@reduxjs/toolkit": "^2.9.0",
         "react-redux": "^9.2.0",
-        "catalyst-core": "0.3.0-beta.3",
+        "catalyst-core": "0.3.0-beta.4",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "redux": "^5.0.1"

--- a/packages/create-catalyst-app/templates/redux-ts/package.json
+++ b/packages/create-catalyst-app/templates/redux-ts/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@reduxjs/toolkit": "^2.9.0",
         "react-redux": "^9.2.0",
-        "catalyst-core": "0.3.0-beta.3",
+        "catalyst-core": "0.3.0-beta.4",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "redux": "^5.0.1"

--- a/packages/create-catalyst-app/templates/rtk-js/package.json
+++ b/packages/create-catalyst-app/templates/rtk-js/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@reduxjs/toolkit": "^2.9.0",
         "react-redux": "^9.2.0",
-        "catalyst-core": "0.3.0-beta.3",
+        "catalyst-core": "0.3.0-beta.4",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "redux": "^5.0.1"

--- a/packages/create-catalyst-app/templates/rtk-ts/package.json
+++ b/packages/create-catalyst-app/templates/rtk-ts/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@reduxjs/toolkit": "^2.9.0",
         "react-redux": "^9.2.0",
-        "catalyst-core": "0.3.0-beta.3",
+        "catalyst-core": "0.3.0-beta.4",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "redux": "^5.0.1"


### PR DESCRIPTION
## Problem

The node loader decided whether an app file was CommonJS by regex-testing its source for `module.exports`:

```js
const CJS_PATTERN = /\b(module\.exports\b|exports\.\w+\s*=)/
```

A regex cannot tell code from text. Any file that merely *mentions* `module.exports` — in a string, comment, or template literal — was treated as CommonJS and had `export default module.exports` appended. When that file was real ESM with its own default export, Node rejected it:

```
SyntaxError: Duplicate export of 'default'
```

## Why this is easy to hit

It comes from content, not code. A docs page documenting a CommonJS config compiles its fenced sample into a string literal, which Vite then inlines into the bundled ESM server output. The whole server fails to boot, and **the error names no file**.

That is exactly how it was found: two pages in `docs/content` document `webpackConfig.js` and the React Compiler config. Their code samples were enough to break the entire docs SSR bundle.

## Fix

Ask esbuild instead of a regex. It parses properly, so a mention inside a string is ignored while genuine CommonJS is still lowered and shimmed as before. The signal is whether esbuild wrapped the output in its `__commonJS` helper — that only happens for a file with no ESM syntax of its own.

## Verification

- The docs SSR bundle that surfaced this fails to import on the previous loader and loads cleanly now
- Fixture cases covering plain ESM, real CommonJS, CommonJS using `require`/`__dirname`, and named exports from CommonJS all behave as before

## Note for the release

`packages/catalyst-core/package.json` is currently at `0.3.0-beta.3`, which is already published — it needs a bump before this can ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)