### PR TITLE
fix(vite): resolve SSR module-sync condition to fix duplicate react-router instances on Node 22

### DIFF
--- a/src/vite/vite.config.js
+++ b/src/vite/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig, transformWithEsbuild } from "vite"
+import { defineConfig, transformWithEsbuild, defaultServerConditions } from "vite"
 import react from "@vitejs/plugin-react"
 import svgr from "vite-plugin-svgr"
 
@@ -239,6 +239,22 @@ export default defineConfig({
     ssr: {
         // Keep selected React-side packages bundled for SSR (transformed by Vite, NOT pre-bundled)
         // noExternal: ["@tata1mg/slowboi-react"],
+        resolve: {
+            // react-router/react-router-dom v7 ship dual CJS/ESM builds selected via the
+            // "module-sync" exports condition. Node 20.19+/22 understands this condition
+            // and resolves to the real ESM build even via require() — but Vite's SSR
+            // resolver does not know "module-sync" and falls back to the CJS build,
+            // including for packages Vite treats as external and hands off to Node's own
+            // loader (e.g. a consumer dependency that itself imports react-router-dom).
+            // When Vite and Node disagree on which build to load, the app ends up with
+            // two separate react-router module instances — each with its own React
+            // Context — so hooks like useLocation() throw "may be used only in the
+            // context of a <Router>" even though a Router is mounted, because the
+            // Provider populated one Context instance and the consumer read the other.
+            // Adding "module-sync" here makes Vite's resolution agree with Node's.
+            conditions: ["module-sync", ...defaultServerConditions],
+            externalConditions: ["module-sync", ...defaultServerConditions],
+        },
         // Ensure Node-only instrumentation and low-level Node deps stay external so
         // the bundler never tries to resolve the optional (opt-in) OTEL packages.
         external: nodeOnlyExternalDeps,


### PR DESCRIPTION
## Summary
Same fix as #430, targeted at `fix/react-router-v7-upgrade-mweb-master` — the branch mweb actually pins its `catalyst-core` dependency to (`github:tata1mg/catalyst-core#fix/react-router-v7-upgrade-mweb-master`), rather than `main`.

- On Node 22 (20.19+), SSR requests in mweb crashed on every request with `useLocation() may be used only in the context of a <Router> component.` — despite a `<Router>` being mounted. Only reproduced on Node 22, not Node 20.
- Root cause: `react-router`/`react-router-dom` v7 ship dual CJS/ESM builds selected via the `"module-sync"` exports condition. Node 20.19+/22 understands `module-sync` and resolves to the real ESM build even via `require()`. Vite's SSR resolver does not know this condition and falls back to the CJS build — including for packages Vite treats as external and hands off to Node's own loader (e.g. `@tata1mg/slowboi-react`, which itself imports `react-router-dom`).
- When Vite and Node disagree on which build to load, the app ends up with two separate `react-router` module instances in the same process — each with its own React Context — so any hook reading the "wrong" instance's Context throws the Router-context error even though a Router is mounted.
- Fix: add `"module-sync"` to `ssr.resolve.conditions` / `ssr.resolve.externalConditions` so Vite's SSR resolution agrees with Node's, collapsing every consumer onto the same single ESM instance.

## Verification
Instrumented all `react-router`/`react-router-dom`/`@tata1mg/slowboi-react` build files (CJS + ESM) with load markers in mweb (pointed at this exact file via `node_modules/catalyst-core`):
- **Before fix**: `react-router`'s CJS build (`dist/development/index.js`) loaded twice, alongside a separate ESM load — confirming two live instances.
- **After fix**: only the ESM build (`.mjs`) loads, exactly once, for `react-router`, `react-router-dom`, and `@tata1mg/slowboi-react`.
- SSR requests to `/`, `/cart`, `/health-products` on Node 22.18.0 all return clean `200`s with zero occurrences of the crash signature in server logs (previously present on every request).

Byte-identical diff to #430 (same file content, same line numbers) — this branch predates the monorepo restructure so the file lives at `src/vite/vite.config.js` instead of `packages/catalyst-core/src/vite/vite.config.js`.

## Test plan
- [x] Reproduced the crash on Node 22 with a clean `npm ci` install (ruled out local package contamination as the cause)
- [x] Instrumented build files to prove duplicate module instances before the fix
- [x] Applied `ssr.resolve.conditions`/`externalConditions` fix, confirmed single instance per package after
- [x] Verified multiple SSR routes return 200 with no crash-signature log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)