### PR TITLE
Native Tier 2: emulator/simulator instrumented coverage (#416)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -409,6 +409,157 @@ jobs:
                   path: packages/catalyst-core/src/native/androidProject/app/build/reports/jacoco/jacocoTestReport
                   retention-days: 14
 
+    # Tier 2 (#416): emulator-instrumented coverage for the
+    # tier2FrameworkBoundFilter classes that jacocoTestReport (the Tier 1
+    # gate) deliberately excludes -- CustomWebView, MainActivity,
+    # SplashActivity, SecurityAlertUI and the rest. app/src/androidTest
+    # drives them on a real emulator; jacocoAndroidTestReport is the
+    # inverse-filtered report over ONLY those classes.
+    #
+    # REPORT-ONLY: this job's coverage number is printed and (on main)
+    # baselined, but has no regression-enforce step, and coverage-summary
+    # treats a non-success here as a warning, not a gate failure -- a
+    # fresh Tier 2 baseline is still moving, and day-one emulator flake
+    # must not block every android PR.
+    #
+    # Runs on ubuntu-latest (has KVM) parallel to the iOS critical path,
+    # inside android's ~6-min parallel headroom, so pipeline wall-clock is
+    # unchanged. timeout-minutes is generous because a cold AVD (cache
+    # miss) can take ~8-10 min to create + boot; that time is still off
+    # the critical path.
+    android-instrumented-coverage:
+        needs: detect-changes
+        if: needs.detect-changes.outputs.android == 'true'
+        runs-on: ubuntu-latest
+        timeout-minutes: 25
+        permissions:
+            contents: read
+            actions: write
+        outputs:
+            line_pct: ${{ steps.coverage.outputs.line_pct }}
+
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+              with:
+                  distribution: "temurin"
+                  java-version: "17"
+
+            # KVM is present on ubuntu-latest but not group-accessible by
+            # default; the emulator needs it for hardware acceleration.
+            - name: Enable KVM
+              run: |
+                  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+                    | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+                  sudo udevadm control --reload-rules
+                  sudo udevadm trigger --name-match=kvm
+
+            # AVD snapshot cache: the first job to miss creates a clean
+            # boot snapshot (next step), every later run restores it and
+            # boots warm (~1-2 min vs ~4 cold). Keyed on API/arch/target
+            # only -- bump the -vN suffix to invalidate.
+            - name: AVD cache
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              id: avd-cache
+              with:
+                  path: |
+                      ~/.android/avd/*
+                      ~/.android/adb*
+                  key: avd-api34-x86_64-google_apis-v1
+
+            - name: Warm AVD snapshot (cache miss only)
+              if: steps.avd-cache.outputs.cache-hit != 'true'
+              uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
+              with:
+                  api-level: 34
+                  arch: x86_64
+                  target: google_apis
+                  force-avd-creation: false
+                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+                  disable-animations: true
+                  script: echo "Generated AVD snapshot"
+
+            - name: Run instrumented tests + Tier-2 coverage report
+              uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
+              with:
+                  api-level: 34
+                  arch: x86_64
+                  target: google_apis
+                  force-avd-creation: false
+                  emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+                  disable-animations: true
+                  working-directory: packages/catalyst-core/src/native/androidProject
+                  script: |
+                      chmod +x ./gradlew
+                      ./gradlew connectedDebugAndroidTest jacocoAndroidTestReport --console=plain
+
+            - name: Print Tier-2 coverage summary
+              id: coverage
+              working-directory: packages/catalyst-core/src/native/androidProject
+              run: |
+                  python3 - <<'EOF'
+                  import os
+                  import xml.etree.ElementTree as ET
+                  root = ET.parse("app/build/reports/jacoco/jacocoAndroidTestReport/jacocoAndroidTestReport.xml").getroot()
+                  line_pct = 0.0
+                  for c in root.findall("counter"):
+                      cov, miss = int(c.get("covered")), int(c.get("missed"))
+                      total = cov + miss
+                      pct = (cov / total * 100) if total else 0
+                      print(f"{c.get('type'):12s} {cov:6d}/{total:<6d} ({pct:5.2f}%)")
+                      if c.get("type") == "LINE":
+                          line_pct = pct
+                  with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                      f.write(f"line_pct={line_pct:.2f}\n")
+                  print(f"::notice::Android Tier-2 (instrumented) line coverage: {line_pct:.2f}% (report-only)")
+                  EOF
+
+            # Report-only: restore + print the baseline for context, but
+            # NEVER fail on a drop (contrast android-unit-and-coverage's
+            # enforce step). Baseline is written on main-push only.
+            - name: Restore Tier-2 baseline
+              if: github.event_name == 'pull_request'
+              uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: coverage-baseline-android-tier2.json
+                  key: coverage-baseline-android-tier2-v1
+
+            - name: Compare to Tier-2 baseline (informational)
+              if: github.event_name == 'pull_request'
+              run: |
+                  CURRENT="${{ steps.coverage.outputs.line_pct }}"
+                  if [ -f coverage-baseline-android-tier2.json ]; then
+                    BASELINE=$(python3 -c "import json; print(json.load(open('coverage-baseline-android-tier2.json'))['line_pct'])")
+                    echo "::notice::Android Tier-2 coverage ${CURRENT}% (baseline ${BASELINE}%) -- report-only, not gated"
+                  else
+                    echo "::notice::No Android Tier-2 baseline yet. Current: ${CURRENT}%"
+                  fi
+
+            - name: Update Tier-2 baseline (main only)
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  echo "{\"line_pct\": ${{ steps.coverage.outputs.line_pct }}}" > coverage-baseline-android-tier2.json
+                  gh cache delete coverage-baseline-android-tier2-v1 --repo "${{ github.repository }}" || true
+
+            - name: Save Tier-2 baseline (main only)
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+              uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: coverage-baseline-android-tier2.json
+                  key: coverage-baseline-android-tier2-v1
+
+            - name: Upload Tier-2 Jacoco report
+              if: always()
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: android-jacoco-tier2-report
+                  path: packages/catalyst-core/src/native/androidProject/app/build/reports/jacoco/jacocoAndroidTestReport
+                  retention-days: 14
+
     # Split from what was a single test-ios-unit job into two: CoreLogic
     # (this job) runs first, has zero dependencies, needs no simulator, and
     # is the only iOS target that can produce a real coverage percentage
@@ -767,7 +918,7 @@ jobs:
     # because a skipped platform (e.g. an android-only PR, where the iOS
     # and web jobs never run) must still count as fine here, not failure.
     coverage-summary:
-        needs: [detect-changes, unit-and-contract-tests, web-integration-smoke, android-unit-and-coverage, ios-corelogic-and-coverage, ios-app-simulator-tests]
+        needs: [detect-changes, unit-and-contract-tests, web-integration-smoke, android-unit-and-coverage, android-instrumented-coverage, ios-corelogic-and-coverage, ios-app-simulator-tests]
         if: always()
         runs-on: ubuntu-latest
         steps:
@@ -777,10 +928,12 @@ jobs:
                   web_status="${{ needs.unit-and-contract-tests.result }}"
                   web_smoke_status="${{ needs.web-integration-smoke.result }}"
                   android_status="${{ needs.android-unit-and-coverage.result }}"
+                  android_tier2_status="${{ needs.android-instrumented-coverage.result }}"
                   ios_corelogic_status="${{ needs.ios-corelogic-and-coverage.result }}"
                   ios_app_status="${{ needs.ios-app-simulator-tests.result }}"
                   web_pct="${{ needs.unit-and-contract-tests.outputs.line_pct }}"
                   android_pct="${{ needs.android-unit-and-coverage.outputs.line_pct }}"
+                  android_tier2_pct="${{ needs.android-instrumented-coverage.outputs.line_pct }}"
                   ios_corelogic_pct="${{ needs.ios-corelogic-and-coverage.outputs.line_pct }}"
                   ios_app_pct="${{ needs.ios-app-simulator-tests.outputs.line_pct }}"
 
@@ -798,9 +951,19 @@ jobs:
                   echo "Coverage summary:"
                   report_platform "web (js unit tests, 3 workspaces aggregated)" "$web_status" "$web_pct"
                   report_platform "web-integration-smoke (not a coverage platform, pass/fail only)" "$web_smoke_status" ""
-                  report_platform "android (jacoco)" "$android_status" "$android_pct"
+                  report_platform "android (jacoco, Tier 1 unit)" "$android_status" "$android_pct"
+                  report_platform "android-tier2 (jacoco, instrumented, REPORT-ONLY)" "$android_tier2_status" "$android_tier2_pct"
                   report_platform "ios-corelogic (CatalystCoreLogic, llvm-cov)" "$ios_corelogic_status" "$ios_corelogic_pct"
                   report_platform "ios-app (iosnativeWebView.app target, xccov)" "$ios_app_status" "$ios_app_pct"
+
+                  # android-tier2 (#416) is report-only: a non-success here
+                  # is surfaced as a warning but does NOT fail this gate --
+                  # it is deliberately absent from the fail loop below. A
+                  # fresh Tier 2 baseline is still moving and day-one
+                  # emulator flake must not block every android PR.
+                  if [ "$android_tier2_status" != "success" ] && [ "$android_tier2_status" != "skipped" ]; then
+                    echo "::warning::android-instrumented-coverage did not pass (status: $android_tier2_status) -- report-only, not blocking"
+                  fi
 
                   # detect-changes itself failing/erroring (not just "nothing
                   # changed") means the per-platform jobs below were skipped

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -906,6 +906,166 @@ jobs:
                   path: coverage-baseline-ios-app.json
                   key: coverage-baseline-ios-app-v1
 
+    # Tier 2 (#416): simulator UI test for the iosnativeWebView.app
+    # target. iosnativeWebViewTests (the job above) never launches the
+    # real app, so AppDelegate.didFinishLaunchingWithOptions,
+    # iosnativeWebViewApp.init and ContentView.body are uncovered by it;
+    # one XCUIApplication().launch() exercises all of them plus
+    # WebViewContainer / WebView.makeUIView view construction.
+    #
+    # SEPARATE parallel job (not folded into ios-app-simulator-tests)
+    # specifically to keep the pipeline critical path flat:
+    # ios-app-simulator-tests IS the wall-clock, and adding
+    # -only-testing:iosnativeWebViewUITests to it would grow that job
+    # 1:1. This job has the same needs: [detect-changes,
+    # ios-corelogic-and-coverage] so both macOS jobs start together.
+    #
+    # MEASURED GO/NO-GO: if this job's own duration comes in above
+    # ~6 min it becomes the new critical path -- in that case revert this
+    # commit (the target wiring + LaunchTests.swift stay) and track iOS
+    # Tier 2 as a follow-up. <= ~5m50s means wall-clock stays flat.
+    #
+    # REPORT-ONLY: prints iosnativeWebView.app coverage from this run and
+    # baselines it on main push, but NO regression-enforce step; a
+    # non-success is surfaced by coverage-summary as ::warning:: only.
+    # Its baseline (coverage-baseline-ios-app-uitests-v1) is separate from
+    # ios-app-simulator-tests' gated coverage-baseline-ios-app-v1 -- two
+    # independent numbers over the same target, not merged.
+    ios-app-uitests:
+        needs: [detect-changes, ios-corelogic-and-coverage]
+        if: needs.detect-changes.outputs.ios == 'true'
+        runs-on: macos-latest
+        permissions:
+            contents: read
+            actions: write
+        outputs:
+            line_pct: ${{ steps.coverage.outputs.line_pct }}
+
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            - name: Cache SPM packages
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: packages/catalyst-core/src/native/iosnativeWebView/.spm-cache
+                  key: spm-${{ runner.os }}-${{ hashFiles('packages/catalyst-core/src/native/iosnativeWebView/Package.resolved') }}
+                  restore-keys: |
+                      spm-${{ runner.os }}-
+
+            - name: Pick an available iOS simulator
+              id: sim
+              run: |
+                  set -o pipefail
+                  RESULT=$(xcrun simctl list devices available -j | jq -r '
+                    .devices
+                    | to_entries
+                    | map(select(.key | test("com\\.apple\\.CoreSimulator\\.SimRuntime\\.iOS")))
+                    | sort_by(.key) | reverse
+                    | map(.value | map(select(.name | test("^iPhone( [0-9]+)?$|^iPhone [0-9]+ ")) | select(.name | test("[0-9]+e( |$)") | not)))
+                    | flatten
+                    | .[0]
+                    | if . == null then "" else (.udid + "\t" + .name) end
+                  ')
+                  if [ -z "$RESULT" ]; then
+                    echo "::error::No available iOS Simulator with an iPhone destination found on this runner"
+                    xcrun simctl list devices available
+                    exit 1
+                  fi
+                  UDID=$(echo "$RESULT" | cut -f1)
+                  NAME=$(echo "$RESULT" | cut -f2)
+                  echo "id=$UDID" >> "$GITHUB_OUTPUT"
+                  echo "Selected simulator: $NAME ($UDID)"
+
+            - name: Boot iOS simulator
+              run: |
+                  xcrun simctl boot "${{ steps.sim.outputs.id }}"
+                  xcrun simctl bootstatus "${{ steps.sim.outputs.id }}" -b
+
+            # -only-testing:iosnativeWebViewUITests -- the UI-testing bundle
+            # only. -parallel-testing-enabled stays OFF (same flake
+            # rationale as ios-app-simulator-tests).
+            - name: Run iosnativeWebViewUITests (Tier 2 simulator UI test)
+              working-directory: packages/catalyst-core/src/native/iosnativeWebView
+              run: |
+                  set -o pipefail
+                  xcodebuild test \
+                    -project iosnativeWebView.xcodeproj \
+                    -scheme iosnativeWebView \
+                    -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
+                    -only-testing:iosnativeWebViewUITests \
+                    -clonedSourcePackagesDirPath .spm-cache \
+                    -enableCodeCoverage YES \
+                    -resultBundlePath TestResults.xcresult \
+                    CODE_SIGNING_ALLOWED=NO \
+                    | xcbeautify --renderer github-actions
+
+            - name: Print coverage summary
+              id: coverage
+              working-directory: packages/catalyst-core/src/native/iosnativeWebView
+              run: |
+                  xcrun xccov view --report --json TestResults.xcresult > xccov-report.json
+                  python3 - <<'EOF'
+                  import json, os
+                  with open("xccov-report.json") as f:
+                      report = json.load(f)
+                  app_target = next(
+                      (t for t in report["targets"] if t["name"] == "iosnativeWebView.app"),
+                      None,
+                  )
+                  if app_target is None:
+                      raise SystemExit("iosnativeWebView.app target not found in xccov report")
+                  covered = app_target["coveredLines"]
+                  total = app_target["executableLines"]
+                  pct = (covered / total * 100) if total else 0
+                  print(f"LINE {covered}/{total} ({pct:.2f}%)")
+                  with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                      f.write(f"line_pct={pct:.2f}\n")
+                  print(f"::notice::iOS app-target UI-test line coverage: {pct:.2f}% (report-only)")
+                  EOF
+
+            # Report-only: restore + print the baseline for context, NEVER
+            # fail on a drop. Written on main-push only.
+            - name: Restore UI-test coverage baseline
+              if: github.event_name == 'pull_request'
+              uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: coverage-baseline-ios-app-uitests.json
+                  key: coverage-baseline-ios-app-uitests-v1
+
+            - name: Compare to UI-test baseline (informational)
+              if: github.event_name == 'pull_request'
+              run: |
+                  CURRENT="${{ steps.coverage.outputs.line_pct }}"
+                  if [ -f coverage-baseline-ios-app-uitests.json ]; then
+                    BASELINE=$(python3 -c "import json; print(json.load(open('coverage-baseline-ios-app-uitests.json'))['line_pct'])")
+                    echo "::notice::iOS UI-test coverage ${CURRENT}% (baseline ${BASELINE}%) -- report-only, not gated"
+                  else
+                    echo "::notice::No iOS UI-test baseline yet. Current: ${CURRENT}%"
+                  fi
+
+            - name: Update UI-test coverage baseline (main only)
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  echo "{\"line_pct\": ${{ steps.coverage.outputs.line_pct }}}" > coverage-baseline-ios-app-uitests.json
+                  gh cache delete coverage-baseline-ios-app-uitests-v1 --repo "${{ github.repository }}" || true
+
+            - name: Save UI-test coverage baseline (main only)
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+              uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: coverage-baseline-ios-app-uitests.json
+                  key: coverage-baseline-ios-app-uitests-v1
+
+            - name: Upload UI-test result bundle
+              if: always()
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: ios-app-uitests-xcresult
+                  path: packages/catalyst-core/src/native/iosnativeWebView/TestResults.xcresult
+                  retention-days: 14
+
     # Terminal join point for the ENTIRE pipeline -- every test/coverage
     # job feeds into this one, including web-integration-smoke (no
     # coverage number, gated on pass/fail only -- it's an
@@ -918,7 +1078,7 @@ jobs:
     # because a skipped platform (e.g. an android-only PR, where the iOS
     # and web jobs never run) must still count as fine here, not failure.
     coverage-summary:
-        needs: [detect-changes, unit-and-contract-tests, web-integration-smoke, android-unit-and-coverage, android-instrumented-coverage, ios-corelogic-and-coverage, ios-app-simulator-tests]
+        needs: [detect-changes, unit-and-contract-tests, web-integration-smoke, android-unit-and-coverage, android-instrumented-coverage, ios-corelogic-and-coverage, ios-app-simulator-tests, ios-app-uitests]
         if: always()
         runs-on: ubuntu-latest
         steps:
@@ -931,11 +1091,13 @@ jobs:
                   android_tier2_status="${{ needs.android-instrumented-coverage.result }}"
                   ios_corelogic_status="${{ needs.ios-corelogic-and-coverage.result }}"
                   ios_app_status="${{ needs.ios-app-simulator-tests.result }}"
+                  ios_app_uitests_status="${{ needs.ios-app-uitests.result }}"
                   web_pct="${{ needs.unit-and-contract-tests.outputs.line_pct }}"
                   android_pct="${{ needs.android-unit-and-coverage.outputs.line_pct }}"
                   android_tier2_pct="${{ needs.android-instrumented-coverage.outputs.line_pct }}"
                   ios_corelogic_pct="${{ needs.ios-corelogic-and-coverage.outputs.line_pct }}"
                   ios_app_pct="${{ needs.ios-app-simulator-tests.outputs.line_pct }}"
+                  ios_app_uitests_pct="${{ needs.ios-app-uitests.outputs.line_pct }}"
 
                   report_platform() {
                     name="$1"; status="$2"; pct="$3"
@@ -955,15 +1117,20 @@ jobs:
                   report_platform "android-tier2 (jacoco, instrumented, REPORT-ONLY)" "$android_tier2_status" "$android_tier2_pct"
                   report_platform "ios-corelogic (CatalystCoreLogic, llvm-cov)" "$ios_corelogic_status" "$ios_corelogic_pct"
                   report_platform "ios-app (iosnativeWebView.app target, xccov)" "$ios_app_status" "$ios_app_pct"
+                  report_platform "ios-app-uitests (iosnativeWebView.app, UI test, REPORT-ONLY)" "$ios_app_uitests_status" "$ios_app_uitests_pct"
 
-                  # android-tier2 (#416) is report-only: a non-success here
-                  # is surfaced as a warning but does NOT fail this gate --
-                  # it is deliberately absent from the fail loop below. A
-                  # fresh Tier 2 baseline is still moving and day-one
-                  # emulator flake must not block every android PR.
-                  if [ "$android_tier2_status" != "success" ] && [ "$android_tier2_status" != "skipped" ]; then
-                    echo "::warning::android-instrumented-coverage did not pass (status: $android_tier2_status) -- report-only, not blocking"
-                  fi
+                  # android-tier2 and ios-app-uitests (#416) are report-only:
+                  # a non-success is surfaced as a warning but does NOT fail
+                  # this gate -- both are deliberately absent from the fail
+                  # loop below. Fresh Tier 2 baselines are still moving and
+                  # day-one emulator/simulator flake must not block every
+                  # native PR.
+                  for pair in "android-instrumented-coverage:$android_tier2_status" "ios-app-uitests:$ios_app_uitests_status"; do
+                    job="${pair%%:*}"; st="${pair#*:}"
+                    if [ "$st" != "success" ] && [ "$st" != "skipped" ]; then
+                      echo "::warning::$job did not pass (status: $st) -- report-only, not blocking"
+                    fi
+                  done
 
                   # detect-changes itself failing/erroring (not just "nothing
                   # changed") means the per-platform jobs below were skipped

--- a/packages/catalyst-core/.npmignore
+++ b/packages/catalyst-core/.npmignore
@@ -33,6 +33,8 @@ src/native/iosnativeWebView/Tests/**
 # CatalystCoreLogic (#432) nested package tests — separate Tests/ root, not
 # covered by the pattern above
 src/native/iosnativeWebView/CoreLogic/Tests/**
+# Tier 2 (#416) simulator UI tests — separate target dir
+src/native/iosnativeWebView/iosnativeWebViewUITests/**
 # Exclude Android test files from npm package
 src/native/androidProject/app/src/test/**
 src/native/androidProject/app/src/androidTest/**

--- a/packages/catalyst-core/src/native/androidProject/app/build.gradle.kts
+++ b/packages/catalyst-core/src/native/androidProject/app/build.gradle.kts
@@ -132,6 +132,13 @@ android {
             versionNameSuffix = "-debug"
             isMinifyEnabled = false
             enableUnitTestCoverage = true
+            // #416: also emit coverage from connectedDebugAndroidTest
+            // (instrumented / Tier 2). AGP 8.11 writes the raw .ec under
+            // build/outputs/code_coverage/debugAndroidTest/connected/**;
+            // jacocoAndroidTestReport (below) turns that into a report.
+            // jacocoTestReport (Tier 1) is unaffected — it reads only the
+            // separate testDebugUnitTest.exec.
+            enableAndroidTestCoverage = true
             buildConfigField("Boolean", "ALLOW_MIXED_CONTENT", "true")
             buildConfigField("String", "LOCAL_IP", "\"${getLocalIpAddress()}\"")
         }
@@ -305,6 +312,79 @@ dependencies {
     }
 }
 
+// ── Shared Jacoco filter lists ────────────────────────────────────────
+// Hoisted to top level (#416) so jacocoTestReport (Tier 1, uses them as
+// exclude()) and jacocoAndroidTestReport (Tier 2, uses tier2… as the
+// inverse include()) reference the SAME list and cannot drift.
+//
+// generatedCodeFilter: generated / non-authored code (R.class,
+// BuildConfig, view/data binding scaffolding) — no coverage story either
+// way, excluded from both reports.
+val generatedCodeFilter = listOf(
+    "**/R.class", "**/R$*.class",
+    "**/BuildConfig.*",
+    "**/Manifest*.*",
+    "**/*Test*.*",
+    "android/**/*.*",
+    "**/databinding/**",
+    "**/android/databinding/**",
+    "**/androidx/databinding/**",
+    "**/*_ViewBinding*.*",
+    "**/*\$ViewInjector*.*",
+    "**/*\$ViewBinder*.*",
+    "**/*_MembersInjector.class"
+)
+
+// tier2FrameworkBoundFilter: files that build real Android Views, extend
+// Activity/Fragment, or otherwise structurally require a real
+// device/emulator to exercise (confirmed via a full-repo classification
+// pass, not a guess from filenames — see PR description / issue for the
+// per-file reasoning). These ARE real, authored logic — excluding them
+// from jacocoTestReport isn't "inflating" the number, it's making the
+// Tier 1 gate honest: a gate that includes Tier 2 in its denominator
+// would fail any PR that touches WebView/Activity/View code regardless of
+// how well-tested that PR's actual testable logic is. Mirrors the
+// CoreLogic/UI split already accepted on iOS (#432).
+//
+// jacocoAndroidTestReport (#416) is the INVERSE — it includes exactly
+// these classes and reports their emulator-instrumented coverage as a
+// separate, report-only number.
+//
+// Each Tier 2 file's top-level class, Kt-file facade, and compiled
+// lambda/inner classes are all listed, so nothing structurally
+// untestable is left counting against the Tier 1 gate. The one exception
+// is NativeBridge, which has an already-tested companion object
+// (parseAndValidateMessage, compiled separately as
+// NativeBridge$Companion.class) — Gradle's Ant-style exclude() does not
+// reliably support "!" negation, so instead of pattern-negating the
+// companion out, its lambda pattern uses "$*$*" (two "$" segments), which
+// Kotlin lambda class names always have and the single-"$" companion
+// class name never does. This keeps the companion in Tier 1 AND out of
+// the Tier 2 include set, with no double counting.
+val tier2FrameworkBoundFilter = listOf(
+    "**/CustomWebView.class", "**/CustomWebView\$*.class", "**/CustomWebViewKt.class",
+    "**/MainActivity.class", "**/MainActivity\$*.class",
+    "**/SplashActivity.class", "**/SplashActivity\$*.class",
+    "**/NativeCameraManager.class", "**/NativeCameraManager\$*.class",
+    "**/camera/CameraSessionManager.class", "**/camera/CameraSessionManager\$*.class",
+    "**/TransitionManager.class", "**/TransitionManager\$*.class",
+    "**/utils/KeyboardUtil.class", "**/utils/KeyboardUtil\$*.class",
+    "**/security/SecurityAlertUI.class", "**/security/SecurityAlertUI\$*.class",
+    "**/security/SecurityAlertHandler.class", "**/security/SecurityAlertHandler\$*.class",
+    "**/security/SecurityBottomSheet.class", "**/security/SecurityBottomSheet\$*.class",
+    "**/NativeBridge.class", "**/NativeBridgeKt.class", "**/NativeBridge\$*\$*.class"
+)
+
+// Both noFcm/withFcm are listed (not just whichever isNotificationsEnabled()
+// picked for this build) purely so the HTML report can resolve source
+// lines for whichever one actually got compiled — listing the inactive
+// one is harmless, Jacoco just won't find matching class files for it.
+val jacocoSourceDirs = listOf(
+    "${project.projectDir}/src/main/java",
+    "${project.projectDir}/src/noFcm/java",
+    "${project.projectDir}/src/withFcm/java"
+)
+
 // JVM unit test coverage (Tier 1). Mirrors the CatalystCoreLogic
 // llvm-cov setup on iOS (#432): real, measured line coverage for
 // app/src/test, not just a pass/fail count. Scoped to testDebugUnitTest —
@@ -321,94 +401,54 @@ tasks.register<JacocoReport>("jacocoTestReport") {
         html.required.set(true)
     }
 
-    // Excludes are split into two groups. The first is generated/non-authored
-    // code (R.class, BuildConfig, view/data binding scaffolding) — no
-    // coverage story either way, always excluded.
-    //
-    // The second is the Tier 2 classification below: files that build real
-    // Android Views, extend Activity/Fragment, or otherwise structurally
-    // require Robolectric or a real device/emulator to exercise (confirmed
-    // via a full-repo classification pass, not a guess from filenames —
-    // see PR description / issue for the per-file reasoning). These ARE
-    // real, authored logic — excluding them isn't "inflating" the number,
-    // it's making the gate honest: a Tier 1/Tier 2 coverage gate that
-    // includes Tier 2 in its denominator would fail any PR that touches
-    // WebView/Activity/View code regardless of how well-tested that PR's
-    // actual testable logic is. Mirrors the CoreLogic/UI split already
-    // accepted on iOS (#432).
-    //
-    // Each Tier 2 file's top-level class, Kt-file facade, and compiled
-    // lambda/inner classes are all excluded, so nothing structurally
-    // untestable is left counting against the gate. The one exception is
-    // NativeBridge, which has an already-tested companion object
-    // (parseAndValidateMessage, compiled separately as
-    // NativeBridge$Companion.class) — Gradle's Ant-style exclude() does
-    // not reliably support "!" negation, so instead of pattern-negating
-    // the companion out, its lambda exclude uses "$*$*" (two "$"
-    // segments), which Kotlin lambda class names always have and the
-    // single-"$" companion class name never does. See the comment next
-    // to that pattern below for the concrete example.
-    val generatedCodeFilter = listOf(
-        "**/R.class", "**/R$*.class",
-        "**/BuildConfig.*",
-        "**/Manifest*.*",
-        "**/*Test*.*",
-        "android/**/*.*",
-        "**/databinding/**",
-        "**/android/databinding/**",
-        "**/androidx/databinding/**",
-        "**/*_ViewBinding*.*",
-        "**/*\$ViewInjector*.*",
-        "**/*\$ViewBinder*.*",
-        "**/*_MembersInjector.class"
-    )
-
-    val tier2FrameworkBoundFilter = listOf(
-        // Real WebView/Activity construction, ViewBinding, real lifecycle.
-        // Each file's top-level class, Kt-file facade, and compiled lambda
-        // classes (Kotlin: OuterClass$methodName$N.class) are all excluded.
-        // None of these files has a companion object worth protecting
-        // (that only applies to NativeBridge, handled separately below),
-        // so a plain "$*" is safe here.
-        "**/CustomWebView.class", "**/CustomWebView\$*.class", "**/CustomWebViewKt.class",
-        "**/MainActivity.class", "**/MainActivity\$*.class",
-        "**/SplashActivity.class", "**/SplashActivity\$*.class",
-        "**/NativeCameraManager.class", "**/NativeCameraManager\$*.class",
-        "**/camera/CameraSessionManager.class", "**/camera/CameraSessionManager\$*.class",
-        "**/TransitionManager.class", "**/TransitionManager\$*.class",
-        "**/utils/KeyboardUtil.class", "**/utils/KeyboardUtil\$*.class",
-        "**/security/SecurityAlertUI.class", "**/security/SecurityAlertUI\$*.class",
-        "**/security/SecurityAlertHandler.class", "**/security/SecurityAlertHandler\$*.class",
-        "**/security/SecurityBottomSheet.class", "**/security/SecurityBottomSheet\$*.class",
-        // NativeBridge has an already-tested companion (parseAndValidateMessage,
-        // compiled as NativeBridge$Companion.class — one "$"). Kotlin lambda
-        // classes always carry two "$" segments (e.g.
-        // NativeBridge$downloadAndOpenFile$1.class), so "$*$*" excludes every
-        // lambda while a single-"$" glob would be needed to also exclude the
-        // companion — which this pattern does NOT match, by construction.
-        "**/NativeBridge.class", "**/NativeBridgeKt.class", "**/NativeBridge\$*\$*.class"
-    )
-
     val debugTree = fileTree(layout.buildDirectory.dir("intermediates/javac/debug/compileDebugJavaWithJavac/classes")) {
         exclude(generatedCodeFilter + tier2FrameworkBoundFilter)
     }
     val kotlinDebugTree = fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
         exclude(generatedCodeFilter + tier2FrameworkBoundFilter)
     }
-    // Both noFcm/withFcm are listed (not just whichever isNotificationsEnabled()
-    // picked for this build) purely so the HTML report can resolve source
-    // lines for whichever one actually got compiled — listing the inactive
-    // one is harmless, Jacoco just won't find matching class files for it.
-    val sourceDirs = listOf(
-        "${project.projectDir}/src/main/java",
-        "${project.projectDir}/src/noFcm/java",
-        "${project.projectDir}/src/withFcm/java"
-    )
 
-    sourceDirectories.setFrom(files(sourceDirs))
+    sourceDirectories.setFrom(files(jacocoSourceDirs))
     classDirectories.setFrom(files(debugTree, kotlinDebugTree))
     executionData.setFrom(fileTree(layout.buildDirectory) {
         include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
+    })
+}
+
+// Instrumented / emulator coverage (Tier 2, #416). The INVERSE of
+// jacocoTestReport: it includes ONLY the tier2FrameworkBoundFilter
+// classes and measures how much of them the app/src/androidTest
+// instrumented tests exercise on a real emulator. REPORT-ONLY — no
+// regression gate (see .github/workflows/node.js.yml). jacocoTestReport
+// is untouched; the two reports are separate numbers over disjoint class
+// sets.
+//
+// AGP 8.11 also auto-generates `createDebugAndroidTestCoverageReport`
+// once enableAndroidTestCoverage=true, but that reports the whole app —
+// this task is the inverse-filtered Tier-2-only view we actually want.
+tasks.register<JacocoReport>("jacocoAndroidTestReport") {
+    dependsOn("connectedDebugAndroidTest")
+    group = "verification"
+    description = "Tier 2 instrumented coverage: ONLY the tier2FrameworkBoundFilter classes."
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+
+    fun tier2Tree(path: String) = fileTree(layout.buildDirectory.dir(path)) {
+        include(tier2FrameworkBoundFilter)
+        exclude(generatedCodeFilter)
+    }
+    val debugTree = tier2Tree("intermediates/javac/debug/compileDebugJavaWithJavac/classes")
+    val kotlinDebugTree = tier2Tree("tmp/kotlin-classes/debug")
+
+    sourceDirectories.setFrom(files(jacocoSourceDirs))
+    classDirectories.setFrom(files(debugTree, kotlinDebugTree))
+    // AGP 8.11 writes one .ec per connected device under this tree.
+    executionData.setFrom(fileTree(layout.buildDirectory) {
+        include("outputs/code_coverage/debugAndroidTest/connected/**/*.ec")
+        include("outputs/managed_device_code_coverage/**/*.ec")
     })
 }
 

--- a/packages/catalyst-core/src/native/androidProject/app/src/androidTest/java/io/yourname/androidproject/tier2/CustomWebViewInstrumentedTest.kt
+++ b/packages/catalyst-core/src/native/androidProject/app/src/androidTest/java/io/yourname/androidproject/tier2/CustomWebViewInstrumentedTest.kt
@@ -1,0 +1,79 @@
+package io.yourname.androidproject.tier2
+
+import android.os.Bundle
+import android.webkit.WebView
+import android.widget.ProgressBar
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import io.yourname.androidproject.CustomWebView
+import io.yourname.androidproject.MainActivity
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Properties
+
+/**
+ * Tier 2 (#416): instrumented coverage for CustomWebView — the largest
+ * framework-bound class (~1350 lines), excluded from the Tier 1 Jacoco
+ * gate because it wraps a real android.webkit.WebView.
+ *
+ * These tests construct a real CustomWebView on the main thread with a
+ * real Activity Context and drive its public surface. They assert on
+ * construction and method invocation, NOT on rendered page content —
+ * there is no dev server in CI, and the missing-offline-asset path
+ * (assets/offline/offline.html is not checked in) is caught and logged,
+ * not a crash. So no IdlingResource, no page-load wait, no flakiness.
+ *
+ * The init {} block alone exercises setupFromProperties, WebCacheManager,
+ * OfflineCacheService, setupWebView and setupServiceWorker.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class CustomWebViewInstrumentedTest {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun constructsAndDrivesCorePaths() {
+        activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        activityRule.scenario.onActivity { activity ->
+            val webView = WebView(activity)
+            val progressBar = ProgressBar(activity)
+            val properties = Properties().apply {
+                setProperty("buildType", "debug")
+                setProperty("cachePatterns", "*.css,*.js")
+            }
+
+            // init {} runs here: setupFromProperties, WebCacheManager,
+            // OfflineCacheService, setupWebView, setupServiceWorker.
+            val customWebView = CustomWebView(activity, webView, progressBar, properties)
+            assertNotNull(customWebView.getWebView())
+
+            customWebView.setDefaultRequestHeaders(mapOf("X-Test" to "1"))
+            customWebView.updateLastTargetUrl("http://localhost:3005/")
+            customWebView.loadUrl("http://localhost:3005/")
+
+            // Missing-asset catch path — assets/offline/offline.html is
+            // not in the repo; showOfflinePage catches and logs.
+            customWebView.showOfflinePage()
+            customWebView.showOfflineRouteOrOfflinePage("http://localhost:3005/route")
+
+            val bundle = Bundle()
+            customWebView.saveState(bundle)
+            customWebView.restoreState(bundle)
+
+            customWebView.canGoBack()
+            customWebView.onPause()
+            customWebView.onResume()
+            customWebView.enableHardwareAcceleration()
+            customWebView.disableHardwareAcceleration()
+            customWebView.clearCache()
+            customWebView.clearAllCache()
+            customWebView.cleanupCache()
+        }
+    }
+}

--- a/packages/catalyst-core/src/native/androidProject/app/src/androidTest/java/io/yourname/androidproject/tier2/MainActivityLaunchTest.kt
+++ b/packages/catalyst-core/src/native/androidProject/app/src/androidTest/java/io/yourname/androidproject/tier2/MainActivityLaunchTest.kt
@@ -1,0 +1,36 @@
+package io.yourname.androidproject.tier2
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import io.yourname.androidproject.MainActivity
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tier 2 (#416): instrumented coverage for MainActivity.onCreate and its
+ * lifecycle. One launch transitively wires up CustomWebView, NativeBridge,
+ * PluginBridge, NativeCameraManager, KeyboardUtil, setupSafeAreaHandling,
+ * the back-press callback, and the launch-URL + network branch — all
+ * framework-bound code excluded from the Tier 1 gate.
+ *
+ * No dev server in CI: the WebView load fails, onReceivedError fires,
+ * showOfflineRouteOrOfflinePage is reached, the missing-asset path is
+ * caught. The Activity does not crash. recreate() covers the
+ * savedInstanceState != null branch of onCreate.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class MainActivityLaunchTest {
+
+    @Test
+    fun launchesAndRecreates() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            // savedInstanceState != null path in onCreate
+            scenario.recreate()
+            scenario.moveToState(Lifecycle.State.RESUMED)
+        }
+    }
+}

--- a/packages/catalyst-core/src/native/androidProject/app/src/androidTest/java/io/yourname/androidproject/tier2/SecurityAlertUITest.kt
+++ b/packages/catalyst-core/src/native/androidProject/app/src/androidTest/java/io/yourname/androidproject/tier2/SecurityAlertUITest.kt
@@ -1,0 +1,55 @@
+package io.yourname.androidproject.tier2
+
+import android.view.ContextThemeWrapper
+import android.view.ViewGroup
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import io.yourname.androidproject.R
+import io.yourname.androidproject.security.SecurityAlertUI
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tier 2 (#416): instrumented coverage for SecurityAlertUI — a ~360-line
+ * `object` that programmatically builds an alert View tree (FrameLayout /
+ * LinearLayout / ScrollView / TextView / Button, GradientDrawable,
+ * DesignTokens).
+ *
+ * It needs a real Context to inflate views, but NOT an Activity or a
+ * WebView — DesignTokens only reads resources.configuration and
+ * displayMetrics. A themed application context keeps this test cheap and
+ * flake-free (no MainActivity launch, no WebView init). Runs on the
+ * instrumentation thread so view construction is on the right looper.
+ */
+@RunWith(AndroidJUnit4::class)
+@MediumTest
+class SecurityAlertUITest {
+
+    private fun themedContext() = ContextThemeWrapper(
+        ApplicationProvider.getApplicationContext(),
+        R.style.Theme_AndroidProject,
+    )
+
+    @Test
+    fun buildsAlertViewWithThreats() {
+        var exitClicked = false
+        val view = SecurityAlertUI.createSecurityAlertView(
+            themedContext(),
+            listOf("ROOT_DETECTED", "DEBUGGER_ATTACHED", "EMULATOR_DETECTED"),
+        ) { exitClicked = true }
+
+        assertNotNull(view)
+        assertTrue(view is ViewGroup)
+        assertTrue((view as ViewGroup).childCount > 0)
+        assertTrue("callback should not fire on build", !exitClicked)
+    }
+
+    @Test
+    fun buildsAlertViewWithEmptyThreatList() {
+        val view = SecurityAlertUI.createSecurityAlertView(themedContext(), emptyList()) {}
+        assertNotNull(view)
+    }
+}

--- a/packages/catalyst-core/src/native/androidProject/app/src/androidTest/java/io/yourname/androidproject/tier2/SplashActivityLaunchTest.kt
+++ b/packages/catalyst-core/src/native/androidProject/app/src/androidTest/java/io/yourname/androidproject/tier2/SplashActivityLaunchTest.kt
@@ -1,0 +1,31 @@
+package io.yourname.androidproject.tier2
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import io.yourname.androidproject.SplashActivity
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tier 2 (#416): instrumented coverage for SplashActivity.onCreate.
+ *
+ * With no assets/webview_config.properties in the repo, onCreate hits its
+ * catch block and calls startMainActivity() + finish() + return BEFORE
+ * reaching RESUMED. ActivityScenario.launch() waits for RESUMED and would
+ * time out (~45s) — launchActivityForResult() tolerates a self-finishing
+ * activity. The splash-enabled branch (configureSplashScreen /
+ * startSplashTimer) stays uncovered because splash is disabled by default;
+ * that is acceptable for a report-only Tier 2 number.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class SplashActivityLaunchTest {
+
+    @Test
+    fun splashForwardsToMain() {
+        ActivityScenario.launchActivityForResult(SplashActivity::class.java).use {
+            // onCreate ran: assets.open threw -> startMainActivity() -> finish().
+        }
+    }
+}

--- a/packages/catalyst-core/src/native/iosnativeWebView/iosnativeWebView.xcodeproj/project.pbxproj
+++ b/packages/catalyst-core/src/native/iosnativeWebView/iosnativeWebView.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		E9F699DE2EE06506005E972E /* FilePickerHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F699DD2EE06506005E972E /* FilePickerHandlerTests.swift */; };
 		F1234AC22E990180008C7F58 /* localhost.p12 in Resources */ = {isa = PBXBuildFile; fileRef = F1234AC32E990180008C7F58 /* localhost.p12 */; };
 		F2B100012F11111100AAA001 /* PluginBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B100022F11111100AAA001 /* PluginBridgeTests.swift */; };
+		AAF416F416F416F416F41602 /* LaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF416F416F416F416F41601 /* LaunchTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,7 @@
 		F2B100022F11111100AAA001 /* PluginBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginBridgeTests.swift; sourceTree = "<group>"; };
 		XCCONFIG001000000001 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		XCCONFIG001000000002 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		AAF416F416F416F416F41601 /* LaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,6 +95,7 @@
 			isa = PBXGroup;
 			children = (
 				E9F699D12EDEFEF2005E972E /* iosnativeWebViewTests */,
+				AAF416F416F416F416F41603 /* iosnativeWebViewUITests */,
 				E9F699CF2EDEFCF3005E972E /* iosnativeWebView.xctestplan */,
 				47F3CABC2C639BF5007CF14B /* build.swift */,
 				4777D51D2C60B87500E85AC6 /* iosnativeWebView */,
@@ -145,6 +148,14 @@
 				E9F699D52EE05D74005E972E /* BridgeMessageValidatorTests.swift */,
 			);
 			path = iosnativeWebViewTests;
+			sourceTree = "<group>";
+		};
+		AAF416F416F416F416F41603 /* iosnativeWebViewUITests */ = {
+			isa = PBXGroup;
+			children = (
+				AAF416F416F416F416F41601 /* LaunchTests.swift */,
+			);
+			path = iosnativeWebViewUITests;
 			sourceTree = "<group>";
 		};
 		XCCONFIGGROUP001 /* Configurations */ = {
@@ -317,6 +328,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAF416F416F416F416F41602 /* LaunchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -530,7 +542,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				GENERATE_INFOPLIST_FILE = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "-mg.com.iosnativeWebViewUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.1mg.pos.uitests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -544,7 +556,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				GENERATE_INFOPLIST_FILE = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "-mg.com.iosnativeWebViewUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.1mg.pos.uitests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;

--- a/packages/catalyst-core/src/native/iosnativeWebView/iosnativeWebViewUITests/LaunchTests.swift
+++ b/packages/catalyst-core/src/native/iosnativeWebView/iosnativeWebViewUITests/LaunchTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+/// Tier 2 (#416): simulator UI test for the iosnativeWebView app target.
+///
+/// The Tier 1 XCTest unit target (`iosnativeWebViewTests`) never launches
+/// the real app, so `AppDelegate.didFinishLaunchingWithOptions`,
+/// `iosnativeWebViewApp.init`, and `ContentView.body` are uncovered. A
+/// real `XCUIApplication().launch()` exercises all of them plus
+/// `WebViewContainer` / `WebView.makeUIView` view construction.
+///
+/// There is no dev server in CI, so `ConfigConstants.url`
+/// (`http://localhost:3000`) fails to load — but the WKWebView element is
+/// still built and mounted. We assert on element existence, not page
+/// content. Report-only: this test's coverage is not a regression gate.
+final class LaunchTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testAppLaunchesAndMountsWebView() {
+        let app = XCUIApplication()
+        app.launch()
+
+        // A WKWebView surfaces as a `webViews` element once mounted. If
+        // the load stalls before the element registers, fall back to any
+        // top-level element so the launch itself is still asserted.
+        let mounted = app.webViews.firstMatch.waitForExistence(timeout: 30)
+            || app.otherElements.firstMatch.waitForExistence(timeout: 5)
+        XCTAssertTrue(mounted, "App launched but no view hierarchy was mounted")
+    }
+}


### PR DESCRIPTION
# Native Tier 2: emulator/simulator instrumented coverage (#416)

Adds a **report-only** instrumented-coverage number for the framework-bound
native classes that the Tier 1 Jacoco gate deliberately excludes.

## Context

Android native coverage sits at ~60% because `jacocoTestReport`
(`androidProject/app/build.gradle.kts`) excludes a `tier2FrameworkBoundFilter`
list — `CustomWebView`, `MainActivity`, `SplashActivity`, `NativeBridge`,
`SecurityAlert*`, camera classes — that structurally need a real
Activity/WebView/device. That exclusion keeps the Tier 1 gate honest (project
decision #2/#15, mirrors the iOS CoreLogic/app split from #432). The remaining
~40% is exactly those classes.

## What this adds

### Android — `jacocoAndroidTestReport` (commit 1)
- `enableAndroidTestCoverage = true` on the `debug` build type.
- New `jacocoAndroidTestReport` Gradle task — the **inverse** of
  `jacocoTestReport`: includes ONLY the `tier2FrameworkBoundFilter` classes,
  reads the `.ec` from `connectedDebugAndroidTest`.
- The two filter lists are hoisted to top-level `val`s so the reports share one
  definition and cannot drift. `jacocoTestReport` is otherwise untouched — the
  Tier 1 number is byte-for-byte unchanged.

### Android — instrumented tests (commit 2)
`app/src/androidTest/.../tier2/` — 4 files, ~6 `@Test`:
- `CustomWebViewInstrumentedTest` — constructs a real `CustomWebView` and drives
  `loadUrl` / offline paths / `saveState`-`restoreState` / cache / lifecycle.
- `MainActivityLaunchTest` — `ActivityScenario.launch` + `recreate()`;
  transitively wires `NativeBridge`, `PluginBridge`, `KeyboardUtil`, safe-area.
- `SplashActivityLaunchTest` — `launchActivityForResult` (Splash self-finishes
  in `onCreate` without a config file, so plain `launch()` would hang).
- `SecurityAlertUITest` — `SecurityAlertUI.createSecurityAlertView` builder.

No mocks, no dev server, no offline asset: `assets/` is empty in the repo, so the
WebView load fails, `onReceivedError` fires, the missing-asset path is caught.
Tests assert on construction / method invocation, not page content.

### Android CI — `android-instrumented-coverage` job (commit 3)
- New job, `needs: detect-changes`, `ubuntu-latest` (KVM),
  `reactivecircus/android-emulator-runner@v2.34.0` with AVD snapshot caching.
- Runs **parallel to the iOS critical path**, inside Android's ~6-min headroom —
  pipeline wall-clock unchanged.
- **Report-only**: prints the coverage %, baselines it on `main` push, but has
  **no regression-enforce step**. `coverage-summary` surfaces a non-success as a
  `::warning::`, not a gate failure.

### iOS — UITest target wiring (commit 4)
- `iosnativeWebViewUITests/LaunchTests.swift` — `XCUIApplication().launch()` +
  wait for the WebView element.
- Wires the (previously empty) `iosnativeWebViewUITests` target's source into
  `project.pbxproj`, and **fixes its malformed bundle id**
  (`-mg.com.iosnativeWebViewUITests` → `com.1mg.pos.uitests`) — the likely cause
  of the historical "bundle failed to load in CI".
- Changes **no CI**. `.npmignore`d from the published package.

### iOS CI — `ios-app-uitests` job (commit 5) — MEASURED GO/NO-GO
Separate parallel macOS job running `-only-testing:iosnativeWebViewUITests`,
report-only. **After the first CI run**: if its duration is ≤ ~5m50s, wall-clock
stays flat and it's kept; if > ~6 min it becomes the new critical path and this
commit is reverted (commit 4 stays), with iOS Tier 2 tracked as phase 2 on #416.

## Divergences from the #416 sketch

- Tests the checked-in template **in place**, not a `create-catalyst-app`
  scaffold — instrumented `.ec` attributes directly against template classes.
- **Report-only, not a regression gate** — fresh baselines are still moving.
- `jacocoTestReport` (Tier 1) is untouched.
- Goal is the coverage %, not E2E — no Maestro, no dev server.

## Verification

- `./gradlew jacocoTestReport` — Tier 1 LINE % unchanged.
- `./gradlew connectedDebugAndroidTest jacocoAndroidTestReport` — new report
  covers only the ~11 tier2 classes, LINE > 0.
- iOS: `** TEST BUILD SUCCEEDED **` for `-only-testing:iosnativeWebViewUITests`
  (bundle now builds + loads).
- First CI run: confirm `ios-app-simulator-tests` duration within noise of
  ~5m54s and total pipeline wall-clock ~9 min.
