### PR TITLE
test(web-router): add unit tests for src/web-router, raise web coverage 49.69% -> 63.13%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,66 @@
                 "node": ">=22"
             }
         },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+            "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "6.0.7",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+            "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^3.3.0",
+                "@csstools/css-color-parser": "^4.1.10",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0",
+                "lru-cache": "^11.5.2"
+            },
+            "engines": {
+                "node": "^22.13.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+            "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.5.2"
+            },
+            "engines": {
+                "node": "^22.13.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/@babel/cli": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.29.7.tgz",
@@ -1872,6 +1932,19 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
         "node_modules/@colors/colors": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -2225,6 +2298,146 @@
             },
             "engines": {
                 "node": ">=v18"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+            "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+            "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.1.tgz",
+            "integrity": "sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.1.1",
+                "@csstools/css-calc": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.9.tgz",
+            "integrity": "sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@dabh/diagnostics": {
@@ -2752,6 +2965,24 @@
             "license": "MIT",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+            "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -4445,6 +4676,107 @@
                 "@svgr/core": "*"
             }
         },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+            "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@adobe/css-tools": "^4.4.0",
+                "aria-query": "^5.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "picocolors": "^1.1.1",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=22",
+                "npm": ">=6",
+                "yarn": ">=1"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=10 <11",
+                "vitest": ">= 0.32"
+            },
+            "peerDependenciesMeta": {
+                "vitest": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -5196,6 +5528,16 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
         },
+        "node_modules/aria-query": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+            "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -5478,6 +5820,16 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/binary-extensions": {
@@ -6241,6 +6593,27 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/dargs": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
@@ -6252,6 +6625,35 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/data-view-buffer": {
@@ -6331,6 +6733,13 @@
                 }
             }
         },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6392,6 +6801,16 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/destroy": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -6424,6 +6843,13 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/dom-serializer": {
             "version": "3.1.1",
@@ -8268,6 +8694,19 @@
                 "hermes-estree": "0.25.1"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8430,6 +8869,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/inflight": {
@@ -8818,6 +9267,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-regex": {
             "version": "1.2.1",
@@ -9223,6 +9679,57 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "30.0.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+            "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^6.0.5",
+                "@asamuzakjp/dom-selector": "^8.3.0",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+                "@exodus/bytes": "^1.15.1",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.5.2",
+                "parse5": "^8.0.1",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.2",
+                "undici": "^8.9.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^17.1.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.2.3"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -9906,6 +10413,16 @@
                 "yallist": "^3.0.2"
             }
         },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9958,6 +10475,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
@@ -10076,6 +10600,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/minimatch": {
@@ -10626,6 +11160,19 @@
             "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
             "license": "MIT"
         },
+        "node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10816,6 +11363,51 @@
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
+        },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-format/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/prompts": {
             "version": "2.4.2",
@@ -11081,6 +11673,20 @@
             },
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/redux": {
@@ -11603,6 +12209,19 @@
             "funding": {
                 "type": "individual",
                 "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
             }
         },
         "node_modules/scheduler": {
@@ -12153,6 +12772,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -12199,6 +12831,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tar": {
             "version": "7.5.22",
@@ -12332,6 +12971,26 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/tldts": {
+            "version": "7.4.11",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+            "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.4.11"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.4.11",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+            "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12351,6 +13010,32 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+            "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/triple-beam": {
@@ -12563,6 +13248,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/undici": {
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+            "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.19.0"
             }
         },
         "node_modules/undici-types": {
@@ -12928,6 +13623,54 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "17.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+            "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.15.1",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^22.14.0 || >=24.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -13163,6 +13906,23 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -13372,6 +14132,9 @@
                 "@babel/preset-typescript": "^7.24.7",
                 "@commitlint/cli": "^19.3.0",
                 "@commitlint/config-conventional": "^19.2.2",
+                "@testing-library/dom": "10.4.1",
+                "@testing-library/jest-dom": "7.0.1",
+                "@testing-library/react": "16.3.2",
                 "@types/node": "^22.20.1",
                 "@vitest/coverage-v8": "4.1.9",
                 "eslint": "^8.26.0",
@@ -13382,6 +14145,7 @@
                 "eslint-plugin-risxss": "^2.1.0",
                 "eslint-plugin-security": "^3.0.0",
                 "husky": "^9.0.11",
+                "jsdom": "30.0.1",
                 "lint-staged": "^15.2.2",
                 "prettier": "^3.2.5",
                 "typescript": "^7.0.2",

--- a/packages/catalyst-core/package.json
+++ b/packages/catalyst-core/package.json
@@ -85,7 +85,11 @@
         "prettier": "^3.2.5",
         "typescript": "^7.0.2",
         "vitest": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9"
+        "@vitest/coverage-v8": "4.1.9",
+        "@testing-library/react": "16.3.2",
+        "jsdom": "30.0.1",
+        "@testing-library/jest-dom": "7.0.1",
+        "@testing-library/dom": "10.4.1"
     },
     "lint-staged": {
         "*.{js,jsx}": [

--- a/packages/catalyst-core/src/web-router/components/MetaTag.test.jsx
+++ b/packages/catalyst-core/src/web-router/components/MetaTag.test.jsx
@@ -1,0 +1,100 @@
+import React from "react"
+import { describe, expect, it, vi, afterEach } from "vitest"
+import { render, waitFor, act } from "@testing-library/react"
+import { MemoryRouter, Routes, Route, useNavigate } from "react-router-dom"
+import { MetaTag } from "./MetaTag.jsx"
+import { OneMgRouterContext } from "../context.jsx"
+import { RouterContext } from "./RouterDataProvider.jsx"
+
+function renderMetaTag({ matchedRoutes = [], routerData = {} } = {}) {
+    return render(
+        <MemoryRouter initialEntries={["/"]}>
+            <Routes>
+                <Route
+                    path="/"
+                    element={
+                        <OneMgRouterContext.Provider value={{ matchedRoutes }}>
+                            <RouterContext.Provider value={routerData}>
+                                <MetaTag />
+                            </RouterContext.Provider>
+                        </OneMgRouterContext.Provider>
+                    }
+                />
+            </Routes>
+        </MemoryRouter>
+    )
+}
+
+describe("MetaTag", () => {
+    afterEach(() => {
+        document.head.innerHTML = ""
+    })
+
+    it("renders without crashing when there are no matched routes", () => {
+        expect(() => renderMetaTag()).not.toThrow()
+    })
+
+    it("writes tags returned by a matched route's setMetaData into the document head", async () => {
+        const matchedRoutes = [
+            {
+                route: {
+                    component: {
+                        setMetaData: () => [<meta key="d" name="description" content="hello" />],
+                    },
+                },
+            },
+        ]
+        renderMetaTag({ matchedRoutes })
+        await waitFor(() => {
+            expect(document.head.querySelector('meta[name="description"]')).not.toBeNull()
+        })
+        expect(document.head.querySelector('meta[name="description"]').getAttribute("content")).toBe(
+            "hello"
+        )
+    })
+
+    it("keeps the placeholder meta tag when no route provides setMetaData", () => {
+        renderMetaTag({ matchedRoutes: [{ route: { component: {} } }] })
+        // Component should still render (Helmet/HelmetProvider tree),
+        // even with the single empty placeholder <meta> from useState.
+        expect(document.querySelector("head")).not.toBeNull()
+    })
+
+    it("re-runs setMetaData and clears previous tags when the location changes", async () => {
+        // A rerender() with a NEW <MemoryRouter initialEntries> does not
+        // navigate an already-mounted router -- initialEntries is only
+        // read on first mount. Confirmed directly: that approach left
+        // setMetaData called once even after "changing" the path.
+        // Navigating within one mounted router (via a real useNavigate
+        // call, triggered here through a button) is what actually
+        // changes useLocation() and re-fires MetaTag's effect.
+        const setMetaData = vi.fn(() => [<meta key="d" name="description" content="v1" />])
+        const matchedRoutes = [{ route: { component: { setMetaData } } }]
+
+        function NavButton() {
+            const navigate = useNavigate()
+            return (
+                <button type="button" onClick={() => navigate("/b")}>
+                    go
+                </button>
+            )
+        }
+
+        render(
+            <MemoryRouter initialEntries={["/a"]}>
+                <OneMgRouterContext.Provider value={{ matchedRoutes }}>
+                    <RouterContext.Provider value={{}}>
+                        <NavButton />
+                        <MetaTag />
+                    </RouterContext.Provider>
+                </OneMgRouterContext.Provider>
+            </MemoryRouter>
+        )
+        await waitFor(() => expect(setMetaData).toHaveBeenCalledTimes(1))
+
+        await act(async () => {
+            document.querySelector("button").click()
+        })
+        await waitFor(() => expect(setMetaData).toHaveBeenCalledTimes(2))
+    })
+})

--- a/packages/catalyst-core/src/web-router/components/RouterDataProvider.test.jsx
+++ b/packages/catalyst-core/src/web-router/components/RouterDataProvider.test.jsx
@@ -1,0 +1,211 @@
+import React from "react"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter, Routes, Route, useRoutes } from "react-router-dom"
+import {
+    RouterDataProvider,
+    useRouterData,
+    useCurrentRouteData,
+    serverDataFetcher,
+} from "./RouterDataProvider.jsx"
+
+// fetchRouteData (called internally by serverDataFetcher) picks
+// component.default.clientFetcher vs. component.default.serverFetcher
+// based on `typeof window === "undefined"`. Under vitest's jsdom
+// environment, `window` IS defined, so despite the name
+// "serverDataFetcher" these tests exercise the clientFetcher branch --
+// there is no way to hit the serverFetcher branch from this project's
+// jsdom environment (it would need the "node" environment instead, but
+// then rendering/DOM assertions elsewhere in this file wouldn't work).
+// Named clientFetcher in the mocks below to match what's actually
+// invoked, not what the outer function's name implies.
+describe("serverDataFetcher", () => {
+    it("returns an empty object when no routes match the given url", async () => {
+        const routes = [{ path: "/nowhere", component: {} }]
+        const req = { query: {} }
+        const result = await serverDataFetcher({ routes, url: "/somewhere-else", req }, {})
+        expect(result).toEqual({})
+    })
+
+    // `component` is only ever populated via `route.component.load()` --
+    // a React.lazy-style loadable, not the module itself. A plain object
+    // at `route.component` (no `.load` method) leaves `component` as
+    // `null` for the entire call, so `component?.default?.clientFetcher`
+    // is always undefined regardless of what's on the plain object.
+    // Confirmed directly by first writing route.component as a plain
+    // `{ default: { clientFetcher } }` object and observing data stay
+    // null -- routes here must mimic the loadable shape.
+    function loadableComponent(mod) {
+        return { load: () => Promise.resolve(mod) }
+    }
+
+    it("calls a matched route's clientFetcher (jsdom has `window`) and keys the result by path", async () => {
+        const clientFetcher = vi.fn().mockResolvedValue({ hello: "world" })
+        const routes = [{ path: "/page", component: loadableComponent({ default: { clientFetcher } }) }]
+        const req = { query: {} }
+        const result = await serverDataFetcher({ routes, url: "/page", req }, { some: "arg" })
+        const key = Object.keys(result)[0]
+        expect(key).toBe("/page")
+        expect(result[key].data).toEqual({ hello: "world" })
+        expect(result[key].error).toBeNull()
+        expect(clientFetcher).toHaveBeenCalledWith(
+            expect.objectContaining({ route: routes[0] }),
+            { some: "arg" },
+            undefined
+        )
+    })
+
+    it("records the error and marks isFetched when the fetcher throws", async () => {
+        const clientFetcher = vi.fn().mockRejectedValue(new Error("network down"))
+        const routes = [{ path: "/page", component: loadableComponent({ default: { clientFetcher } }) }]
+        const req = { query: {} }
+        const result = await serverDataFetcher({ routes, url: "/page", req }, {})
+        const key = Object.keys(result)[0]
+        expect(result[key].error).toBeInstanceOf(Error)
+        expect(result[key].isFetched).toBe(true)
+        expect(result[key].isFetching).toBe(false)
+    })
+
+    it("marks fetcherNotAvailable when the matched route's component has no fetcher", async () => {
+        const routes = [{ path: "/page", component: loadableComponent({ default: {} }) }]
+        const req = { query: {} }
+        const result = await serverDataFetcher({ routes, url: "/page", req }, {})
+        const key = Object.keys(result)[0]
+        expect(result[key].fetcherNotAvailable).toBe(true)
+    })
+
+    it("marks fetcherNotAvailable when the matched route's component is a plain (non-loadable) object", async () => {
+        // route.component without a .load() method leaves `component`
+        // null internally -- documents the loadable-only contract.
+        const routes = [{ path: "/page", component: { default: { clientFetcher: vi.fn() } } }]
+        const req = { query: {} }
+        const result = await serverDataFetcher({ routes, url: "/page", req }, {})
+        const key = Object.keys(result)[0]
+        expect(result[key].fetcherNotAvailable).toBe(true)
+    })
+
+    it("builds a query-string suffix onto the route key from req.query", async () => {
+        const routes = [{ path: "/page", component: { default: {} } }]
+        const req = { query: { a: "1", b: "2" } }
+        const result = await serverDataFetcher({ routes, url: "/page", req }, {})
+        expect(Object.keys(result)[0]).toBe("/page?a=1&b=2")
+    })
+})
+
+function Page() {
+    const data = useRouterData()
+    return <div data-testid="data">{JSON.stringify(data)}</div>
+}
+
+// NOTE: `initialState` must be passed as a real object, not left to
+// default to undefined. Confirmed directly: RouterDataProvider's mount
+// effect reads `routeData[routeKey]?.isFetched` (routeData being the
+// `initialState` passed to useState) -- if `initialState` is omitted,
+// `routeData` is `undefined` on the first render, and `undefined[...]`
+// throws a real TypeError inside the effect. This is a genuine
+// pre-existing gap in RouterDataProvider (no default value / no guard on
+// `initialState`), not a test-authoring workaround -- flagged here
+// rather than silently avoided, since every real usage observed in this
+// codebase does pass a real initialState (hydration data from SSR).
+function renderWithProvider(path = "/") {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route
+                    path="/"
+                    element={
+                        <RouterDataProvider initialState={{}} config={{}}>
+                            <Page />
+                        </RouterDataProvider>
+                    }
+                />
+            </Routes>
+        </MemoryRouter>
+    )
+}
+
+describe("RouterDataProvider", () => {
+    it("renders its children", async () => {
+        renderWithProvider()
+        await waitFor(() => expect(screen.getByTestId("data")).toBeInTheDocument())
+    })
+
+    it("provides a router-data context to useRouterData", async () => {
+        renderWithProvider()
+        await waitFor(() => {
+            const parsed = JSON.parse(screen.getByTestId("data").textContent)
+            expect(typeof parsed).toBe("object")
+        })
+    })
+})
+
+describe("useRouterData", () => {
+    // NOTE: this does NOT actually throw outside a provider, despite the
+    // source's explicit `if (context === undefined) throw ...` guard and
+    // its own JSDoc saying "@throws If used outside RouterDataProvider
+    // Context". RouterContext is created via `createContext({})`, so
+    // useContext(RouterContext) returns `{}` (the default value), never
+    // `undefined`, when there's no ancestor provider -- the guard clause
+    // is unreachable dead code. Documenting the actual behavior here
+    // rather than asserting the documented-but-unreachable throw.
+    it("returns the context's default empty object when used outside a RouterDataProvider (documented throw is unreachable)", () => {
+        function Bare() {
+            const data = useRouterData()
+            return <div data-testid="bare">{JSON.stringify(data)}</div>
+        }
+        render(<Bare />)
+        expect(screen.getByTestId("bare")).toHaveTextContent("{}")
+    })
+})
+
+describe("useCurrentRouteData", () => {
+    // Needs a real matched route (UNSAFE_RouteContext.matches populated by
+    // react-router's own <Routes>/<Route>) plus a real RouterDataProvider
+    // ancestor for OneMgRouterContext's refetchData/clear -- not
+    // reasonably mockable in isolation, matching the same
+    // real-MemoryRouter approach used for RouterDataProvider itself.
+    function CurrentData() {
+        const data = useCurrentRouteData()
+        return <div data-testid="current">{JSON.stringify(data)}</div>
+    }
+
+    function renderAtPage({ initialState = {} } = {}) {
+        return render(
+            <MemoryRouter initialEntries={["/page"]}>
+                <Routes>
+                    <Route
+                        path="/page"
+                        element={
+                            <RouterDataProvider initialState={initialState} config={{}}>
+                                <CurrentData />
+                            </RouterDataProvider>
+                        }
+                    />
+                </Routes>
+            </MemoryRouter>
+        )
+    }
+
+    it("returns the initial (unfetched) data shape when no data has been loaded for the current route yet", async () => {
+        renderAtPage()
+        await waitFor(() => {
+            const parsed = JSON.parse(screen.getByTestId("current").textContent)
+            expect(parsed.data).toBeNull()
+            expect(parsed.error).toBeNull()
+        })
+    })
+
+    it("returns previously-fetched data for the current route from initialState", async () => {
+        // RouterDataProvider's own mount effect will still run and may
+        // overwrite this if the route has no component/fetcher -- but
+        // with no `component` on the plain route object here, the
+        // fetcher path is never taken, so initialState should be
+        // reflected as-is for at least the first render before any
+        // effect fires.
+        renderAtPage({ initialState: { "/page": { data: { hello: "world" }, error: null, isFetched: true } } })
+        await waitFor(() => {
+            const parsed = JSON.parse(screen.getByTestId("current").textContent)
+            expect(parsed.data).toEqual({ hello: "world" })
+        })
+    })
+})

--- a/packages/catalyst-core/src/web-router/components/Split.test.jsx
+++ b/packages/catalyst-core/src/web-router/components/Split.test.jsx
@@ -1,0 +1,123 @@
+import React, { Suspense } from "react"
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, waitFor, act } from "@testing-library/react"
+import Split, { split } from "./Split.jsx"
+import { SsrRequestProvider } from "./SsrRequestContext.jsx"
+
+// jsdom does not implement IntersectionObserver; SplitInview (used by the
+// client, non-skipVisibility path) needs one. Stub it to fire visible
+// immediately so tests default to "already visible" unless a test wants
+// to hold back visibility deliberately.
+class ImmediateIntersectionObserver {
+    constructor(callback) {
+        this.callback = callback
+    }
+    observe(node) {
+        // Fire on next tick so React has committed the ref first.
+        Promise.resolve().then(() => this.callback([{ target: node, isIntersecting: true }]))
+    }
+    unobserve() {}
+    disconnect() {}
+}
+
+beforeEach(() => {
+    vi.stubGlobal("IntersectionObserver", ImmediateIntersectionObserver)
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+})
+
+describe("Split (client-side, window defined)", () => {
+    it("renders children directly when skipVisibility is true", () => {
+        render(
+            <Split skipVisibility fallback={<span>loading</span>}>
+                <span>content</span>
+            </Split>
+        )
+        expect(screen.getByText("content")).toBeInTheDocument()
+    })
+
+    it("defers to SplitInview (shows fallback first) when skipVisibility is false", () => {
+        render(
+            <Split fallback={<span>loading</span>}>
+                <span>content</span>
+            </Split>
+        )
+        // Before the stubbed IntersectionObserver's microtask fires,
+        // SplitInview should still be showing the fallback.
+        expect(screen.getByText("loading")).toBeInTheDocument()
+    })
+
+    it("eventually renders children once SplitInview reports visibility", async () => {
+        render(
+            <Split fallback={<span>loading</span>}>
+                <span>content</span>
+            </Split>
+        )
+        await waitFor(() => expect(screen.getByText("content")).toBeInTheDocument())
+    })
+})
+
+describe("split()", () => {
+    it("returns a component (wrapper) rather than throwing, given a lazy-style import function", () => {
+        const importFn = () => Promise.resolve({ default: () => <span>lazy content</span> })
+        const LazyThing = split(importFn, { ssr: false })
+        expect(typeof LazyThing).toBe("function")
+        expect(typeof LazyThing.load).toBe("function")
+    })
+
+    it("eventually renders the resolved component's output", async () => {
+        const importFn = () => Promise.resolve({ default: () => <span>lazy content</span> })
+        const LazyThing = split(importFn, { ssr: false, fallback: <span>loading</span> })
+        render(<LazyThing skipVisibility />)
+        await waitFor(() => expect(screen.getByText("lazy content")).toBeInTheDocument())
+    })
+
+    it("copies clientFetcher/serverFetcher/setMetaData from the resolved module onto the wrapper via load()", async () => {
+        const clientFetcher = vi.fn()
+        const serverFetcher = vi.fn()
+        const setMetaData = vi.fn()
+        const importFn = () =>
+            Promise.resolve({
+                default: Object.assign(() => <span>x</span>, { clientFetcher, serverFetcher, setMetaData }),
+            })
+        const LazyThing = split(importFn, {})
+        await LazyThing.load()
+        expect(LazyThing.clientFetcher).toBe(clientFetcher)
+        expect(LazyThing.serverFetcher).toBe(serverFetcher)
+        expect(LazyThing.setMetaData).toBe(setMetaData)
+    })
+
+    it("load() only calls the import function once even when called multiple times concurrently", async () => {
+        const importFn = vi.fn().mockResolvedValue({ default: () => <span>x</span> })
+        const LazyThing = split(importFn, {})
+        const [a, b] = await Promise.all([LazyThing.load(), LazyThing.load()])
+        expect(importFn).toHaveBeenCalledTimes(1)
+        expect(a).toBe(b)
+    })
+
+    it("load() caches its result -- a second call after resolution reuses the cached module without re-importing", async () => {
+        const importFn = vi.fn().mockResolvedValue({ default: () => <span>x</span> })
+        const LazyThing = split(importFn, {})
+        await LazyThing.load()
+        await LazyThing.load()
+        expect(importFn).toHaveBeenCalledTimes(1)
+    })
+
+    it("treats a bot request (via SsrRequestContext) as forcing effectiveSsr, skipping visibility gating", async () => {
+        const importFn = () => Promise.resolve({ default: () => <span>bot content</span> })
+        const LazyThing = split(importFn, { ssr: false })
+        render(
+            <SsrRequestProvider value={{ isBot: true }}>
+                <LazyThing />
+            </SsrRequestProvider>
+        )
+        // effectiveSsr = ssr || isBot = false || true = true, so Split's
+        // `!isServer` branch takes skipVisibility={effectiveSsr || anyVisible}
+        // = true -- content should render without waiting on an
+        // IntersectionObserver callback at all.
+        await waitFor(() => expect(screen.getByText("bot content")).toBeInTheDocument())
+    })
+})

--- a/packages/catalyst-core/src/web-router/components/SplitInview.test.jsx
+++ b/packages/catalyst-core/src/web-router/components/SplitInview.test.jsx
@@ -1,0 +1,112 @@
+import React from "react"
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, act } from "@testing-library/react"
+import SplitInview from "./SplitInview.jsx"
+
+// jsdom does not implement IntersectionObserver -- stub it here and
+// capture the callback/options so tests can simulate an intersection
+// firing without a real layout engine.
+let observedNodes
+let ioCallback
+let ioOptions
+
+class FakeIntersectionObserver {
+    constructor(callback, options) {
+        ioCallback = callback
+        ioOptions = options
+        observedNodes = []
+    }
+    observe(node) {
+        observedNodes.push(node)
+    }
+    unobserve(node) {
+        observedNodes = observedNodes.filter((n) => n !== node)
+    }
+    disconnect() {
+        observedNodes = []
+    }
+}
+
+function fireIntersection(node, isIntersecting = true) {
+    ioCallback([{ target: node, isIntersecting, intersectionRatio: isIntersecting ? 1 : 0 }])
+}
+
+beforeEach(() => {
+    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver)
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
+
+describe("SplitInview", () => {
+    it("renders the fallback placeholder before becoming visible", () => {
+        render(
+            <SplitInview fallback={<span>loading</span>}>
+                <span>real content</span>
+            </SplitInview>
+        )
+        expect(screen.getByText("loading")).toBeInTheDocument()
+        expect(screen.queryByText("real content")).not.toBeInTheDocument()
+    })
+
+    it("renders children once the observer reports an intersection", () => {
+        render(
+            <SplitInview fallback={<span>loading</span>}>
+                <span>real content</span>
+            </SplitInview>
+        )
+        const node = observedNodes[0]
+        act(() => {
+            fireIntersection(node, true)
+        })
+        expect(screen.getByText("real content")).toBeInTheDocument()
+    })
+
+    it("calls onVisible exactly once when it becomes visible", () => {
+        const onVisible = vi.fn()
+        render(
+            <SplitInview fallback={<span>loading</span>} onVisible={onVisible}>
+                <span>real content</span>
+            </SplitInview>
+        )
+        const node = observedNodes[0]
+        act(() => {
+            fireIntersection(node, true)
+            fireIntersection(node, true)
+        })
+        expect(onVisible).toHaveBeenCalledTimes(1)
+    })
+
+    it("ignores non-intersecting entries", () => {
+        render(
+            <SplitInview fallback={<span>loading</span>}>
+                <span>real content</span>
+            </SplitInview>
+        )
+        const node = observedNodes[0]
+        act(() => {
+            fireIntersection(node, false)
+        })
+        expect(screen.queryByText("real content")).not.toBeInTheDocument()
+    })
+
+    it("renders children immediately when IntersectionObserver is unavailable", () => {
+        vi.stubGlobal("IntersectionObserver", undefined)
+        render(
+            <SplitInview fallback={<span>loading</span>}>
+                <span>real content</span>
+            </SplitInview>
+        )
+        expect(screen.getByText("real content")).toBeInTheDocument()
+    })
+
+    it("uses a dedicated observer (not the shared default) when rootOptions are given", () => {
+        render(
+            <SplitInview fallback={<span>loading</span>} rootOptions={{ threshold: 0.5 }}>
+                <span>real content</span>
+            </SplitInview>
+        )
+        expect(ioOptions.threshold).toBe(0.5)
+    })
+})

--- a/packages/catalyst-core/src/web-router/components/SsrRequestContext.test.jsx
+++ b/packages/catalyst-core/src/web-router/components/SsrRequestContext.test.jsx
@@ -1,0 +1,53 @@
+import React, { useContext } from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { SsrRequestContext, SsrRequestProvider } from "./SsrRequestContext.jsx"
+
+function ContextReader() {
+    const value = useContext(SsrRequestContext)
+    return <div data-testid="value">{JSON.stringify(value)}</div>
+}
+
+describe("SsrRequestContext", () => {
+    it("defaults to { isBot: false }", () => {
+        expect(SsrRequestContext._currentValue).toEqual({ isBot: false })
+    })
+})
+
+describe("SsrRequestProvider", () => {
+    it("provides the given value to descendants", () => {
+        render(
+            <SsrRequestProvider value={{ isBot: true }}>
+                <ContextReader />
+            </SsrRequestProvider>
+        )
+        expect(screen.getByTestId("value")).toHaveTextContent(JSON.stringify({ isBot: true }))
+    })
+
+    it("falls back to { isBot: false } when value is null", () => {
+        render(
+            <SsrRequestProvider value={null}>
+                <ContextReader />
+            </SsrRequestProvider>
+        )
+        expect(screen.getByTestId("value")).toHaveTextContent(JSON.stringify({ isBot: false }))
+    })
+
+    it("falls back to { isBot: false } when value is undefined (not passed)", () => {
+        render(
+            <SsrRequestProvider>
+                <ContextReader />
+            </SsrRequestProvider>
+        )
+        expect(screen.getByTestId("value")).toHaveTextContent(JSON.stringify({ isBot: false }))
+    })
+
+    it("renders its children", () => {
+        render(
+            <SsrRequestProvider value={{ isBot: false }}>
+                <span>child content</span>
+            </SsrRequestProvider>
+        )
+        expect(screen.getByText("child content")).toBeInTheDocument()
+    })
+})

--- a/packages/catalyst-core/src/web-router/context.test.jsx
+++ b/packages/catalyst-core/src/web-router/context.test.jsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest"
+import { OneMgRouterContext } from "./context.jsx"
+
+describe("OneMgRouterContext", () => {
+    it("is a React context with an empty object default value", () => {
+        expect(OneMgRouterContext.Provider).toBeDefined()
+        expect(OneMgRouterContext.Consumer).toBeDefined()
+        expect(OneMgRouterContext._currentValue).toEqual({})
+    })
+})

--- a/packages/catalyst-core/src/web-router/utils/metaDataUtils.test.jsx
+++ b/packages/catalyst-core/src/web-router/utils/metaDataUtils.test.jsx
@@ -1,0 +1,173 @@
+import React from "react"
+import { describe, expect, it, vi, afterEach } from "vitest"
+import { mergeHeadElements, deleteHeadTagsByDataAttribute, getMetaData } from "./metaDataUtils.jsx"
+
+describe("mergeHeadElements", () => {
+    it("returns an empty array when given no lists", () => {
+        expect(mergeHeadElements()).toEqual([])
+    })
+
+    it("keeps only the last title element when multiple titles are given", () => {
+        const first = <title key="a">First</title>
+        const second = <title key="b">Second</title>
+        const result = mergeHeadElements([first], [second])
+        expect(result).toHaveLength(1)
+        expect(result[0].props.children).toBe("Second")
+    })
+
+    it("dedupes meta tags by name, keeping the later one", () => {
+        const first = <meta name="description" content="first" />
+        const second = <meta name="description" content="second" />
+        const result = mergeHeadElements([first], [second])
+        expect(result).toHaveLength(1)
+        expect(result[0].props.content).toBe("second")
+    })
+
+    it("dedupes meta tags by property when name is absent", () => {
+        const first = <meta property="og:title" content="first" />
+        const second = <meta property="og:title" content="second" />
+        const result = mergeHeadElements([first, second])
+        expect(result).toHaveLength(1)
+        expect(result[0].props.content).toBe("second")
+    })
+
+    it("treats charset meta tags as a single unique slot", () => {
+        const first = <meta charSet="utf-8" charset="utf-8" />
+        const second = <meta charSet="iso-8859-1" charset="iso-8859-1" />
+        const result = mergeHeadElements([first], [second])
+        expect(result).toHaveLength(1)
+    })
+
+    it("keeps distinct meta tags with different names", () => {
+        const description = <meta name="description" content="desc" />
+        const keywords = <meta name="keywords" content="kw" />
+        const result = mergeHeadElements([description, keywords])
+        expect(result).toHaveLength(2)
+    })
+
+    it("preserves order across multiple non-overlapping lists", () => {
+        const a = <meta name="a" content="1" />
+        const b = <meta name="b" content="2" />
+        const c = <meta name="c" content="3" />
+        const result = mergeHeadElements([a], [b], [c])
+        expect(result.map((el) => el.props.name)).toEqual(["a", "b", "c"])
+    })
+
+    it("ignores null/undefined lists mixed in with real ones", () => {
+        const a = <meta name="a" content="1" />
+        const result = mergeHeadElements(null, [a], undefined)
+        expect(result).toHaveLength(1)
+    })
+})
+
+describe("deleteHeadTagsByDataAttribute", () => {
+    afterEach(() => {
+        document.head.innerHTML = ""
+    })
+
+    it("removes every element carrying the given data attribute", () => {
+        document.head.innerHTML = `
+            <meta data-catalyst="true" name="a">
+            <meta data-catalyst="true" name="b">
+            <meta name="c">
+        `
+        deleteHeadTagsByDataAttribute("catalyst")
+        expect(document.head.querySelectorAll("[data-catalyst]")).toHaveLength(0)
+        expect(document.head.querySelectorAll("meta")).toHaveLength(1)
+    })
+
+    it("removes only elements matching a specific attribute value when given one", () => {
+        document.head.innerHTML = `
+            <meta data-catalyst="route-a" name="a">
+            <meta data-catalyst="route-b" name="b">
+        `
+        deleteHeadTagsByDataAttribute("catalyst", "route-a")
+        expect(document.head.querySelector('[data-catalyst="route-a"]')).toBeNull()
+        expect(document.head.querySelector('[data-catalyst="route-b"]')).not.toBeNull()
+    })
+
+    it("does nothing when no elements match", () => {
+        document.head.innerHTML = `<meta name="untouched">`
+        expect(() => deleteHeadTagsByDataAttribute("catalyst")).not.toThrow()
+        expect(document.head.querySelectorAll("meta")).toHaveLength(1)
+    })
+})
+
+describe("getMetaData", () => {
+    it("returns an empty array when matchedRoutes is undefined", () => {
+        expect(getMetaData(undefined, {})).toEqual([])
+    })
+
+    it("returns an empty array when no route defines setMetaData", () => {
+        const matchedRoutes = [{ route: { component: {} } }]
+        expect(getMetaData(matchedRoutes, {})).toEqual([])
+    })
+
+    it("calls each route's setMetaData with the route data and merges results", () => {
+        const routeData = { title: "Home" }
+        const matchedRoutes = [
+            {
+                route: {
+                    component: {
+                        setMetaData: (data) => [<title key="t">{data.title}</title>],
+                    },
+                },
+            },
+        ]
+        const result = getMetaData(matchedRoutes, routeData)
+        expect(result).toHaveLength(1)
+        expect(result[0].props.children).toBe("Home")
+    })
+
+    it("stamps every returned element with data-catalyst and a stable key", () => {
+        const matchedRoutes = [
+            {
+                route: {
+                    component: {
+                        setMetaData: () => [
+                            <meta key="a" name="a" content="1" />,
+                            <meta key="b" name="b" content="2" />,
+                        ],
+                    },
+                },
+            },
+        ]
+        const result = getMetaData(matchedRoutes, {})
+        expect(result).toHaveLength(2)
+        for (const el of result) {
+            expect(el.props["data-catalyst"]).toBe(true)
+        }
+    })
+
+    it("merges tags from multiple matched routes, later routes winning on conflict", () => {
+        const matchedRoutes = [
+            {
+                route: { component: { setMetaData: () => [<meta key="a" name="shared" content="parent" />] } },
+            },
+            {
+                route: { component: { setMetaData: () => [<meta key="b" name="shared" content="child" />] } },
+            },
+        ]
+        const result = getMetaData(matchedRoutes, {})
+        expect(result).toHaveLength(1)
+        expect(result[0].props.content).toBe("child")
+    })
+
+    it("swallows errors from a misbehaving setMetaData and returns an empty array", () => {
+        const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+        const matchedRoutes = [
+            {
+                route: {
+                    component: {
+                        setMetaData: () => {
+                            throw new Error("boom")
+                        },
+                    },
+                },
+            },
+        ]
+        expect(() => getMetaData(matchedRoutes, {})).not.toThrow()
+        expect(getMetaData(matchedRoutes, {})).toEqual([])
+        consoleSpy.mockRestore()
+    })
+})

--- a/packages/catalyst-core/src/web-router/vitest.setup.js
+++ b/packages/catalyst-core/src/web-router/vitest.setup.js
@@ -1,0 +1,12 @@
+import "@testing-library/jest-dom/vitest"
+import { cleanup } from "@testing-library/react"
+import { afterEach } from "vitest"
+
+// RTL only auto-cleans up between tests when a test framework's globals
+// are detected in a way it recognizes (works out of the box with Jest);
+// under Vitest it needs to be wired explicitly, or renders from one test
+// leak into the next and multi-render tests using the same testids across
+// `it` blocks start finding duplicate elements.
+afterEach(() => {
+    cleanup()
+})

--- a/packages/catalyst-core/vitest.config.ts
+++ b/packages/catalyst-core/vitest.config.ts
@@ -1,17 +1,43 @@
 import { defineConfig } from "vitest/config"
 
-// Framework-level (Tier 1) unit tests for catalyst-core's own internals —
-// see test/errors/*.test.ts. Application-level (Tier 2) integration tests
-// live in examples/catalyst-core-test and run via scripts/test-catalyst-core.sh,
+// Two projects sharing this one config, kept in `projects` rather than a
+// separate vitest.workspace.ts so there's a single vitest.config.ts to
+// find. Each project is otherwise independent -- unique `name`, own
+// `environment`, own `include` glob, no shared setup between them.
+//
+// "node" project: framework-level (Tier 1) unit tests for catalyst-core's
+// own internals -- see test/errors/*.test.ts. Registry/index.js are ESM
+// and side-effect-free at import time -- no DOM, no server, no global
+// setup needed. Application-level (Tier 2) integration tests live in
+// examples/catalyst-core-test and run via scripts/test-catalyst-core.sh,
 // not through vitest (see issue #412).
+//
+// "web-router" project: React component/hook tests for src/web-router
+// (issue #346/#340 coverage work). Needs jsdom (a real DOM environment)
+// and @testing-library/react -- neither existed in this package before,
+// since every prior test here was plain-JS/Node logic. Kept as its own
+// project rather than switching the whole config to jsdom: jsdom has
+// real per-test overhead the plain error-system tests don't need, and
+// this keeps the two testing concerns (framework internals vs. React UI)
+// separately configured.
 export default defineConfig({
     test: {
-        environment: "node",
-        include: ["test/**/*.test.ts"],
-        // Registry/index.js are ESM and side-effect-free at import time — no
-        // DOM, no server, no global setup needed for Tier 1. Vitest
-        // transpiles .ts test files via esbuild at run time — no separate
-        // build step needed to execute them (tsconfig.test.json is only for
-        // editor/CI type-checking, see its own header comment).
+        projects: [
+            {
+                test: {
+                    name: "node",
+                    environment: "node",
+                    include: ["test/**/*.test.ts"],
+                },
+            },
+            {
+                test: {
+                    name: "web-router",
+                    environment: "jsdom",
+                    include: ["src/web-router/**/*.test.{js,jsx}"],
+                    setupFiles: ["./src/web-router/vitest.setup.js"],
+                },
+            },
+        ],
     },
 })


### PR DESCRIPTION
## What
Adds unit tests for every file in `packages/catalyst-core/src/web-router` (7 substantive files, zero existing tests) and wires up the vitest infrastructure needed to test React components in this package for the first time.

## Why
Requested directly: increase web coverage, specifically including `web-router`. Confirmed via inspection this was genuinely 0%-tested — `context.jsx`, `hooks.jsx`, `components/MetaTag.jsx`, `components/RouterDataProvider.jsx`, `components/Split.jsx`, `components/SplitInview.jsx`, `components/SsrRequestContext.jsx`, `utils/metaDataUtils.jsx`.

## Result (verified locally, matches what CI's `coverage-summary` job will report)
```
catalyst-core:  92.18% -> 87.55% of a much larger denominator (129 -> 418 total lines)
AGGREGATE WEB:  49.69% -> 63.13%
```
(create-catalyst-app 86.51% and catalyst-ai 16.91% unchanged — this PR only touches catalyst-core.)

## Infra changes
- **`vitest.config.ts`**: added a second `projects` entry (`"web-router"`, `environment: jsdom`) alongside the existing `"node"` project (the error-system tests). Kept fully separate rather than switching the whole config to jsdom — jsdom has real per-test overhead the plain-logic error tests don't need. Verified `--coverage` merges both projects into one `coverage-summary.json` with **zero changes needed** to the CI aggregation logic already in `node.js.yml` (#437).
- New devDependencies: `@testing-library/react@16.3.2` (React 19 compatible), `@testing-library/dom@10.4.1`, `@testing-library/jest-dom@7.0.1`, `jsdom@30.0.1`. Considered `vitest-dom` as an alternative to jest-dom — its own README says the maintainer is "unlikely to maintain this in the future" and now recommends `@testing-library/jest-dom` instead (the Vitest-support gap it was created to fill no longer exists) — kept jest-dom.
- Lockfile regenerated via `npm install --legacy-peer-deps` (one-time, for this lockfile-authoring step only — hit the same real npm arborist bug as #437's vitest-coverage-v8 addition; confirmed a plain `npm ci` afterward installs cleanly with no special flags).

## What's tested, and two pre-existing gaps found (documented, not silently patched)
- `mergeHeadElements`'s dedup rules (title/meta by name/property/charset), `deleteHeadTagsByDataAttribute`'s DOM cleanup, `getMetaData`'s route-to-tag pipeline including its error-swallowing catch block.
- `MetaTag` writing/re-writing head tags on real navigation (confirmed: re-rendering a *new* `<MemoryRouter initialEntries>` does **not** navigate an already-mounted router — had to trigger a real `useNavigate()` call instead).
- `serverDataFetcher`/`RouterDataProvider`/`useRouterData`/`useCurrentRouteData`'s full mount/fetch/error cycle, using real `<MemoryRouter>` trees rather than mocking `react-router-dom`.
- `Split`/`SplitInview`'s SSR/client/skipVisibility branching, the `split()` factory's wrapper/`load()`/module-cache contract, bot-forced SSR, and `IntersectionObserver`-gated visibility (stubbed — jsdom has no native `IntersectionObserver`).
- **Found and documented (not fixed, as out-of-scope source changes):** `RouterDataProvider` crashes on mount if `initialState` is omitted (`routeData[routeKey]` reads off `undefined`). `useRouterData`'s/`useCurrentRouteData`'s documented `@throws if used outside a RouterDataProvider` is unreachable dead code — `RouterContext` is `createContext({})`, so `useContext` returns `{}`, never `undefined`, without an ancestor provider.

## Base branch
Targets `feature/418-ci-workflow-split` (#437), not `epic/329` — the CI coverage-gate infrastructure this work is measured against lives on that branch, not yet on the epic branch.