### PR TITLE
fix: address CodeRabbit review findings on #437 (F1–F9)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -145,9 +145,9 @@ jobs:
               # deps aren't installed by the root `npm ci` above -- it needs
               # its own install. It now checks in a package-lock.json (was
               # previously .gitignore'd), so `npm ci` applies here: a locked
-              # install, and better-sqlite3 is pinned to 11.10.0, which ships
-              # Node 18/20/22 prebuilt binaries. Previously `npm install` on
-              # an unpinned `^9.4.3` resolved to 9.x, which has no Node 22
+              # install, and better-sqlite3 is pinned to 12.4.6, which ships
+              # Node 20/22/23/24 prebuilt binaries. Previously `npm install`
+              # on an unpinned `^9.4.3` resolved to 9.x, which has no Node 22
               # prebuild -- so CI recompiled better-sqlite3 from source with
               # node-gyp on every run (~75s). `npm ci` + a pinned prebuilt
               # version + the setup-node npm cache above brings this to ~2s.
@@ -325,6 +325,12 @@ jobs:
 
             - name: Run error-catalog contract scenarios
               working-directory: examples/error-catalog
+              # FORCE_PORT_KILL: the runner is disposable and nothing else
+              # listens on 3005, so the harness may hard-sweep the port
+              # between scenarios. Locally this is opt-in (it could kill a
+              # dev server) — see killTree in scripts/test-error.js.
+              env:
+                  CATALYST_ERROR_CATALOG_FORCE_PORT_KILL: "1"
               run: npm test
 
     android-unit-and-coverage:
@@ -817,13 +823,14 @@ jobs:
     # because a skipped platform (e.g. an android-only PR, where the iOS
     # and web jobs never run) must still count as fine here, not failure.
     coverage-summary:
-        needs: [detect-changes, unit-and-contract-tests, web-integration-smoke, error-catalog, android-unit-and-coverage, ios-corelogic-and-coverage, ios-app-simulator-tests]
+        needs: [detect-changes, lint, unit-and-contract-tests, web-integration-smoke, error-catalog, android-unit-and-coverage, ios-corelogic-and-coverage, ios-app-simulator-tests]
         if: always()
         runs-on: ubuntu-latest
         steps:
             - name: Report per-platform coverage and verify no regression
               run: |
                   detect_status="${{ needs.detect-changes.result }}"
+                  lint_status="${{ needs.lint.result }}"
                   web_status="${{ needs.unit-and-contract-tests.result }}"
                   web_smoke_status="${{ needs.web-integration-smoke.result }}"
                   error_catalog_status="${{ needs.error-catalog.result }}"
@@ -866,7 +873,7 @@ jobs:
                   fi
 
                   fail=0
-                  for pair in "web:$web_status" "web-integration-smoke:$web_smoke_status" "error-catalog:$error_catalog_status" "android:$android_status" "ios-corelogic:$ios_corelogic_status" "ios-app:$ios_app_status"; do
+                  for pair in "lint:$lint_status" "web:$web_status" "web-integration-smoke:$web_smoke_status" "error-catalog:$error_catalog_status" "android:$android_status" "ios-corelogic:$ios_corelogic_status" "ios-app:$ios_app_status"; do
                     platform="${pair%%:*}"
                     status="${pair#*:}"
                     if [ "$status" != "success" ] && [ "$status" != "skipped" ]; then

--- a/examples/error-catalog/scripts/demo.js
+++ b/examples/error-catalog/scripts/demo.js
@@ -277,6 +277,11 @@ async function main() {
 
     console.log("==========================================")
 
+    if (onlyCode && results.length === 0) {
+        console.error(`\n--only ${onlyCode}: no scenario matches that code.`)
+        process.exit(1)
+    }
+
     if (!allPassed) {
         console.error("\nSome scenarios failed.")
         process.exit(1)

--- a/examples/error-catalog/scripts/test-error.js
+++ b/examples/error-catalog/scripts/test-error.js
@@ -91,17 +91,32 @@ function killTree(child) {
             child.kill("SIGKILL")
         } catch (__) {}
     }
-    try {
-        const pids = execSync("lsof -i :3005 -t 2>/dev/null || true").toString().trim().split("\n").filter(Boolean)
-        for (const p of pids) {
-            if (p !== String(process.pid)) {
-                try { process.kill(Number(p), "SIGKILL") } catch (_) {}
+    // Last-resort sweep of ANYTHING on port 3005. This can kill an
+    // unrelated local dev server, so it is opt-in: set
+    // CATALYST_ERROR_CATALOG_FORCE_PORT_KILL=1 to enable it (CI does).
+    // The targeted kill above (the harness's own detached process group)
+    // is the normal path and always runs.
+    if (process.env.CATALYST_ERROR_CATALOG_FORCE_PORT_KILL === "1") {
+        try {
+            const pids = execSync("lsof -i :3005 -t 2>/dev/null || true").toString().trim().split("\n").filter(Boolean)
+            for (const p of pids) {
+                if (p !== String(process.pid)) {
+                    try { process.kill(Number(p), "SIGKILL") } catch (_) {}
+                }
             }
-        }
-    } catch (_) {}
+        } catch (_) {}
+    }
 }
 
-function getCatalystScript(scriptRelativePath) {
+// Resolve how to invoke a Catalyst CLI subcommand, returning a COMPLETE
+// argv prefix for either path:
+//   - local:  node <dist>/<scriptRelativePath>        (the subcommand IS the script)
+//   - npx:    npx -y catalyst <subcommand>            (the subcommand is an arg)
+// Callers must NOT re-append the subcommand — earlier this function returned
+// only ["-y","catalyst"] and callers did `scen.run.args.slice(1)`, which
+// silently dropped the subcommand on the npx path (`npx catalyst` with no
+// verb). Pass the subcommand explicitly here instead.
+function getCatalystScript(scriptRelativePath, subcommand) {
     const localBin = path.join(appDir, "node_modules", ".bin", "catalyst")
     if (fs.existsSync(localBin)) {
         const binTarget = fs.realpathSync(localBin)
@@ -110,14 +125,14 @@ function getCatalystScript(scriptRelativePath) {
             return { cmd: process.execPath, argsPrefix: [scriptPath] }
         }
     }
-    return { cmd: "npx", argsPrefix: ["-y", "catalyst"] }
+    return { cmd: "npx", argsPrefix: ["-y", "catalyst", subcommand] }
 }
 
 async function executeCliStartup(scen) {
     killTree(null)
     await new Promise((r) => setTimeout(r, 1500))
     return new Promise((resolve) => {
-        const binInfo = getCatalystScript("scripts/start.js")
+        const binInfo = getCatalystScript("scripts/start.js", scen.run.args[0])
         const cmdArgs = [...binInfo.argsPrefix, ...(scen.run.args.slice(1))]
 
         const child = spawn(binInfo.cmd, cmdArgs, {
@@ -192,7 +207,7 @@ async function executeHttp(scen) {
     await new Promise((r) => setTimeout(r, 1500))
     return new Promise((resolve) => {
         let output = ""
-        const binInfo = getCatalystScript("scripts/start.js")
+        const binInfo = getCatalystScript("scripts/start.js", "start")
         const cmdArgs = [...binInfo.argsPrefix]
 
         const child = spawn(binInfo.cmd, cmdArgs, {
@@ -295,7 +310,8 @@ async function executeBuild(scen) {
         let relScript = "scripts/build.js"
         if (scen.run?.args?.[0] === "buildApp:android") relScript = "native/buildAppAndroid.js"
         if (scen.run?.args?.[0] === "buildApp:ios") relScript = "native/buildAppIos.js"
-        const binInfo = getCatalystScript(relScript)
+        const subcommand = scen.run?.args?.[0] || "build"
+        const binInfo = getCatalystScript(relScript, subcommand)
         const cmdArgs = [...binInfo.argsPrefix]
 
         const child = spawn(binInfo.cmd, cmdArgs, {
@@ -423,6 +439,11 @@ async function main() {
     let passedCount = 0
     let failedCount = 0
     let skippedCount = 0
+    // "covered" = has a real scenario that ran, OR a deliberate ledger
+    // entry documenting why it can't be reproduced here. "uncovered" =
+    // neither (a gap). Tracked separately so the summary line is honest.
+    let ledgerCount = 0
+    let uncoveredCount = 0
 
     const baselineSnapshot = snapshotApp()
 
@@ -501,10 +522,12 @@ async function main() {
             status = "SKIP"
             detail = `Ledger tier: ${ledgerTier}`
             skippedCount++
+            ledgerCount++
         } else {
             status = "SKIP"
             detail = "No scenario or ledger definition"
             skippedCount++
+            uncoveredCount++
         }
 
         console.log(`${code.padEnd(16)} [${tier}]`)
@@ -514,9 +537,14 @@ async function main() {
         console.log(`Result      : ${status}${detail ? ` (${detail})` : ""}`)
     }
 
+    const coveredCount = passedCount + failedCount + ledgerCount
     console.log("=============================================")
     console.log(`Summary: ${passedCount} PASS, ${failedCount} FAIL, ${skippedCount} SKIP`)
-    console.log(`covered ${allCodes.length}/${allCodes.length} error codes`)
+    console.log(
+        `covered ${coveredCount}/${allCodes.length} error codes ` +
+        `(${passedCount + failedCount} via scenario, ${ledgerCount} via ledger` +
+        `${uncoveredCount ? `, ${uncoveredCount} with no definition` : ""})`
+    )
     console.log("=============================================")
 
     if (failedCount > 0) {

--- a/examples/error-catalog/test/scenarios.test.ts
+++ b/examples/error-catalog/test/scenarios.test.ts
@@ -73,17 +73,30 @@ function killTree(child: any) {
             child.kill("SIGKILL")
         } catch (__) {}
     }
-    try {
-        const pids = execSync("lsof -i :3005 -t 2>/dev/null || true").toString().trim().split("\n").filter(Boolean)
-        for (const p of pids) {
-            if (p !== String(process.pid)) {
-                try { process.kill(Number(p), "SIGKILL") } catch (_) {}
+    // Last-resort sweep of ANYTHING on port 3005. Can kill an unrelated
+    // local dev server, so it is opt-in via
+    // CATALYST_ERROR_CATALOG_FORCE_PORT_KILL=1 (set in CI, where the runner
+    // is disposable). The targeted process-group kill above always runs.
+    if (
+        process.env.CATALYST_ERROR_CATALOG_FORCE_PORT_KILL === "1" ||
+        process.env.CI === "true"
+    ) {
+        try {
+            const pids = execSync("lsof -i :3005 -t 2>/dev/null || true").toString().trim().split("\n").filter(Boolean)
+            for (const p of pids) {
+                if (p !== String(process.pid)) {
+                    try { process.kill(Number(p), "SIGKILL") } catch (_) {}
+                }
             }
-        }
-    } catch (_) {}
+        } catch (_) {}
+    }
 }
 
-function getCatalystScript(scriptRelativePath: string) {
+// Resolve how to invoke a Catalyst CLI subcommand, returning a COMPLETE
+// argv prefix for either path (local `node <dist>/<script>` vs
+// `npx -y catalyst <subcommand>`). Callers must not re-append the
+// subcommand — the npx path needs it as an explicit arg.
+function getCatalystScript(scriptRelativePath: string, subcommand: string) {
     const localBin = path.join(appDir, "node_modules", ".bin", "catalyst")
     if (fs.existsSync(localBin)) {
         const binTarget = fs.realpathSync(localBin)
@@ -92,14 +105,14 @@ function getCatalystScript(scriptRelativePath: string) {
             return { cmd: process.execPath, argsPrefix: [scriptPath] }
         }
     }
-    return { cmd: "npx", argsPrefix: ["-y", "catalyst"] }
+    return { cmd: "npx", argsPrefix: ["-y", "catalyst", subcommand] }
 }
 
 async function executeCliStartup(scen: any): Promise<{ passed: boolean; output: string }> {
     killTree(null)
     await new Promise((r) => setTimeout(r, 1500))
     return new Promise((resolve) => {
-        const binInfo = getCatalystScript("scripts/start.js")
+        const binInfo = getCatalystScript("scripts/start.js", scen.run.args[0])
         const cmdArgs = [...binInfo.argsPrefix, ...(scen.run.args.slice(1))]
 
         const child = spawn(binInfo.cmd, cmdArgs, {
@@ -173,7 +186,7 @@ async function executeHttp(scen: any): Promise<{ passed: boolean; output: string
     await new Promise((r) => setTimeout(r, 1500))
     return new Promise((resolve) => {
         let output = ""
-        const binInfo = getCatalystScript("scripts/start.js")
+        const binInfo = getCatalystScript("scripts/start.js", "start")
         const cmdArgs = [...binInfo.argsPrefix]
 
         const child = spawn(binInfo.cmd, cmdArgs, {
@@ -266,7 +279,7 @@ async function executeBuild(scen: any): Promise<{ passed: boolean; output: strin
         let relScript = "scripts/build.js"
         if (scen.run?.args?.[0] === "buildApp:android") relScript = "native/buildAppAndroid.js"
         if (scen.run?.args?.[0] === "buildApp:ios") relScript = "native/buildAppIos.js"
-        const binInfo = getCatalystScript(relScript)
+        const binInfo = getCatalystScript(relScript, scen.run?.args?.[0] || "build")
         const cmdArgs = [...binInfo.argsPrefix]
 
         const child = spawn(binInfo.cmd, cmdArgs, {
@@ -382,10 +395,18 @@ describe("Error Catalog Contract Fixtures", () => {
 
     it("completeness: covers all 72 error codes", () => {
         const scenarioCodes = new Set(scenarios.map((s) => s.code))
+        let viaScenario = 0
+        let viaLedger = 0
+        const missing: string[] = []
         for (const code of allCodes) {
-            const hasCoverage = scenarioCodes.has(code) || Boolean(LEDGER[code as keyof typeof LEDGER])
-            expect(hasCoverage, `Missing coverage for error code ${code}`).toBe(true)
+            if (scenarioCodes.has(code)) viaScenario++
+            else if (LEDGER[code as keyof typeof LEDGER]) viaLedger++
+            else missing.push(code)
         }
-        console.log(`covered ${allCodes.length}/${allCodes.length} error codes`)
+        expect(missing, `Missing coverage for: ${missing.join(", ")}`).toEqual([])
+        console.log(
+            `covered ${viaScenario + viaLedger}/${allCodes.length} error codes ` +
+            `(${viaScenario} via scenario, ${viaLedger} via ledger)`
+        )
     })
 })

--- a/packages/catalyst-core/mcp_v2/package-lock.json
+++ b/packages/catalyst-core/mcp_v2/package-lock.json
@@ -8,7 +8,7 @@
             "name": "catalyst-mcp",
             "version": "2.0.0",
             "dependencies": {
-                "better-sqlite3": "11.10.0"
+                "better-sqlite3": "12.4.6"
             },
             "devDependencies": {
                 "typescript": "^7.0.2",
@@ -813,14 +813,17 @@
             "license": "MIT"
         },
         "node_modules/better-sqlite3": {
-            "version": "11.10.0",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-            "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+            "version": "12.4.6",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.4.6.tgz",
+            "integrity": "sha512-gaYt9yqTbQ1iOxLpJA8FPR5PiaHP+jlg8I5EX0Rs2KFwNzhBsF40KzMZS5FwelY7RG0wzaucWdqSAJM3uNCPCg==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "bindings": "^1.5.0",
                 "prebuild-install": "^7.1.1"
+            },
+            "engines": {
+                "node": "20.x || 22.x || 23.x || 24.x || 25.x"
             }
         },
         "node_modules/bindings": {

--- a/packages/catalyst-core/mcp_v2/package.json
+++ b/packages/catalyst-core/mcp_v2/package.json
@@ -12,7 +12,7 @@
         "test:types": "tsc --noEmit"
     },
     "dependencies": {
-        "better-sqlite3": "11.10.0"
+        "better-sqlite3": "12.4.6"
     },
     "devDependencies": {
         "typescript": "^7.0.2",

--- a/packages/catalyst-core/src/scripts/preflight.js
+++ b/packages/catalyst-core/src/scripts/preflight.js
@@ -33,10 +33,14 @@ function readJson(filePath) {
 
 /**
  * Run the static preflight checks against an app directory.
- * @param {string} appDir - the consumer app root (defaults to process.env.PWD)
+ * @param {string} [appDir] - the consumer app root. Defaults to the current
+ *   working directory. `process.env.PWD` is preferred when set (it survives a
+ *   `cd` in the invoking shell script), but it is not exported by every shell
+ *   / CI runner, so `process.cwd()` is the fallback — never `undefined`, which
+ *   would make the `path.join` calls below throw.
  * @returns {import("../errors/index.js").CatalystError[]} all failures (empty = passed)
  */
-export function runStaticPreflight(appDir = process.env.PWD) {
+export function runStaticPreflight(appDir = process.env.PWD || process.cwd()) {
     const failures = []
 
     // config/config.json
@@ -91,7 +95,7 @@ export function runStaticPreflight(appDir = process.env.PWD) {
  * of a CLI entry script (start / serve / build).
  * @param {string} [appDir]
  */
-export function runStaticPreflightOrExit(appDir = process.env.PWD) {
+export function runStaticPreflightOrExit(appDir = process.env.PWD || process.cwd()) {
     const mode = resolveOutputMode(process.argv)
     const failures = runStaticPreflight(appDir)
     if (failures.length === 0) return

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -371,9 +371,18 @@ async function _handler(req, res) {
     try {
         let context = {}
         let fetcherData = {}
+        // A missing / non-function configureStore is not recoverable per
+        // request: every downstream step (serverSideFunction, data fetchers,
+        // render) assumes a real store. Log the coded error and fail the
+        // request with a 500 rather than rendering with `store = null`, which
+        // surfaces as a confusing render-time crash further down.
         const configureStoreErr = validateConfigureStore(createStore)
-        if (configureStoreErr) handleError(configureStoreErr)
-        const store = configureStoreErr ? null : await createStore({}, req, res)
+        if (configureStoreErr) {
+            handleError(configureStoreErr)
+            if (!res.headersSent) res.status(500).send("Internal Server Error")
+            return
+        }
+        const store = await createStore({}, req, res)
 
         const cachedRoutes = getCachedRoutes()
         const allMatches = cachedRoutes ? NestedMatchRoutes(cachedRoutes, req.originalUrl) || [] : []

--- a/packages/catalyst-core/src/server/utils/validator.js
+++ b/packages/catalyst-core/src/server/utils/validator.js
@@ -76,11 +76,14 @@ const validatePackageJson = (obj) => {
 const validateModuleAlias = (obj) => {
     if (!obj) return createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_MISSING)
     if (typeof obj !== "object") return createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_NOT_OBJECT)
-    // A consumer app must not shadow the framework's own "@catalyst/*" aliases
-    // with its own moduleAliases entries — check the INPUT's keys, not the
-    // required list (that check was previously on the wrong side and could
-    // never fire; PREFLIGHT-008).
-    if (Object.keys(obj).some((key) => key.includes("catalyst")))
+    // A consumer app must not shadow the framework's own "@catalyst*" aliases
+    // (both "@catalyst/…" and "@catalyst-…" are reserved) with its own
+    // moduleAliases entries — check the INPUT's keys, not the required list
+    // (that check was previously on the wrong side and could never fire;
+    // PREFLIGHT-008). Anchored to the start and case-insensitive: a bare
+    // `.includes("catalyst")` also (wrongly) rejected unrelated names like
+    // "@my-catalyst-helpers", which don't shadow anything.
+    if (Object.keys(obj).some((key) => /^@catalyst($|[/-])/i.test(key)))
         return createError(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_RESTRICTED)
     const requiredModuleAliases = ["@api", "@containers", "@server", "@config", "@css", "@routes"]
     for (const key of requiredModuleAliases) {

--- a/packages/catalyst-core/test/server/handler.test.ts
+++ b/packages/catalyst-core/test/server/handler.test.ts
@@ -158,6 +158,34 @@ describe("SSR handler", () => {
         expect(res.getHtml()).toContain("<html")
     })
 
+    it("fails the request with 500 (no render) when configureStore is not a function", async () => {
+        // handler.jsx imports createStore as a module-scope default binding,
+        // so swap the fixture module before the fresh import. A non-function
+        // default makes validateConfigureStore return a CatalystError ->
+        // _handler must handleError + 500 + return, not render with a null
+        // store.
+        vi.resetModules()
+        vi.doMock("@catalyst/template/src/js/store/index.js", () => ({ default: {} }))
+        const logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+        try {
+            const { default: handler } = await import("../../src/server/renderer/handler.jsx")
+            const { req, res } = makeReqRes("/")
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(500)
+            expect(res.send).toHaveBeenCalledWith("Internal Server Error")
+            // no HTML streamed
+            expect(res.getHtml()).toBe("")
+            // handleError logs the coded error (via console.log)
+            const logged = logSpy.mock.calls.flat().join("\n")
+            expect(logged).toMatch(/PREFLIGHT-01[0-9]|configureStore/i)
+        } finally {
+            vi.doUnmock("@catalyst/template/src/js/store/index.js")
+            vi.resetModules()
+        }
+    })
+
     it("does not throw out of handler when request handling fails entirely", async () => {
         const { default: handler } = await import("../../src/server/renderer/handler.jsx")
         // a req with no originalUrl / no get() -> NestedMatchRoutes and

--- a/packages/catalyst-core/test/server/validator.test.ts
+++ b/packages/catalyst-core/test/server/validator.test.ts
@@ -91,6 +91,22 @@ describe("validateModuleAlias", () => {
         const err = validateModuleAlias({ ...VALID_ALIASES, "@catalyst/thing": "x" })
         expect(err?.code).toBe(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_RESTRICTED)
     })
+    it("PREFLIGHT-008 matches the @catalyst namespace case-insensitively", () => {
+        const err = validateModuleAlias({ ...VALID_ALIASES, "@Catalyst/core": "x" })
+        expect(err?.code).toBe(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_RESTRICTED)
+    })
+    it("PREFLIGHT-008 also rejects a bare '@catalyst' key (no separator)", () => {
+        const err = validateModuleAlias({ ...VALID_ALIASES, "@catalyst": "x" })
+        expect(err?.code).toBe(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_RESTRICTED)
+    })
+    it("PREFLIGHT-008 rejects the '@catalyst-' hyphen form too (e.g. @catalyst-custom)", () => {
+        const err = validateModuleAlias({ ...VALID_ALIASES, "@catalyst-custom": "x" })
+        expect(err?.code).toBe(ERROR_CODES.PREFLIGHT_MODULE_ALIAS_RESTRICTED)
+    })
+    it("does NOT reject an unrelated alias that merely contains 'catalyst'", () => {
+        expect(validateModuleAlias({ ...VALID_ALIASES, "@my-catalyst-helpers": "x" })).toBeNull()
+        expect(validateModuleAlias({ ...VALID_ALIASES, "@catalystic": "x" })).toBeNull()
+    })
     it("PREFLIGHT-009 when a required alias is missing, naming it", () => {
         const { "@containers": _omit, ...rest } = VALID_ALIASES
         const err = validateModuleAlias(rest)


### PR DESCRIPTION
Follow-up to the CodeRabbit review posted on #437. Fixes every valid finding; F10 was a false positive.

| # | Sev | Fix |
|---|-----|-----|
| **F1** | Major | `coverage-summary` now `needs:` **`lint`** and checks its result in the status loop — a red lint job is no longer masked by downstream skips. |
| **F2** | Major | `runStaticPreflight` / `runStaticPreflightOrExit` fall back to `process.cwd()` when `process.env.PWD` is unset (some shells / CI runners don't export it → `path.join(undefined,…)` threw). |
| **F3** | Major | `validateModuleAlias` reserved-namespace check: `key.includes("catalyst")` → `/^@catalyst($\|[/-])/i`. Still rejects `@catalyst/…` **and** `@catalyst-…` (PREFLIGHT-008, incl. the error-catalog scenario's `@catalyst-custom`); no longer rejects `@my-catalyst-helpers` / `@catalystic`. |
| **F4** | Major | `handler.jsx`: a non-function `configureStore` now → `handleError` + **500 + return**, instead of rendering with `store = null` and crashing downstream. |
| **F5** | Minor | `killTree`'s port-3005 `lsof` sweep is gated behind `CATALYST_ERROR_CATALOG_FORCE_PORT_KILL=1` / `CI=true` (both set in the CI job). Targeted process-group kill still always runs — no more killing an unrelated local dev server. |
| **F6** | Major | `getCatalystScript` takes the subcommand explicitly and returns a complete argv prefix for both the local and `npx` paths — the npx path was dropping the verb (`npx catalyst` with nothing). Applied to `scripts/test-error.js` and `test/scenarios.test.ts`. |
| **F7** | Minor | `demo.js`: `--only <code>` with no match now errors + exits non-zero instead of reporting a successful empty run. |
| **F8** | Minor | `covered N/N` summary line is derived, not hard-coded: `covered <scenario+ledger>/<total> (<n> via scenario, <n> via ledger)`. |
| **F9** | Minor | `better-sqlite3` `11.10.0` → **`12.4.6`** — adds Node 24 (ABI 137) prebuilds on top of 20/22/23. Only v11→v12 breaking change is dropping EOL Node 18 (mcp_v2 is `engines: >=20`). Lockfile regenerated; `npm ci` still ~2s, 6/6 tests pass. |
| **F10** | — | **Not a bug.** `androidSetup.js` already imports `./terminalProgress.js` (lowercase); no PascalCase path ref exists. CodeRabbit matched the class identifier. |

### New tests
- `handler.test.ts` — the 500-on-bad-`configureStore` path (F4)
- `validator.test.ts` — `@catalyst-` / `@Catalyst` case-insensitive rejection + `@my-catalyst-helpers` / `@catalystic` allowed (F3)

### Verification
- catalyst-core: node **155/155**, web-router **62/62**, `tsc -p tsconfig.test.json` clean
- mcp_v2: **6/6**, `npm ci` ~2s
- error-catalog `scenarios.test.ts`: **54 pass / 8 skip** — exact parity with the base branch (bisected the F3 regex against this suite; the `@catalyst-` hyphen form is genuinely reserved here, so the fix keeps PREFLIGHT-008 firing)
- `node.js.yml` YAML validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)