### PR TITLE
test: convert test folders to TypeScript across all 4 packages (#420)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
             "devDependencies": {
                 "husky": "^9.0.11",
                 "lint-staged": "^15.2.2"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@babel/cli": {
@@ -2543,6 +2546,326 @@
         "node_modules/@types/use-sync-external-store": {
             "version": "0.0.6",
             "license": "MIT"
+        },
+        "node_modules/@typescript/typescript-aix-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+            "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+            "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+            "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+            "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+            "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+            "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-loong64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+            "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-mips64el": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+            "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+            "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-riscv64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+            "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-s390x": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+            "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+            "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-sunos-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+            "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+            "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+            "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
         },
         "node_modules/@ungap/structured-clone": {
             "version": "1.3.1",
@@ -9250,6 +9573,8 @@
             "hasInstallScript": true,
             "license": "MIT",
             "devDependencies": {
+                "@types/node": "^22.20.1",
+                "typescript": "^7.0.2",
                 "vitest": "^4.1.11"
             },
             "peerDependencies": {
@@ -9260,6 +9585,55 @@
                     "optional": false
                 }
             }
+        },
+        "packages/catalyst-ai/node_modules/@types/node": {
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "packages/catalyst-ai/node_modules/typescript": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc"
+            },
+            "engines": {
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/typescript-aix-ppc64": "7.0.2",
+                "@typescript/typescript-darwin-arm64": "7.0.2",
+                "@typescript/typescript-darwin-x64": "7.0.2",
+                "@typescript/typescript-freebsd-arm64": "7.0.2",
+                "@typescript/typescript-freebsd-x64": "7.0.2",
+                "@typescript/typescript-linux-arm": "7.0.2",
+                "@typescript/typescript-linux-arm64": "7.0.2",
+                "@typescript/typescript-linux-loong64": "7.0.2",
+                "@typescript/typescript-linux-mips64el": "7.0.2",
+                "@typescript/typescript-linux-ppc64": "7.0.2",
+                "@typescript/typescript-linux-riscv64": "7.0.2",
+                "@typescript/typescript-linux-s390x": "7.0.2",
+                "@typescript/typescript-linux-x64": "7.0.2",
+                "@typescript/typescript-netbsd-arm64": "7.0.2",
+                "@typescript/typescript-netbsd-x64": "7.0.2",
+                "@typescript/typescript-openbsd-arm64": "7.0.2",
+                "@typescript/typescript-openbsd-x64": "7.0.2",
+                "@typescript/typescript-sunos-x64": "7.0.2",
+                "@typescript/typescript-win32-arm64": "7.0.2",
+                "@typescript/typescript-win32-x64": "7.0.2"
+            }
+        },
+        "packages/catalyst-ai/node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true
         },
         "packages/catalyst-core": {
             "version": "0.3.0-beta.3",
@@ -9299,6 +9673,7 @@
                 "@babel/preset-typescript": "^7.24.7",
                 "@commitlint/cli": "^19.3.0",
                 "@commitlint/config-conventional": "^19.2.2",
+                "@types/node": "^22.20.1",
                 "eslint": "^8.26.0",
                 "eslint-plugin-babel": "^5.3.1",
                 "eslint-plugin-react": "^7.34.1",
@@ -9309,7 +9684,17 @@
                 "husky": "^9.0.11",
                 "lint-staged": "^15.2.2",
                 "prettier": "^3.2.5",
+                "typescript": "^7.0.2",
                 "vitest": "^4.1.11"
+            }
+        },
+        "packages/catalyst-core/node_modules/@types/node": {
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~6.21.0"
             }
         },
         "packages/catalyst-core/node_modules/dom-serializer": {
@@ -9460,6 +9845,46 @@
             "version": "0.25.0",
             "license": "MIT"
         },
+        "packages/catalyst-core/node_modules/typescript": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc"
+            },
+            "engines": {
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/typescript-aix-ppc64": "7.0.2",
+                "@typescript/typescript-darwin-arm64": "7.0.2",
+                "@typescript/typescript-darwin-x64": "7.0.2",
+                "@typescript/typescript-freebsd-arm64": "7.0.2",
+                "@typescript/typescript-freebsd-x64": "7.0.2",
+                "@typescript/typescript-linux-arm": "7.0.2",
+                "@typescript/typescript-linux-arm64": "7.0.2",
+                "@typescript/typescript-linux-loong64": "7.0.2",
+                "@typescript/typescript-linux-mips64el": "7.0.2",
+                "@typescript/typescript-linux-ppc64": "7.0.2",
+                "@typescript/typescript-linux-riscv64": "7.0.2",
+                "@typescript/typescript-linux-s390x": "7.0.2",
+                "@typescript/typescript-linux-x64": "7.0.2",
+                "@typescript/typescript-netbsd-arm64": "7.0.2",
+                "@typescript/typescript-netbsd-x64": "7.0.2",
+                "@typescript/typescript-openbsd-arm64": "7.0.2",
+                "@typescript/typescript-openbsd-x64": "7.0.2",
+                "@typescript/typescript-sunos-x64": "7.0.2",
+                "@typescript/typescript-win32-arm64": "7.0.2",
+                "@typescript/typescript-win32-x64": "7.0.2"
+            }
+        },
+        "packages/catalyst-core/node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true
+        },
         "packages/create-catalyst-app": {
             "version": "0.3.0-beta.3",
             "license": "MIT",
@@ -9477,8 +9902,19 @@
                 "create-catalyst-app": "scripts/cli.cjs"
             },
             "devDependencies": {
+                "@types/node": "^22.20.1",
                 "prettier": "^3.2.5",
+                "typescript": "^7.0.2",
                 "vitest": "^4.1.11"
+            }
+        },
+        "packages/create-catalyst-app/node_modules/@types/node": {
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~6.21.0"
             }
         },
         "packages/create-catalyst-app/node_modules/commander": {
@@ -9502,6 +9938,46 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "packages/create-catalyst-app/node_modules/typescript": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc"
+            },
+            "engines": {
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/typescript-aix-ppc64": "7.0.2",
+                "@typescript/typescript-darwin-arm64": "7.0.2",
+                "@typescript/typescript-darwin-x64": "7.0.2",
+                "@typescript/typescript-freebsd-arm64": "7.0.2",
+                "@typescript/typescript-freebsd-x64": "7.0.2",
+                "@typescript/typescript-linux-arm": "7.0.2",
+                "@typescript/typescript-linux-arm64": "7.0.2",
+                "@typescript/typescript-linux-loong64": "7.0.2",
+                "@typescript/typescript-linux-mips64el": "7.0.2",
+                "@typescript/typescript-linux-ppc64": "7.0.2",
+                "@typescript/typescript-linux-riscv64": "7.0.2",
+                "@typescript/typescript-linux-s390x": "7.0.2",
+                "@typescript/typescript-linux-x64": "7.0.2",
+                "@typescript/typescript-netbsd-arm64": "7.0.2",
+                "@typescript/typescript-netbsd-x64": "7.0.2",
+                "@typescript/typescript-openbsd-arm64": "7.0.2",
+                "@typescript/typescript-openbsd-x64": "7.0.2",
+                "@typescript/typescript-sunos-x64": "7.0.2",
+                "@typescript/typescript-win32-arm64": "7.0.2",
+                "@typescript/typescript-win32-x64": "7.0.2"
+            }
+        },
+        "packages/create-catalyst-app/node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true
         },
         "packages/create-catalyst-app/node_modules/yallist": {
             "version": "5.0.0",

--- a/packages/catalyst-ai/package.json
+++ b/packages/catalyst-ai/package.json
@@ -9,8 +9,9 @@
     },
     "scripts": {
         "preinstall": "node ./scripts/check-peer.js",
-        "test": "vitest run",
-        "test:watch": "vitest"
+        "test": "npm run test:types && vitest run",
+        "test:watch": "vitest",
+        "test:types": "tsc --noEmit"
     },
     "peerDependencies": {
         "catalyst-core": ">=0.3.0-0"
@@ -27,6 +28,8 @@
         "directory": "packages/catalyst-ai"
     },
     "devDependencies": {
+        "@types/node": "^22.20.1",
+        "typescript": "^7.0.2",
         "vitest": "^4.1.11"
     }
 }

--- a/packages/catalyst-ai/src/route.d.ts
+++ b/packages/catalyst-ai/src/route.d.ts
@@ -1,0 +1,82 @@
+// Hand-written type declaration for route.js — that file stays plain CJS
+// until a future source conversion (see issue #420); this exists only so
+// require("../src/route.js") gets real types in test/route.test.ts instead
+// of `unknown`. Keep in sync with route.js's actual shape by hand for now.
+//
+// Not importing express's own Router type here — catalyst-ai doesn't
+// declare express as a direct dependency (it's provided transitively via
+// catalyst-core), and @types/express isn't installed anywhere in this repo.
+// The real export is an Express router; ExpressRouterLike below only
+// declares the callable/middleware shape this package's own call sites
+// actually touch (expressServer.js does `app.use(aiBasePath, aiRouter)`).
+
+export interface AIProviderConfig {
+    apiKey: string
+    defaultModel?: string
+    [key: string]: unknown
+}
+
+export interface AIConfig {
+    enabled?: boolean
+    basePath?: string
+    providers?: Record<string, AIProviderConfig>
+    [key: string]: unknown
+}
+
+// Common normalized usage shape every provider/API adapter maps onto —
+// see route.js's own "usage normalization" comment block for the exact
+// per-provider field-name differences this papers over.
+export interface NormalizedUsage {
+    model: string
+    promptTokens: number
+    cachedTokens: number
+    completionTokens: number
+    reasoningTokens: number
+}
+
+export interface RequestLike {
+    body?: {
+        messages?: unknown
+        model?: unknown
+        [key: string]: unknown
+    }
+}
+
+export interface ProviderConfigLike {
+    defaultModel?: string
+}
+
+export interface ResponseLike {
+    status: number
+    text(): Promise<string>
+}
+
+export interface RouterInternal {
+    getAIConfig(): AIConfig
+    isAIEnabled(): boolean
+    getProviderConfig(provider: string): AIProviderConfig | null
+    validateRequestBody(req: RequestLike, cfg: ProviderConfigLike): string | null
+    MODEL_NAME_RE: RegExp
+    normalizeOpenAIChatUsage(usage: Record<string, unknown> | null | undefined, model: string): NormalizedUsage | null
+    normalizeOpenAIResponsesUsage(usage: Record<string, unknown> | null | undefined, model: string): NormalizedUsage | null
+    normalizeGeminiUsage(usageMetadata: Record<string, unknown> | null | undefined, model: string): NormalizedUsage | null
+    normalizeGeminiInteractionUsage(usage: Record<string, unknown> | null | undefined, model: string): NormalizedUsage | null
+    throwProviderError(provider: string, response: ResponseLike): Promise<never>
+}
+
+// Minimal shape of what an Express router actually is: a callable request
+// handler with .use()/.get()/.post()/etc. attached. Deliberately not the
+// full express.Router type (see the header comment above).
+export interface ExpressRouterLike {
+    (req: unknown, res: unknown, next: unknown): void
+    use(...args: unknown[]): ExpressRouterLike
+    get(...args: unknown[]): ExpressRouterLike
+    post(...args: unknown[]): ExpressRouterLike
+}
+
+// The real export is an Express Router with _internal attached as an extra
+// property (see route.js's own comment on why).
+export type AIRouter = ExpressRouterLike & { _internal: RouterInternal }
+
+declare const router: AIRouter
+export = router

--- a/packages/catalyst-ai/test/route.test.ts
+++ b/packages/catalyst-ai/test/route.test.ts
@@ -1,8 +1,14 @@
 // describe/it/expect come from vitest's `globals: true` config (see
-// vitest.config.mjs) — vitest's own exports can't be require()'d from a
-// .cjs file, only import'd, so globals keeps this file plain CommonJS
-// throughout, matching route.js's own module system.
-const router = require("../src/route.js")
+// vitest.config.mjs) — vitest's own exports can't be require()'d, only
+// import'd, so globals injects them instead.
+//
+// route.js itself is loaded via require() rather than import — it's a
+// CommonJS module (module.exports = router), matching how every other
+// require("catalyst-ai/route") call site in this repo loads it. Typed
+// against the hand-written declaration in ../src/route.d.ts rather than
+// left as `unknown` (route.js stays plain JS until #420's source
+// conversion).
+const router: typeof import("../src/route.js") = require("../src/route.js")
 const { getAIConfig, isAIEnabled, getProviderConfig, validateRequestBody, MODEL_NAME_RE, normalizeOpenAIChatUsage, normalizeOpenAIResponsesUsage, normalizeGeminiUsage, normalizeGeminiInteractionUsage, throwProviderError } = router._internal
 
 // Framework-level (Tier 1) contract tests for catalyst-ai's route.js
@@ -165,7 +171,7 @@ describe("throwProviderError()", () => {
             await throwProviderError("gemini", fakeResponse)
             expect.unreachable("should have thrown")
         } catch (err) {
-            expect(err.cause.message).toContain("Internal server error from upstream")
+            expect((err as { cause: { message: string } }).cause.message).toContain("Internal server error from upstream")
         }
     })
 })

--- a/packages/catalyst-ai/tsconfig.json
+++ b/packages/catalyst-ai/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        /* Type-checks test/ only (via `tsc --noEmit`) — src/route.js stays
+         * plain JS/CJS until a future source conversion (see issue #420).
+         * This exists for editor/CI type-checking; vitest transpiles .ts
+         * test files via esbuild at run time and doesn't need this config
+         * to execute them. */
+        "target": "es2022",
+        "lib": ["es2022"],
+        "module": "node16",
+        "moduleResolution": "node16",
+        "allowJs": true,
+        "checkJs": false,
+        "strict": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "types": ["node", "vitest/globals"],
+        "noEmit": true
+    },
+    "include": ["test", "src/route.d.ts"],
+    "exclude": ["node_modules"]
+}

--- a/packages/catalyst-ai/vitest.config.mjs
+++ b/packages/catalyst-ai/vitest.config.mjs
@@ -1,17 +1,20 @@
 import { defineConfig } from "vitest/config"
 
 // Framework-level (Tier 1) unit tests for catalyst-ai's own internals — see
-// test/route.test.cjs. route.js exports the Express router as its primary
+// test/route.test.ts. route.js exports the Express router as its primary
 // export (unchanged, for expressServer.js's require("catalyst-ai/route"))
 // with testable pure-logic internals attached as router._internal.
 export default defineConfig({
     test: {
         environment: "node",
-        include: ["test/**/*.test.cjs"],
-        // route.js is CommonJS (see its own header comment on why), and
-        // vitest's describe/it/expect exports can't be require()'d from a
-        // .cjs file — only import'd. globals injects them instead, matching
-        // the same setup used in create-catalyst-app's vitest.config.mjs.
+        include: ["test/**/*.test.ts"],
+        // route.js itself is CommonJS (see its own header comment), loaded
+        // via require() from the .ts test file below. .ts, not .cts: this
+        // Vite/Rollup version's SSR transform doesn't strip TS syntax from
+        // .cts files at all (fails to parse even a single type annotation —
+        // a real tooling gap, confirmed empirically, not a config mistake).
+        // vitest's own describe/it/expect exports can't be require()'d,
+        // only import'd — globals injects them instead.
         globals: true,
     },
 })

--- a/packages/catalyst-core/mcp_v2/package.json
+++ b/packages/catalyst-core/mcp_v2/package.json
@@ -7,13 +7,15 @@
     "scripts": {
         "setup": "node setup.js",
         "start": "node mcp.js",
-        "test": "vitest run",
-        "test:watch": "vitest"
+        "test": "npm run test:types && vitest run",
+        "test:watch": "vitest",
+        "test:types": "tsc --noEmit"
     },
     "dependencies": {
         "better-sqlite3": "^9.4.3"
     },
     "devDependencies": {
+        "typescript": "^7.0.2",
         "vitest": "^4.1.11"
     }
 }

--- a/packages/catalyst-core/mcp_v2/test/errors.test.ts
+++ b/packages/catalyst-core/mcp_v2/test/errors.test.ts
@@ -1,10 +1,15 @@
 // describe/it/expect come from vitest's `globals: true` config (see
-// vitest.config.mjs) — vitest's own exports can't be require()'d from a
-// .cjs file, only import'd, so globals keeps this file plain CommonJS
-// throughout, matching errors.js's own module system.
+// vitest.config.mjs) — vitest's own exports can't be require()'d, only
+// import'd, so globals injects them instead.
+//
+// tools/errors.js itself is loaded via require() rather than import — it's
+// a CommonJS module, matching how it's actually loaded in production.
+// Typed against the hand-written declaration in ../tools/errors.d.ts rather
+// than left as `unknown` (errors.js stays plain JS until #420's source
+// conversion).
 const fs = require("fs")
 const path = require("path")
-const { init, handle_explain_error } = require("../tools/errors.js")
+const { init, handle_explain_error }: typeof import("../tools/errors.js") = require("../tools/errors.js")
 
 // Framework-level (Tier 1) contract tests for the explain_error MCP tool —
 // see issue #340/#411. Covers both real load paths (packaged dist/ copy and
@@ -45,7 +50,7 @@ describe("init() + handle_explain_error() — packaged path (dist/errors-index.j
 })
 
 describe("init() + handle_explain_error() — monorepo-root fallback (errors/index.json)", () => {
-    let packagedBackup
+    let packagedBackup: Buffer | undefined
 
     beforeAll(() => {
         // Force the fallback path: temporarily move the packaged copy aside
@@ -86,7 +91,7 @@ describe("init() + handle_explain_error() — monorepo-root fallback (errors/ind
 })
 
 describe("init() — neither path resolvable", () => {
-    let packagedBackup
+    let packagedBackup: Buffer | undefined
 
     beforeAll(() => {
         if (fs.existsSync(PACKAGED_INDEX_PATH)) {

--- a/packages/catalyst-core/mcp_v2/tools/errors.d.ts
+++ b/packages/catalyst-core/mcp_v2/tools/errors.d.ts
@@ -1,0 +1,20 @@
+// Hand-written type declaration for errors.js — that file stays plain CJS
+// until a future source conversion (see issue #420); this exists only so
+// require("../tools/errors.js") gets real types in test/errors.test.ts
+// instead of `unknown`. Keep in sync with errors.js's actual shape by hand
+// for now.
+
+export interface ExplainErrorResult {
+    code?: string
+    error?: string
+    is_catalyst_owned?: boolean
+    category?: string
+    message?: string
+    details?: string
+    suggestedAction?: string
+    docUrl?: string
+    note?: string
+}
+
+export function init(): void
+export function handle_explain_error(args?: { code?: string }): ExplainErrorResult

--- a/packages/catalyst-core/mcp_v2/tsconfig.json
+++ b/packages/catalyst-core/mcp_v2/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        /* Type-checks test/ only (via `tsc --noEmit`) — tools/errors.js stays
+         * plain JS/CJS until a future source conversion (see issue #420).
+         * This exists for editor/CI type-checking; vitest transpiles .ts
+         * test files via esbuild at run time and doesn't need this config
+         * to execute them. mcp_v2 isn't an npm workspace, so typescript/
+         * @types/node resolve here via hoisting from the parent
+         * packages/catalyst-core workspace, not a local install. */
+        "target": "es2022",
+        "lib": ["es2022"],
+        "module": "node16",
+        "moduleResolution": "node16",
+        "allowJs": true,
+        "checkJs": false,
+        "strict": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "types": ["node", "vitest/globals"],
+        "noEmit": true
+    },
+    "include": ["test", "tools/errors.d.ts"],
+    "exclude": ["node_modules"]
+}

--- a/packages/catalyst-core/mcp_v2/vitest.config.mjs
+++ b/packages/catalyst-core/mcp_v2/vitest.config.mjs
@@ -9,10 +9,14 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
     test: {
         environment: "node",
-        include: ["test/**/*.test.cjs"],
-        // This package is CommonJS and vitest's describe/it/expect exports
-        // can't be require()'d from a .cjs file, only import'd — globals
-        // injects them instead, same pattern as the other CJS packages here.
+        include: ["test/**/*.test.ts"],
+        // tools/errors.js itself is CommonJS, loaded via require() from the
+        // .ts test file below. .ts, not .cts: this Vite/Rollup version's SSR
+        // transform doesn't strip TS syntax from .cts files at all (fails to
+        // parse even a single type annotation — a real tooling gap,
+        // confirmed empirically, not a config mistake). vitest's own
+        // describe/it/expect exports can't be require()'d, only import'd —
+        // globals injects them instead.
         globals: true,
     },
 })

--- a/packages/catalyst-core/package.json
+++ b/packages/catalyst-core/package.json
@@ -34,8 +34,9 @@
         "prettify": "prettier . --write",
         "prepare": "node ../../scripts/safe-rimraf.js ./dist && cp -r ./src ./dist && babel src/native --out-dir dist/native --config-file ./babel.native.config.cjs --ignore '**/.build/**' && babel src/sentry.js --out-file dist/sentry.cjs --config-file ./babel.native.config.cjs && node ./mcp_v2/scripts/copyErrorsIndex.cjs",
         "prepublishOnly": "npm run prepare",
-        "test": "vitest run",
+        "test": "npm run test:types && vitest run",
         "test:watch": "vitest",
+        "test:types": "tsc -p tsconfig.test.json --noEmit",
         "test:fixture": "sh ../../scripts/test-catalyst-core.sh"
     },
     "license": "MIT",
@@ -71,6 +72,7 @@
         "@babel/preset-typescript": "^7.24.7",
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
+        "@types/node": "^22.20.1",
         "eslint": "^8.26.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-react": "^7.34.1",
@@ -81,6 +83,7 @@
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
+        "typescript": "^7.0.2",
         "vitest": "^4.1.11"
     },
     "lint-staged": {

--- a/packages/catalyst-core/test/errors/docsDrift.test.ts
+++ b/packages/catalyst-core/test/errors/docsDrift.test.ts
@@ -17,7 +17,18 @@ const __dirname = path.dirname(__filename)
 // test/errors -> repo root /errors (the committed output)
 const COMMITTED_ERRORS_DIR = path.resolve(__dirname, "../../../../errors")
 
-let scratchDir
+// Shape of one errors/index.json entry, as written by generateDocs.js.
+// registry.js/generateDocs.js stay plain JS until #420's source conversion —
+// this type exists only to give the test file real safety in the meantime.
+interface IndexEntry {
+    category: string
+    message: string
+    details: string
+    suggestedAction: string
+    docUrl: string
+}
+
+let scratchDir: string | undefined
 
 afterEach(() => {
     if (scratchDir) rmSync(scratchDir, { recursive: true, force: true })
@@ -29,7 +40,7 @@ describe("generated error docs match committed output (docs-drift check)", () =>
         scratchDir = mkdtempSync(path.join(tmpdir(), "catalyst-core-docs-drift-"))
         generateDocs(scratchDir)
 
-        const mismatches = []
+        const mismatches: string[] = []
         for (const [code, def] of Object.entries(ERROR_DEFINITIONS)) {
             const relPath = path.join(def.category, `${code}.md`)
             const committedPath = path.join(COMMITTED_ERRORS_DIR, relPath)
@@ -50,9 +61,9 @@ describe("generated error docs match committed output (docs-drift check)", () =>
 
     it("committed index.json has an up-to-date entry for every core-owned code", () => {
         const indexPath = path.join(COMMITTED_ERRORS_DIR, "index.json")
-        const committedIndex = JSON.parse(readFileSync(indexPath, "utf8"))
+        const committedIndex: Record<string, IndexEntry> = JSON.parse(readFileSync(indexPath, "utf8"))
 
-        const mismatches = []
+        const mismatches: string[] = []
         for (const [code, def] of Object.entries(ERROR_DEFINITIONS)) {
             const entry = committedIndex[code]
             if (!entry) {
@@ -69,10 +80,10 @@ describe("generated error docs match committed output (docs-drift check)", () =>
 
     it("committed index.json has no stale core-category entry for a code removed from the registry", () => {
         const indexPath = path.join(COMMITTED_ERRORS_DIR, "index.json")
-        const committedIndex = JSON.parse(readFileSync(indexPath, "utf8"))
+        const committedIndex: Record<string, IndexEntry> = JSON.parse(readFileSync(indexPath, "utf8"))
         const ownedCategories = new Set(Object.values(ERROR_DEFINITIONS).map((d) => d.category))
 
-        const stale = []
+        const stale: string[] = []
         for (const [code, entry] of Object.entries(committedIndex)) {
             if (ownedCategories.has(entry.category) && !(code in ERROR_DEFINITIONS)) {
                 stale.push(`${code}: stale entry in errors/index.json — its category ("${entry.category}") is core-owned but this code no longer exists in the registry`)
@@ -87,7 +98,7 @@ describe("generated error docs match committed output (docs-drift check)", () =>
             Object.entries(ERROR_DEFINITIONS).map(([code, def]) => path.join(def.category, `${code}.md`))
         )
 
-        const stray = []
+        const stray: string[] = []
         for (const category of ownedCategories) {
             const dir = path.join(COMMITTED_ERRORS_DIR, category)
             if (!existsSync(dir)) continue

--- a/packages/catalyst-core/test/errors/index.test.ts
+++ b/packages/catalyst-core/test/errors/index.test.ts
@@ -78,14 +78,17 @@ describe("wrapForeignError()", () => {
     })
 
     it("shows the upstream named error code when present (e.g. Rollup's PLUGIN_LOAD_ERROR)", () => {
-        const original = new Error("failed to load")
+        // .code isn't part of the standard Error interface — it's a Node
+        // convention (see NodeJS.ErrnoException) that upstream build tools
+        // like Rollup also follow for their own error codes.
+        const original: NodeJS.ErrnoException = new Error("failed to load")
         original.code = "PLUGIN_LOAD_ERROR"
         const wrapped = wrapForeignError("BUNDLE", original)
         expect(wrapped.message).toContain("PLUGIN_LOAD_ERROR")
     })
 
     it("does NOT show a bare numeric process exit code as if it were a named upstream code", () => {
-        const original = new Error("process exited")
+        const original = new Error("process exited") as Error & { code: number }
         original.code = 1 // numeric, e.g. a spawned child's exit status — not a named identifier
         const wrapped = wrapForeignError("BUNDLE", original)
         expect(wrapped.message).not.toContain("1")

--- a/packages/catalyst-core/test/errors/registry.test.ts
+++ b/packages/catalyst-core/test/errors/registry.test.ts
@@ -55,8 +55,8 @@ describe("ERROR_CODES / ERROR_DEFINITIONS shape invariants", () => {
     })
 
     it("every definition has all required fields, non-empty", () => {
-        const REQUIRED_FIELDS = ["category", "defaultMessage", "defaultDetails", "suggestedAction"]
-        const problems = []
+        const REQUIRED_FIELDS = ["category", "defaultMessage", "defaultDetails", "suggestedAction"] as const
+        const problems: string[] = []
         for (const [code, def] of Object.entries(ERROR_DEFINITIONS)) {
             for (const field of REQUIRED_FIELDS) {
                 const value = def[field]

--- a/packages/catalyst-core/tsconfig.test.json
+++ b/packages/catalyst-core/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        /* This config is for type-checking test/ only (via `tsc -p tsconfig.test.json --noEmit`)
+         * — separate from tsconfig.json, which is scoped to src/ and configured for
+         * .d.ts emit ahead of a future source-file TS conversion (see issue #420).
+         * Vitest itself transpiles .ts test files via esbuild at run time and doesn't
+         * need this config to execute tests; this exists for editor/CI type-checking. */
+        "types": ["node", "vitest/globals"],
+        "noEmit": true,
+        "emitDeclarationOnly": false,
+        "declaration": false,
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "target": "es2022",
+        "lib": ["es2022"]
+    },
+    "include": ["test"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/catalyst-core/vitest.config.ts
+++ b/packages/catalyst-core/vitest.config.ts
@@ -1,14 +1,17 @@
 import { defineConfig } from "vitest/config"
 
 // Framework-level (Tier 1) unit tests for catalyst-core's own internals —
-// see test/errors/*.test.js. Application-level (Tier 2) integration tests
+// see test/errors/*.test.ts. Application-level (Tier 2) integration tests
 // live in examples/catalyst-core-test and run via scripts/test-catalyst-core.sh,
 // not through vitest (see issue #412).
 export default defineConfig({
     test: {
         environment: "node",
-        include: ["test/**/*.test.js"],
+        include: ["test/**/*.test.ts"],
         // Registry/index.js are ESM and side-effect-free at import time — no
-        // DOM, no server, no global setup needed for Tier 1.
+        // DOM, no server, no global setup needed for Tier 1. Vitest
+        // transpiles .ts test files via esbuild at run time — no separate
+        // build step needed to execute them (tsconfig.test.json is only for
+        // editor/CI type-checking, see its own header comment).
     },
 })

--- a/packages/create-catalyst-app/package.json
+++ b/packages/create-catalyst-app/package.json
@@ -10,8 +10,9 @@
     },
     "scripts": {
         "prettify": "prettier . --write",
-        "test": "vitest run",
-        "test:watch": "vitest"
+        "test": "npm run test:types && vitest run",
+        "test:watch": "vitest",
+        "test:types": "tsc --noEmit"
     },
     "dependencies": {
         "ansis": "^4.3.1",
@@ -24,7 +25,9 @@
         "validate-npm-package-name": "^5.0.0"
     },
     "devDependencies": {
+        "@types/node": "^22.20.1",
         "prettier": "^3.2.5",
+        "typescript": "^7.0.2",
         "vitest": "^4.1.11"
     },
     "license": "MIT"

--- a/packages/create-catalyst-app/scripts/errors.d.cts
+++ b/packages/create-catalyst-app/scripts/errors.d.cts
@@ -1,0 +1,55 @@
+// Hand-written type declaration for errors.cjs — that file stays plain CJS
+// until a future source conversion (see issue #420); this exists only so
+// require("./errors.cjs") gets real types in test/errors.test.cts instead of
+// `unknown`. Keep in sync with errors.cjs's actual shape by hand for now.
+
+export interface ErrorDefinition {
+    category: string
+    defaultMessage: string
+    defaultDetails: string
+    suggestedAction: string
+}
+
+export type ErrorCodes = Record<string, string>
+export type ErrorDefinitions = Record<string, ErrorDefinition>
+
+export interface CCAErrorOverrides {
+    message?: string
+    details?: string
+    suggestedAction?: string
+    category?: string
+    docUrl?: string
+    cause?: unknown
+}
+
+export class CCAError extends Error {
+    code: string
+    category?: string
+    details?: string
+    suggestedAction?: string
+    docUrl?: string
+    cause?: unknown
+    constructor(code: string, overrides?: CCAErrorOverrides)
+}
+
+export type OutputMode = "default" | "verbose" | "debug"
+
+// formatError's debug mode just does Object.entries(env) and prints each
+// key/value — getDebugEnvInfo() always returns all three fields, but any
+// caller (including tests) may legitimately pass a partial record.
+export type DebugEnvInfo = Partial<{
+    node: string
+    platform: string
+    createCatalystApp: string
+}> &
+    Record<string, string>
+
+export const ERROR_CODES: ErrorCodes
+export const ERROR_DEFINITIONS: ErrorDefinitions
+
+export function createError(code: string, overrides?: CCAErrorOverrides): CCAError
+export function wrapForeignError(err: unknown): CCAError
+export function formatError(err: CCAError, mode?: OutputMode, env?: DebugEnvInfo): string
+export function resolveOutputMode(argv?: string[]): OutputMode
+export function getDebugEnvInfo(): DebugEnvInfo
+export function getDocUrl(code: string): string | null

--- a/packages/create-catalyst-app/test/errors.test.ts
+++ b/packages/create-catalyst-app/test/errors.test.ts
@@ -1,8 +1,15 @@
 // describe/it/expect come from vitest's `globals: true` config (see
-// vitest.config.mjs) — vitest's own exports can't be require()'d from a
-// .cjs file, only import'd, so globals keeps this file plain CommonJS
-// throughout, matching errors.cjs's own module system.
-const cca = require("../scripts/errors.cjs")
+// vitest.config.mjs) — vitest's own exports can't be require()'d, only
+// import'd, so globals injects them instead.
+//
+// errors.cjs itself is loaded via require() rather than import — it's a
+// CommonJS module and this keeps the runtime behavior identical to how
+// every other require("./errors.cjs") call site in this package loads it.
+// require(...) is untyped by default, and errors.cjs stays plain JS until a
+// future source conversion (see issue #420), so we annotate it against the
+// hand-written declaration in ../scripts/errors.d.cts rather than let every
+// usage below infer as `unknown`.
+const cca: typeof import("../scripts/errors.cjs") = require("../scripts/errors.cjs")
 
 // Framework-level (Tier 1) contract + parity tests for the CCA error mirror
 // (packages/create-catalyst-app/scripts/errors.cjs). This is a standalone
@@ -55,8 +62,8 @@ describe("CCA ERROR_CODES / ERROR_DEFINITIONS shape invariants (mirrors registry
     })
 
     it("every definition has all required fields, non-empty — same required-field set as the core registry", () => {
-        const REQUIRED_FIELDS = ["category", "defaultMessage", "defaultDetails", "suggestedAction"]
-        const problems = []
+        const REQUIRED_FIELDS = ["category", "defaultMessage", "defaultDetails", "suggestedAction"] as const
+        const problems: string[] = []
         for (const [code, def] of Object.entries(ERROR_DEFINITIONS)) {
             for (const field of REQUIRED_FIELDS) {
                 const value = def[field]
@@ -123,7 +130,9 @@ describe("wrapForeignError() — same never-reinterpret contract as catalyst-cor
     })
 
     it("shows the upstream named code when present", () => {
-        const original = new Error("failed")
+        // .code isn't part of the standard Error interface — it's a Node
+        // convention (see NodeJS.ErrnoException).
+        const original: NodeJS.ErrnoException = new Error("failed")
         original.code = "ENOENT"
         const wrapped = cca.wrapForeignError(original)
         expect(wrapped.message).toContain("ENOENT")
@@ -135,17 +144,17 @@ describe("wrapForeignError() — same never-reinterpret contract as catalyst-cor
     })
 
     it("omits the suffix for an empty or whitespace-only .code too — still typeof \"string\", but not a real name", () => {
-        const emptyCode = new Error("failed")
+        const emptyCode: NodeJS.ErrnoException = new Error("failed")
         emptyCode.code = ""
         expect(cca.wrapForeignError(emptyCode).message).toBe("An upstream command failed")
 
-        const blankCode = new Error("failed")
+        const blankCode: NodeJS.ErrnoException = new Error("failed")
         blankCode.code = "   "
         expect(cca.wrapForeignError(blankCode).message).toBe("An upstream command failed")
     })
 
     it("trims surrounding whitespace off a real named code", () => {
-        const padded = new Error("failed")
+        const padded: NodeJS.ErrnoException = new Error("failed")
         padded.code = "  ENOENT  "
         expect(cca.wrapForeignError(padded).message).toBe("An upstream command failed (upstream: ENOENT)")
     })

--- a/packages/create-catalyst-app/tsconfig.json
+++ b/packages/create-catalyst-app/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        /* Type-checks test/ only (via `tsc --noEmit`) — scripts/errors.cjs and
+         * the rest of create-catalyst-app's source stay plain JS/CJS until a
+         * future source conversion (see issue #420). This exists for
+         * editor/CI type-checking; vitest transpiles .ts test files via
+         * esbuild at run time and doesn't need this config to execute them. */
+        "target": "es2022",
+        "lib": ["es2022"],
+        "module": "node16",
+        "moduleResolution": "node16",
+        "allowJs": true,
+        "checkJs": false,
+        "strict": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "types": ["node", "vitest/globals"],
+        "noEmit": true
+    },
+    "include": ["test"],
+    "exclude": ["node_modules"]
+}

--- a/packages/create-catalyst-app/vitest.config.mjs
+++ b/packages/create-catalyst-app/vitest.config.mjs
@@ -1,19 +1,24 @@
 import { defineConfig } from "vitest/config"
 
 // Framework-level (Tier 1) unit tests for create-catalyst-app's own
-// internals — see test/*.test.cjs. errors.cjs is a standalone CJS mirror of
+// internals — see test/*.test.ts. errors.cjs is a standalone CJS mirror of
 // catalyst-core's error registry shape (it can't depend on catalyst-core —
 // CCA packs/extracts itself before catalyst-core is ever installed), so its
 // parity test lives here rather than in catalyst-core's test suite.
 export default defineConfig({
     test: {
         environment: "node",
-        include: ["test/**/*.test.cjs"],
-        // errors.cjs and its tests are CommonJS (see the file header for why),
-        // and vitest's own describe/it/expect exports can't be require()'d
-        // from a .cjs file — only import'd. globals injects them instead, so
-        // test files stay plain require(...) throughout, matching this
-        // package's module system.
+        include: ["test/**/*.test.ts"],
+        // errors.cjs itself is CommonJS (see its own file header), loaded
+        // via require() from the .ts test file below — TypeScript allows
+        // require() in a .ts file (it's still just a global Node function),
+        // it just doesn't get CJS *emit* semantics the way .cts would.
+        // .cts was tried first and rejected: this Vite/Rollup version's SSR
+        // transform doesn't strip TS syntax from .cts files at all (fails
+        // to parse even a single `const x: number` type annotation) — a
+        // real tooling gap, not a config mistake. vitest's own describe/it/
+        // expect exports can't be require()'d, only import'd — globals
+        // injects them instead.
         globals: true,
     },
 })


### PR DESCRIPTION
## What

Converts the #411 test suites (catalyst-core, catalyst-ai, create-catalyst-app, mcp_v2 — ~94 tests) from JS/CJS to TypeScript. Stacked on `feature/412-playwright-ci` (#422).

Reverses the earlier decision in #420 to defer TS conversion until source is also typed — doing the test-folder conversion now, while it's ~6 files, rather than as a bigger revamp later.

## Per-package changes

| Package | Test files | New tsconfig | New `.d.ts`/`.d.cts` |
|---|---|---|---|
| catalyst-core | `test/**/*.js` → `.ts` | `tsconfig.test.json` (module/moduleResolution: `bundler`, target/lib `es2022`) | — |
| catalyst-ai | `route.test.cjs` → `.ts` | `tsconfig.json` (`node16`/`node16`) | `src/route.d.ts` (types the `_internal` test surface added in #411) |
| create-catalyst-app | `errors.test.cjs` → `.ts` | `tsconfig.json` (`node16`/`node16`) | `scripts/errors.d.cts` |
| mcp_v2 | `errors.test.cjs` → `.ts` | `tsconfig.json` (`node16`/`node16`) | `tools/errors.d.ts` |

Each package's `test` script is now `test:types && vitest run`.

## Notable findings

- **`.cts` doesn't work with this vitest/Vite/Rollup version's SSR transform** — it fails to strip TS syntax entirely, even a single type annotation. All CJS-semantics test files use `.ts` + `require()` instead (TS allows `require()` inside `.ts`, it just doesn't emit CJS wrapper semantics). Documented in each `vitest.config.mjs`.
- **`typescript` was stale at `^5.9.3`** — caught mid-task ("typescript 8 came, why are we on 5?"). Verified actual latest is `7.0.2` (native Go rewrite, "Project Corsa" — there is no 8.x). Upgraded to `^7.0.2` across all 4 packages. TS7 requires Node ≥22.12.0 and is itself ESM-native, reinforcing the Node 22 pin from #412.

## Verified

- All 94 tests pass, all 4 `tsc --noEmit` checks clean, under Node 22 with each package's own local `typescript@7.0.2` (mcp_v2 has no local bin by design — not an npm workspace — and correctly resolves via its own `npm install`).
- **Fresh-install check**: ran the exact sequence CI would run — `git worktree` on this branch, `npm ci` at root + `npm install` in `mcp_v2` (uncached, no pre-existing `node_modules`), then `npm run test:unit`. All 94 tests passed clean on the fresh tree.

## Known gap — not fixed here, flagging for #415

None of the existing `.github/workflows/node.js.yml` jobs invoke `npm run test:unit` (the new `tsc` + `vitest` path) yet — `test-catalyst-core.sh` only runs the Playwright fixture's own `npm run test`. So these new TypeScript tests aren't wired into CI on any Node version yet. That's squarely #415's scope (CI enforcement: new workflow jobs), not this PR's — leaving a note there so it isn't lost. Separately, the job containers (`mcr.microsoft.com/playwright:v1.62.1-noble`) ship Node 24.x, comfortably above the TS7 floor of ≥22.12.0, so no version conflict is expected once wired in.

Refs #420, #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
