### PR TITLE
fix(vite): bundle react-router/react-helmet into SSR output to dedupe React

### DIFF
--- a/packages/catalyst-core/src/vite/vite.config.js
+++ b/packages/catalyst-core/src/vite/vite.config.js
@@ -362,6 +362,15 @@ export const isNodeOnlyExternal = (id) =>
     id === "@grpc/grpc-js" ||
     id.startsWith("@opentelemetry/")
 
+// React-consuming packages that must be bundled into the SSR output (ssr.noExternal)
+// rather than externalized. When left external, each package's `require("react")` resolves
+// relative to its own (often hoisted, monorepo-root) location — which in a mixed React 18/19
+// monorepo can be a different React instance than the app's react-dom/server, producing
+// "$$typeof" element mismatches ("Objects are not valid as a React child"). Bundling hoists
+// their `import "react"` into the SSR bundle so it resolves (via resolve.dedupe below) to the
+// app's single React instance across the whole server render tree.
+const ssrBundledReactDeps = ["react-router-dom", "react-router", "react-helmet-async"]
+
 export default defineConfig({
     // Parallel `vite build` (SSR + client) must use separate dirs or Vite will block on shared `node_modules/.vite`.
     cacheDir: path.join(
@@ -372,6 +381,9 @@ export default defineConfig({
     ssr: {
         // Keep selected React-side packages bundled for SSR (transformed by Vite, NOT pre-bundled)
         // noExternal: ["@tata1mg/slowboi-react"],
+        // Bundle React-consuming router/helmet packages so they share the app's single React
+        // instance (see ssrBundledReactDeps above for the full rationale).
+        noExternal: ssrBundledReactDeps,
         // Ensure Node-only instrumentation and low-level Node deps stay external so
         // the bundler never tries to resolve the optional (opt-in) OTEL packages.
         external: nodeOnlyExternalDeps,


### PR DESCRIPTION
## Problem

In a monorepo mixing **React 18 and 19**, `react-router-dom`, `react-router`, and `react-helmet-async` are commonly hoisted to the root `node_modules` (shared with the React 18 apps). For SSR they were left **external**, so at runtime each package's `require("react")` resolved relative to its own (root) location and bound to **React 18**, while the app's `react-dom/server` resolved to **React 19**.

React 19's renderer then rejects the React 18 elements (`$$typeof` mismatch: `react.element` vs `react.transitional.element`):

```
Error: Objects are not valid as a React child
(found: object with keys {$$typeof, type, key, ref, props, _owner})
```

## Fix

Add these packages to `ssr.noExternal` so Vite **bundles** them into the SSR output. Once bundled, their `import "react"` is hoisted into the SSR bundle and resolves (via the existing `resolve.dedupe`) to the app's **single** React instance — matching `react-dom/server` across the whole server render tree.

```js
const ssrBundledReactDeps = ["react-router-dom", "react-router", "react-helmet-async"]
// ...
ssr: {
    noExternal: ssrBundledReactDeps,
    external: nodeOnlyExternalDeps,
    ...
}
```

Because the `ssr` config is shared, this covers **both** dev (`start`) and prod (`build`/`serve`).

## Notes
- No effect on single-React-version apps: `noExternal` only changes *where* `react` resolves from; `dedupe` already guaranteed a single copy — this makes it hold for these deps under SSR too.
- Client build was already unaffected (it bundles these via `manualChunks`); this brings SSR in line.

## Testing
Verified against an app on React 19 within a mixed 18/19 monorepo:
- **Before:** `renderToPipeableStream` threw the `$$typeof` error on every SSR render.
- **After:** SSR renders successfully (full HTML + hydration state), in both dev and production `serve`. Confirmed the built SSR bundle externalizes only `react`, `react/jsx-runtime`, `react-dom/server` (all one React instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)