### PR TITLE
feat: Early Hints support (Cloudflare Link header + native Node)

### DIFF
--- a/packages/catalyst-core/src/server/renderer/extract.js
+++ b/packages/catalyst-core/src/server/renderer/extract.js
@@ -87,6 +87,17 @@ export const generateModulePreloadLinkElements = (jsUrls = [], keyPrefix = "modu
     )
 
 /**
+ * HTTP `Link` header value for critical JS, so Cloudflare Early Hints (103)
+ * can preload them before SSR finishes. `as=script; crossorigin` matches the
+ * fetch mode of the `<script type="module">` tags these accompany, avoiding
+ * a double download.
+ * @param {string[]} jsUrls
+ * @returns {string}
+ */
+export const generateLinkHeader = (jsUrls = []) =>
+    [...new Set(jsUrls)].map((url) => `<${url}>; rel=preload; as=script; crossorigin`).join(", ")
+
+/**
  * Read CSS files from disk and return concatenated CSS string for inlining.
  * @param {string[]} cssPaths - Relative CSS paths (from manifest).
  * @param {string} basePath  - Build output directory on disk.

--- a/packages/catalyst-core/src/server/renderer/extract.js
+++ b/packages/catalyst-core/src/server/renderer/extract.js
@@ -98,6 +98,24 @@ export const generateLinkHeader = (jsUrls = []) =>
     [...new Set(jsUrls)].map((url) => `<${url}>; rel=preload; as=script; crossorigin`).join(", ")
 
 /**
+ * HTTP `Link` header value for app-supplied preconnect/preload entries — third-party analytics
+ * origins, a static LCP image, fonts, etc. Never hardcoded here: the app declares exactly which
+ * URLs it wants hinted (see EARLY_HINTS_LINKS in handler.jsx), and this only formats them.
+ * @param {{url: string, rel: "preconnect"|"preload", as?: string, crossorigin?: boolean}[]} links
+ * @returns {string}
+ */
+export const generateCustomLinkHeader = (links = []) =>
+    links
+        .filter((link) => link?.url && (link.rel === "preload" || link.rel === "preconnect"))
+        .map((link) => {
+            const parts = [`<${link.url}>`, `rel=${link.rel}`]
+            if (link.as) parts.push(`as=${link.as}`)
+            if (link.crossorigin) parts.push("crossorigin")
+            return parts.join("; ")
+        })
+        .join(", ")
+
+/**
  * Read CSS files from disk and return concatenated CSS string for inlining.
  * @param {string[]} cssPaths - Relative CSS paths (from manifest).
  * @param {string} basePath  - Build output directory on disk.

--- a/packages/catalyst-core/src/server/renderer/extract.js
+++ b/packages/catalyst-core/src/server/renderer/extract.js
@@ -91,17 +91,29 @@ export const generateModulePreloadLinkElements = (jsUrls = [], keyPrefix = "modu
  * can preload them before SSR finishes. `as=script; crossorigin` matches the
  * fetch mode of the `<script type="module">` tags these accompany, avoiding
  * a double download.
+ *
+ * `fetchPriority` matters once there's more than a handful of URLs in one
+ * hint: without it, every entry competes equally for bandwidth on the same
+ * HTTP/2 connection, so a page with many shell-rendered split() widgets can
+ * end up starving the actual app-shell bundles (main/vendor/route entry) of
+ * bandwidth behind a pile of secondary widget chunks. Pass "high" for the
+ * critical bucket and "low" for the shell-deferred one — see handler.jsx.
  * @param {string[]} jsUrls
+ * @param {"high"|"low"} [fetchPriority]
  * @returns {string}
  */
-export const generateLinkHeader = (jsUrls = []) =>
-    [...new Set(jsUrls)].map((url) => `<${url}>; rel=preload; as=script; crossorigin`).join(", ")
+export const generateLinkHeader = (jsUrls = [], fetchPriority) => {
+    const priorityPart = fetchPriority ? `; fetchpriority=${fetchPriority}` : ""
+    return [...new Set(jsUrls)]
+        .map((url) => `<${url}>; rel=preload; as=script; crossorigin${priorityPart}`)
+        .join(", ")
+}
 
 /**
  * HTTP `Link` header value for app-supplied preconnect/preload entries — third-party analytics
  * origins, a static LCP image, fonts, etc. Never hardcoded here: the app declares exactly which
  * URLs it wants hinted (see EARLY_HINTS_LINKS in handler.jsx), and this only formats them.
- * @param {{url: string, rel: "preconnect"|"preload", as?: string, crossorigin?: boolean}[]} links
+ * @param {{url: string, rel: "preconnect"|"preload", as?: string, crossorigin?: boolean, fetchPriority?: "high"|"low"}[]} links
  * @returns {string}
  */
 export const generateCustomLinkHeader = (links = []) =>
@@ -111,6 +123,7 @@ export const generateCustomLinkHeader = (links = []) =>
             const parts = [`<${link.url}>`, `rel=${link.rel}`]
             if (link.as) parts.push(`as=${link.as}`)
             if (link.crossorigin) parts.push("crossorigin")
+            if (link.fetchPriority) parts.push(`fetchpriority=${link.fetchPriority}`)
             return parts.join("; ")
         })
         .join(", ")

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -106,10 +106,17 @@ if (process.env.OTEL_ENABLE === true) {
 
 const SSR_SERVICE = process.env.SERVICE_NAME || `pwa-${process.env.APPLICATION}-node-server`
 
-// Config-driven (config.json → EARLY_HINTS_ENABLE): when on, critical JS is advertised via
-// an HTTP `Link` header so a fronting CDN (e.g. Cloudflare Early Hints) can preload it before
-// SSR finishes. Off by default — no behavior change unless explicitly enabled.
-const EARLY_HINTS_ENABLE = process.env.EARLY_HINTS_ENABLE === true
+// Config-driven (config.json → CLOUDFLARE_EARLY_HINTS_ENABLE): when on, critical + shell JS is
+// advertised via an HTTP `Link` header so a fronting CDN (e.g. Cloudflare Early Hints) can learn
+// it and replay it as a 103 on later requests to the same URL. Off by default.
+const CLOUDFLARE_EARLY_HINTS_ENABLE = process.env.CLOUDFLARE_EARLY_HINTS_ENABLE === true
+
+// Config-driven (config.json → NATIVE_EARLY_HINTS_ENABLE): when on, this server sends real HTTP
+// 103 Early Hints responses itself via res.writeEarlyHints() — useful when nothing in front of
+// Node (or the proxy in front of it) already does this, e.g. no CDN, or a non-Cloudflare one.
+// Unlike the Cloudflare path, this can hint the *current* request, not just future ones, since
+// it doesn't depend on a CDN having learned anything from a prior response. Off by default.
+const NATIVE_EARLY_HINTS_ENABLE = process.env.NATIVE_EARLY_HINTS_ENABLE === true
 
 const traceHook = (fn, spanName) =>
     typeof fn === "function" ? withSyncObservability(SSR_SERVICE, fn, spanName) : fn
@@ -296,16 +303,22 @@ const _renderMarkUp = async (
             const { pipe } = renderToPipeableStream(<CompleteDocument />, {
                 onShellReady() {
                     res.setHeader("content-type", "text/html")
-                    if (EARLY_HINTS_ENABLE) {
-                        // window.__SSR_RENDERED_COMPONENTS__ (split() chunks discovered during
-                        // render) are eagerly re-imported client-side and block hydrateRoot via
-                        // hydrationReady() — not lazy — so they're as hint-worthy as critical JS.
-                        // Only what's been discovered by shell-ready is known this early; chunks
-                        // behind Suspense boundaries still pending resolve after headers are sent
-                        // and can't be included.
-                        const shellDeferredJs = chunkExtractor ? chunkExtractor.getDeferredAssets().js : []
+                    // window.__SSR_RENDERED_COMPONENTS__ (split() chunks discovered during
+                    // render) are eagerly re-imported client-side and block hydrateRoot via
+                    // hydrationReady() — not lazy — so they're as hint-worthy as critical JS.
+                    // Only what's been discovered by shell-ready is known this early; chunks
+                    // behind Suspense boundaries still pending resolve after headers are sent
+                    // and can't be included.
+                    const shellDeferredJs = chunkExtractor ? chunkExtractor.getDeferredAssets().js : []
+                    if (CLOUDFLARE_EARLY_HINTS_ENABLE) {
                         const linkHeader = generateLinkHeader([...criticalAssets.js, ...shellDeferredJs])
                         if (linkHeader) res.setHeader("link", linkHeader)
+                    }
+                    if (NATIVE_EARLY_HINTS_ENABLE) {
+                        // Critical JS was already hinted in _handler, before data-fetching —
+                        // only the newly-discovered shell JS needs a (second) 103 here.
+                        const linkValues = generateLinkHeader(shellDeferredJs)
+                        if (linkValues) res.writeEarlyHints({ link: linkValues.split(", ") })
                     }
                     pipe(tail)
                 },
@@ -366,6 +379,17 @@ async function _handler(req, res) {
         safeCall(onRouteMatch, { req, res, matches: allMatches, store })
 
         if (res.headersSent) return
+
+        if (NATIVE_EARLY_HINTS_ENABLE) {
+            // Sent as early as possible — before the app-side hook and data fetcher, which can
+            // be slow — so the browser can start fetching critical JS in parallel with them
+            // instead of waiting for the full SSR response. A throwaway extractor: the route's
+            // critical JS depends only on `allMatches`, already known here, and re-collecting it
+            // below for the real render is unaffected.
+            const earlyAssets = collectAssets(req, allMatches).getCriticalAssets()
+            const linkValues = generateLinkHeader(earlyAssets.js)
+            if (linkValues) res.writeEarlyHints({ link: linkValues.split(", ") })
+        }
 
         try {
             await tracedAppServerSideFunction({ store, req, res })

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -246,10 +246,6 @@ const _renderMarkUp = async (
     try {
         const status = errorCode || (allMatches.length && allMatches[0]?.route?.path === "*" ? 404 : 200)
         res.set({ "content-type": "text/html; charset=utf-8" })
-        if (EARLY_HINTS_ENABLE) {
-            const linkHeader = generateLinkHeader(criticalAssets.js)
-            if (linkHeader) res.setHeader("link", linkHeader)
-        }
         res.status(status)
 
         return new Promise((resolve, reject) => {
@@ -300,6 +296,17 @@ const _renderMarkUp = async (
             const { pipe } = renderToPipeableStream(<CompleteDocument />, {
                 onShellReady() {
                     res.setHeader("content-type", "text/html")
+                    if (EARLY_HINTS_ENABLE) {
+                        // window.__SSR_RENDERED_COMPONENTS__ (split() chunks discovered during
+                        // render) are eagerly re-imported client-side and block hydrateRoot via
+                        // hydrationReady() — not lazy — so they're as hint-worthy as critical JS.
+                        // Only what's been discovered by shell-ready is known this early; chunks
+                        // behind Suspense boundaries still pending resolve after headers are sent
+                        // and can't be included.
+                        const shellDeferredJs = chunkExtractor ? chunkExtractor.getDeferredAssets().js : []
+                        const linkHeader = generateLinkHeader([...criticalAssets.js, ...shellDeferredJs])
+                        if (linkHeader) res.setHeader("link", linkHeader)
+                    }
                     pipe(tail)
                 },
 

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -329,8 +329,12 @@ const _renderMarkUp = async (
                     if (CLOUDFLARE_EARLY_HINTS_ENABLE) {
                         // customLinkHeader (app-supplied preconnect/preload entries) included here
                         // too — Cloudflare only ever sees this one combined header per response.
+                        // fetchpriority keeps a page with many shell-rendered split() widgets from
+                        // hinting all of them equally — deferred chunks yield bandwidth to the
+                        // app-shell bundles that actually gate hydration.
                         const linkHeader = [
-                            generateLinkHeader([...criticalAssets.js, ...shellDeferredJs]),
+                            generateLinkHeader(criticalAssets.js, "high"),
+                            generateLinkHeader(shellDeferredJs, "low"),
                             customLinkHeader,
                         ]
                             .filter(Boolean)
@@ -340,7 +344,7 @@ const _renderMarkUp = async (
                     if (NATIVE_EARLY_HINTS_ENABLE) {
                         // Critical JS was already hinted in _handler, before data-fetching —
                         // only the newly-discovered shell JS needs a (second) 103 here.
-                        const linkValues = generateLinkHeader(shellDeferredJs)
+                        const linkValues = generateLinkHeader(shellDeferredJs, "low")
                         if (linkValues) res.writeEarlyHints({ link: linkValues.split(", ") })
                     }
                     pipe(tail)
@@ -411,7 +415,7 @@ async function _handler(req, res) {
             // route's critical JS depends only on `allMatches`, already known here, and
             // re-collecting it below for the real render is unaffected.
             const earlyAssets = collectAssets(req, allMatches).getCriticalAssets()
-            const linkValues = [generateLinkHeader(earlyAssets.js), customLinkHeader]
+            const linkValues = [generateLinkHeader(earlyAssets.js, "high"), customLinkHeader]
                 .filter(Boolean)
                 .join(", ")
             if (linkValues) res.writeEarlyHints({ link: linkValues.split(", ") })

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -22,6 +22,7 @@ import {
     getDeferredPreloadScriptUrls,
     generateModulePreloadLinkElements,
     generateLinkHeader,
+    generateCustomLinkHeader,
 } from "./extract.js"
 import path from "path"
 import { Transform } from "node:stream"
@@ -117,6 +118,21 @@ const CLOUDFLARE_EARLY_HINTS_ENABLE = process.env.CLOUDFLARE_EARLY_HINTS_ENABLE 
 // Unlike the Cloudflare path, this can hint the *current* request, not just future ones, since
 // it doesn't depend on a CDN having learned anything from a prior response. Off by default.
 const NATIVE_EARLY_HINTS_ENABLE = process.env.NATIVE_EARLY_HINTS_ENABLE === true
+
+// Config-driven (config.json → EARLY_HINTS_LINKS): app-supplied preconnect/preload entries —
+// third-party analytics origins, a static LCP image, fonts, etc. Never hardcoded in catalyst-core
+// itself; the app declares the exact URLs it wants hinted. JSON array of
+// { url, rel: "preconnect"|"preload", as?, crossorigin? }. Computed once — this list is static
+// for the process lifetime, unlike criticalAssets/deferredAssets which vary per request.
+const EARLY_HINTS_LINKS = (() => {
+    try {
+        const parsed = JSON.parse(process.env.EARLY_HINTS_LINKS || "[]")
+        return Array.isArray(parsed) ? parsed : []
+    } catch {
+        return []
+    }
+})()
+const customLinkHeader = generateCustomLinkHeader(EARLY_HINTS_LINKS)
 
 const traceHook = (fn, spanName) =>
     typeof fn === "function" ? withSyncObservability(SSR_SERVICE, fn, spanName) : fn
@@ -311,7 +327,14 @@ const _renderMarkUp = async (
                     // and can't be included.
                     const shellDeferredJs = chunkExtractor ? chunkExtractor.getDeferredAssets().js : []
                     if (CLOUDFLARE_EARLY_HINTS_ENABLE) {
-                        const linkHeader = generateLinkHeader([...criticalAssets.js, ...shellDeferredJs])
+                        // customLinkHeader (app-supplied preconnect/preload entries) included here
+                        // too — Cloudflare only ever sees this one combined header per response.
+                        const linkHeader = [
+                            generateLinkHeader([...criticalAssets.js, ...shellDeferredJs]),
+                            customLinkHeader,
+                        ]
+                            .filter(Boolean)
+                            .join(", ")
                         if (linkHeader) res.setHeader("link", linkHeader)
                     }
                     if (NATIVE_EARLY_HINTS_ENABLE) {
@@ -382,12 +405,15 @@ async function _handler(req, res) {
 
         if (NATIVE_EARLY_HINTS_ENABLE) {
             // Sent as early as possible — before the app-side hook and data fetcher, which can
-            // be slow — so the browser can start fetching critical JS in parallel with them
-            // instead of waiting for the full SSR response. A throwaway extractor: the route's
-            // critical JS depends only on `allMatches`, already known here, and re-collecting it
-            // below for the real render is unaffected.
+            // be slow — so the browser can start fetching critical JS (and any app-supplied
+            // preconnect/preload entries, which don't depend on the route at all) in parallel
+            // with them instead of waiting for the full SSR response. A throwaway extractor: the
+            // route's critical JS depends only on `allMatches`, already known here, and
+            // re-collecting it below for the real render is unaffected.
             const earlyAssets = collectAssets(req, allMatches).getCriticalAssets()
-            const linkValues = generateLinkHeader(earlyAssets.js)
+            const linkValues = [generateLinkHeader(earlyAssets.js), customLinkHeader]
+                .filter(Boolean)
+                .join(", ")
             if (linkValues) res.writeEarlyHints({ link: linkValues.split(", ") })
         }
 

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -21,6 +21,7 @@ import {
     registerDeferredAssetsForRoute,
     getDeferredPreloadScriptUrls,
     generateModulePreloadLinkElements,
+    generateLinkHeader,
 } from "./extract.js"
 import path from "path"
 import { Transform } from "node:stream"
@@ -104,6 +105,11 @@ if (process.env.OTEL_ENABLE === true) {
 }
 
 const SSR_SERVICE = process.env.SERVICE_NAME || `pwa-${process.env.APPLICATION}-node-server`
+
+// Config-driven (config.json → EARLY_HINTS_ENABLE): when on, critical JS is advertised via
+// an HTTP `Link` header so a fronting CDN (e.g. Cloudflare Early Hints) can preload it before
+// SSR finishes. Off by default — no behavior change unless explicitly enabled.
+const EARLY_HINTS_ENABLE = process.env.EARLY_HINTS_ENABLE === true
 
 const traceHook = (fn, spanName) =>
     typeof fn === "function" ? withSyncObservability(SSR_SERVICE, fn, spanName) : fn
@@ -240,6 +246,10 @@ const _renderMarkUp = async (
     try {
         const status = errorCode || (allMatches.length && allMatches[0]?.route?.path === "*" ? 404 : 200)
         res.set({ "content-type": "text/html; charset=utf-8" })
+        if (EARLY_HINTS_ENABLE) {
+            const linkHeader = generateLinkHeader(criticalAssets.js)
+            if (linkHeader) res.setHeader("link", linkHeader)
+        }
         res.status(status)
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- Adds three complementary, flag-gated Early Hints mechanisms:
  - **`CLOUDFLARE_EARLY_HINTS_ENABLE`** (renamed from `EARLY_HINTS_ENABLE`): sets an HTTP `Link: <url>; rel=preload; as=script; crossorigin` header — for critical JS and every `split()` chunk discovered by the time the SSR shell is ready — so Cloudflare's Early Hints can learn it and replay it as a `103` on later requests to the same URL.
  - **`NATIVE_EARLY_HINTS_ENABLE`**: sends real `103` responses directly from this Node server via `res.writeEarlyHints()`, for deployments with no CDN in front (or one that doesn't generate Early Hints itself). Sent progressively — critical JS right after route matching (before the app-side hook and data fetcher, so it can speed up the *current* request, unlike Cloudflare's cache-replay model), then shell-deferred JS again at `onShellReady`.
  - **`EARLY_HINTS_LINKS`**: a JSON array the app supplies — `{ url, rel: "preconnect"|"preload", as?, crossorigin? }` — for things `catalyst-core` has no visibility into: third-party analytics origins (`rel=preconnect`), a static LCP image or font (`rel=preload`). Never hardcoded in `catalyst-core` itself; it only formats whatever the app declares, and merges it into both the earliest native `103` and the Cloudflare header.
- All three are off/empty by default and independent — enable any combination depending on topology and needs.
- Deferred/`split()` JS is included because it's eagerly re-imported client-side via `hydrationReady()`, blocking `hydrateRoot` — not lazy-loaded, so it's just as hint-worthy as critical JS. Critical/deferred CSS is excluded — it's server-inlined, never fetched by URL.

## Test plan
- [x] With `CLOUDFLARE_EARLY_HINTS_ENABLE=true`, confirm the SSR response's `link` header lists critical JS (and shell-rendered `split()` chunks, cross-checked against `window.__SSR_RENDERED_COMPONENTS__`)
- [x] With `NATIVE_EARLY_HINTS_ENABLE=true`, `curl -v --http1.1` directly against the app and confirm a `103` arrives immediately after connecting (before data-fetching completes), with a second `103` for shell-deferred JS shortly after — **verified locally against `apps/catalyst-core-test`**
- [x] With `EARLY_HINTS_LINKS` set, confirm the configured `preconnect`/`preload` entries appear in the `103`'s `Link` header alongside critical/deferred JS — **verified locally**
- [ ] With all flags off/empty (default), confirm no `link` header and no `103` at all
- [ ] Behind a real Cloudflare zone with Early Hints enabled, confirm a `103` precedes the `200` on a route hit at least twice
- [ ] Verify (open question) whether Cloudflare's proxy forwards the native path's own `103`s, or only its own cache-generated ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)