### PR TITLE
fix(core): stop hydration from re-fetching CSS already inlined by SSR

### DIFF
--- a/packages/catalyst-core/src/server/renderer/ChunkExtractor.js
+++ b/packages/catalyst-core/src/server/renderer/ChunkExtractor.js
@@ -114,7 +114,13 @@ export class ChunkExtractor {
         return `${this.publicPath}${cleaned}`
     }
 
-    _toCssUrl(filePath) {
+    /**
+     * Public asset URL for a manifest-relative CSS path. Must stay byte-identical to how Vite's
+     * compiled client bundle concatenates `config.base + <css path>` for its own dynamic-import CSS
+     * deps — the client-side appendChild patch (see extract.js) only recognizes a dep as "already
+     * inlined" if this matches Vite's own `link.href` exactly.
+     */
+    toCssUrl(filePath) {
         const cleaned = filePath.replace(/^\/+/, "")
         return `${this.publicPath}${cleaned}`
     }

--- a/packages/catalyst-core/src/server/renderer/extract.js
+++ b/packages/catalyst-core/src/server/renderer/extract.js
@@ -162,12 +162,16 @@ export const generateScriptElements = (jsUrls = []) =>
  * Inline bootstrap <script>. Records which CSS URLs were already inlined as <style> for this
  * response (window.__INLINED_CSS_URLS__) and patches document.head.appendChild so that if
  * hydration's dynamic-import prefetch (via Vite's own __vitePreload) tries to insert a
- * <link rel="stylesheet"> for one of those URLs, its href is swapped to an inert `data:` URI
- * before insertion — eliminating the redundant network fetch while `load` still fires
- * synchronously, so Vite's own preload promise resolves normally instead of hanging.
+ * <link rel="stylesheet"> for one of those URLs, the node is never actually connected to the
+ * document — its href is swapped to an inert `data:` URI first (harmless if anything else ever
+ * reads it) and a synthetic `load` event is dispatched on it directly, so Vite's own preload
+ * promise resolves normally instead of hanging. Since the link never touches the DOM there's no
+ * network fetch, no CSSOM/style-recalc cost, and nothing left behind to inspect.
  *
- * Verified against Vite's compiled output (v6.4.3): __vitePreload always sets `link.href` before
- * calling `document.head.appendChild(link)`, so appendChild is the single interception point.
+ * Verified against Vite's compiled output (v6.4.3): __vitePreload only awaits the link's `load`
+ * event — it never reads the element back afterward — so a synthetic event on a detached node is
+ * indistinguishable to it from a real one, and appendChild is the single interception point (it
+ * always sets `link.href` before calling `document.head.appendChild(link)`).
  * CSS not in this set — e.g. reached only via later client-side navigation, never inlined for
  * this response — is left untouched and fetches exactly as Vite already does.
  */
@@ -177,7 +181,8 @@ export const generateInlinedCssUrlsBootstrapScript = (cssUrls = []) => {
         `<script>window.__INLINED_CSS_URLS__=new Set(${urlsJson});` +
         `(function(){var o=document.head.appendChild.bind(document.head);` +
         `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
-        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,"}}` +
+        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){` +
+        `n.href="data:text/css,";n.dispatchEvent(new Event("load"));return n}}` +
         `catch(e){}return o(n)}})()</script>`
     )
 }

--- a/packages/catalyst-core/src/server/renderer/extract.js
+++ b/packages/catalyst-core/src/server/renderer/extract.js
@@ -162,16 +162,20 @@ export const generateScriptElements = (jsUrls = []) =>
  * Inline bootstrap <script>. Records which CSS URLs were already inlined as <style> for this
  * response (window.__INLINED_CSS_URLS__) and patches document.head.appendChild so that if
  * hydration's dynamic-import prefetch (via Vite's own __vitePreload) tries to insert a
- * <link rel="stylesheet"> for one of those URLs, the node is never actually connected to the
- * document — its href is swapped to an inert `data:` URI first (harmless if anything else ever
- * reads it) and a synthetic `load` event is dispatched on it directly, so Vite's own preload
- * promise resolves normally instead of hanging. Since the link never touches the DOM there's no
- * network fetch, no CSSOM/style-recalc cost, and nothing left behind to inspect.
+ * <link rel="stylesheet"> for one of those URLs, its href is swapped to an inert `data:` URI
+ * before insertion — eliminating the redundant network fetch while `load` still fires
+ * (from the browser resolving the data: URI), so Vite's own preload promise resolves normally.
  *
- * Verified against Vite's compiled output (v6.4.3): __vitePreload only awaits the link's `load`
- * event — it never reads the element back afterward — so a synthetic event on a detached node is
- * indistinguishable to it from a real one, and appendChild is the single interception point (it
- * always sets `link.href` before calling `document.head.appendChild(link)`).
+ * The link is still inserted (not left detached) deliberately: Vite's __vitePreload appears to
+ * dedupe/cache concurrent requests for the same dependency URL in a way that depends on the link
+ * actually being connected — a detached node whose `load` is dispatched synthetically resolves
+ * the widget that triggered it, but leaves any other widget concurrently awaiting the same URL
+ * hanging forever (verified empirically: real hydration prefetches ~10 SSR'd widgets at once,
+ * several sharing common CSS deps; a detached-node version left 9 of them stuck pending
+ * indefinitely, with only the first resolving — no errors, just a silent hang). Keeping the real
+ * appendChild call, with only the href swapped, avoids this: same zero-network-fetch outcome,
+ * but Vite's own dedup path sees a real inserted link and behaves correctly for later requests.
+ *
  * CSS not in this set — e.g. reached only via later client-side navigation, never inlined for
  * this response — is left untouched and fetches exactly as Vite already does.
  */
@@ -181,8 +185,7 @@ export const generateInlinedCssUrlsBootstrapScript = (cssUrls = []) => {
         `<script>window.__INLINED_CSS_URLS__=new Set(${urlsJson});` +
         `(function(){var o=document.head.appendChild.bind(document.head);` +
         `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
-        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){` +
-        `n.href="data:text/css,";n.dispatchEvent(new Event("load"));return n}}` +
+        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,"}}` +
         `catch(e){}return o(n)}})()</script>`
     )
 }

--- a/packages/catalyst-core/src/server/renderer/extract.js
+++ b/packages/catalyst-core/src/server/renderer/extract.js
@@ -165,16 +165,23 @@ export const generateScriptElements = (jsUrls = []) =>
  * <link rel="stylesheet"> for one of those URLs, its href is swapped to an inert `data:` URI
  * before insertion — eliminating the redundant network fetch while `load` still fires
  * (from the browser resolving the data: URI), so Vite's own preload promise resolves normally.
+ * The link is removed from the DOM once its own `load` fires, so it doesn't linger.
  *
- * The link is still inserted (not left detached) deliberately: Vite's __vitePreload appears to
- * dedupe/cache concurrent requests for the same dependency URL in a way that depends on the link
- * actually being connected — a detached node whose `load` is dispatched synthetically resolves
- * the widget that triggered it, but leaves any other widget concurrently awaiting the same URL
- * hanging forever (verified empirically: real hydration prefetches ~10 SSR'd widgets at once,
- * several sharing common CSS deps; a detached-node version left 9 of them stuck pending
- * indefinitely, with only the first resolving — no errors, just a silent hang). Keeping the real
- * appendChild call, with only the href swapped, avoids this: same zero-network-fetch outcome,
- * but Vite's own dedup path sees a real inserted link and behaves correctly for later requests.
+ * The link is still genuinely inserted (not left detached) deliberately: Vite's __vitePreload
+ * appears to dedupe/cache concurrent requests for the same dependency URL in a way that depends
+ * on the link actually being connected — a detached node whose `load` is dispatched synthetically
+ * resolves the widget that triggered it, but leaves any other widget concurrently awaiting the
+ * same URL hanging forever (verified empirically: real hydration prefetches ~10 SSR'd widgets at
+ * once, several sharing common CSS deps; a detached-node version left 9 of them stuck pending
+ * indefinitely, with only the first resolving — no errors, just a silent hang).
+ *
+ * Removing on `load` — rather than never inserting — is safe for the same concurrent-widget case:
+ * every widget's `__vitePreload` deps are enumerated synchronously (in the same tick split()s run
+ * in), so any dedup check against this exact link has already happened by the time `load` fires
+ * asynchronously and removal runs. A widget that somehow checks after removal just creates (and
+ * this patch again neutralizes) a fresh link for the same URL — still zero network fetches, only
+ * a harmless redundant no-op, never a hang. Verified under staggered/shared-dependency timing
+ * before relying on this in the real app.
  *
  * CSS not in this set — e.g. reached only via later client-side navigation, never inlined for
  * this response — is left untouched and fetches exactly as Vite already does.
@@ -185,7 +192,8 @@ export const generateInlinedCssUrlsBootstrapScript = (cssUrls = []) => {
         `<script>window.__INLINED_CSS_URLS__=new Set(${urlsJson});` +
         `(function(){var o=document.head.appendChild.bind(document.head);` +
         `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
-        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,"}}` +
+        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,";` +
+        `n.addEventListener("load",function(){try{n.remove()}catch(e){}})}}` +
         `catch(e){}return o(n)}})()</script>`
     )
 }

--- a/packages/catalyst-core/src/server/renderer/extract.js
+++ b/packages/catalyst-core/src/server/renderer/extract.js
@@ -86,6 +86,10 @@ export const generateModulePreloadLinkElements = (jsUrls = [], keyPrefix = "modu
         })
     )
 
+// nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal - asset paths come from the Vite build manifest generated at build time, never from a request, so there is no user-controlled input here.
+const resolveCssFilePath = (asset, basePath) =>
+    path.isAbsolute(asset) ? asset : path.join(basePath, asset.replace(/^\/+/, ""))
+
 /**
  * Read CSS files from disk and return concatenated CSS string for inlining.
  * @param {string[]} cssPaths - Relative CSS paths (from manifest).
@@ -103,8 +107,7 @@ export const readCssFromDisk = (cssPaths = [], basePath) => {
         seen.add(asset)
         if (asset.startsWith("http")) continue
 
-        // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal - asset paths come from the Vite build manifest generated at build time, never from a request, so there is no user-controlled input here.
-        const filePath = path.isAbsolute(asset) ? asset : path.join(basePath, asset.replace(/^\/+/, ""))
+        const filePath = resolveCssFilePath(asset, basePath)
 
         try {
             if (!process.cssFileCache[filePath]) {
@@ -121,6 +124,28 @@ export const readCssFromDisk = (cssPaths = [], basePath) => {
     return chunks.join("\n")
 }
 
+/**
+ * Filters cssPaths down to those actually inlined by a prior readCssFromDisk call for the same
+ * basePath (i.e. present and non-empty in process.cssFileCache). The client-side appendChild patch
+ * (see generateInlinedCssUrlsBootstrapScript) must only be told about these — a URL for a path whose
+ * CSS silently failed to read would suppress Vite's own fetch with nothing to fall back on.
+ * @param {string[]} cssPaths - Relative CSS paths (from manifest).
+ * @param {string} basePath  - Build output directory on disk.
+ * @returns {string[]} The subset of cssPaths whose content is cached (deduped).
+ */
+export const getInlinedCssPaths = (cssPaths = [], basePath) => {
+    const seen = new Set()
+    const inlined = []
+    for (const asset of cssPaths) {
+        if (!asset || seen.has(asset) || asset.startsWith("http")) continue
+        seen.add(asset)
+        if (process.cssFileCache[resolveCssFilePath(asset, basePath)]) {
+            inlined.push(asset)
+        }
+    }
+    return inlined
+}
+
 // ── React elements (for SSR rendering inside <Head>) ───────────────────
 
 /**
@@ -134,10 +159,38 @@ export const generateScriptElements = (jsUrls = []) =>
 // ── HTML strings (for streaming injection after body via res.write) ────
 
 /**
- * <link rel="stylesheet"> HTML strings for deferred CSS (non-blocking, after body).
+ * Inline bootstrap <script>. Records which CSS URLs were already inlined as <style> for this
+ * response (window.__INLINED_CSS_URLS__) and patches document.head.appendChild so that if
+ * hydration's dynamic-import prefetch (via Vite's own __vitePreload) tries to insert a
+ * <link rel="stylesheet"> for one of those URLs, its href is swapped to an inert `data:` URI
+ * before insertion — eliminating the redundant network fetch while `load` still fires
+ * synchronously, so Vite's own preload promise resolves normally instead of hanging.
+ *
+ * Verified against Vite's compiled output (v6.4.3): __vitePreload always sets `link.href` before
+ * calling `document.head.appendChild(link)`, so appendChild is the single interception point.
+ * CSS not in this set — e.g. reached only via later client-side navigation, never inlined for
+ * this response — is left untouched and fetches exactly as Vite already does.
  */
-export const generateCssLinkStrings = (cssUrls = []) =>
-    [...new Set(cssUrls)].map((url) => `<link rel="stylesheet" href="${url}">`).join("")
+export const generateInlinedCssUrlsBootstrapScript = (cssUrls = []) => {
+    const urlsJson = JSON.stringify([...new Set(cssUrls)])
+    return (
+        `<script>window.__INLINED_CSS_URLS__=new Set(${urlsJson});` +
+        `(function(){var o=document.head.appendChild.bind(document.head);` +
+        `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
+        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,"}}` +
+        `catch(e){}return o(n)}})()</script>`
+    )
+}
+
+/**
+ * Extends window.__INLINED_CSS_URLS__ (see generateInlinedCssUrlsBootstrapScript) with CSS URLs
+ * inlined after the initial <head> — the first-ever deferred <style> streamed for a route.
+ */
+export const generateInlinedCssUrlsExtendScript = (cssUrls = []) => {
+    if (!cssUrls.length) return ""
+    const urlsJson = JSON.stringify([...new Set(cssUrls)])
+    return `<script>${urlsJson}.forEach(function(u){window.__INLINED_CSS_URLS__.add(u)})</script>`
+}
 
 /**
  * <link rel="modulepreload"> + <script type="module"> HTML strings.

--- a/packages/catalyst-core/src/server/renderer/extract.js
+++ b/packages/catalyst-core/src/server/renderer/extract.js
@@ -193,6 +193,7 @@ export const generateInlinedCssUrlsBootstrapScript = (cssUrls = []) => {
         `(function(){var o=document.head.appendChild.bind(document.head);` +
         `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
         `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,";` +
+        `n.rel="prefetch";n.removeAttribute("as");` +
         `n.addEventListener("load",function(){try{n.remove()}catch(e){}})}}` +
         `catch(e){}return o(n)}})()</script>`
     )

--- a/packages/catalyst-core/src/server/renderer/handler.jsx
+++ b/packages/catalyst-core/src/server/renderer/handler.jsx
@@ -13,8 +13,10 @@ import { validateConfigureStore, validateGetRoutes, safeCall } from "../utils/va
 import { ChunkExtractor } from "./ChunkExtractor.js"
 import {
     readCssFromDisk,
+    getInlinedCssPaths,
     generateScriptElements,
-    generateCssLinkStrings,
+    generateInlinedCssUrlsBootstrapScript,
+    generateInlinedCssUrlsExtendScript,
     generateScriptStrings,
     getDeferredRouteKey,
     getCachedDeferredCssPathsForRoute,
@@ -181,10 +183,16 @@ const _renderMarkUp = async (
     const inlineCss = readCssFromDisk(criticalAssets.css, buildDir)
 
     const deferredRouteKey = getDeferredRouteKey(req, allMatches)
-    const deferredRouteInlineCss = readCssFromDisk(
-        getCachedDeferredCssPathsForRoute(deferredRouteKey),
-        buildDir
-    )
+    const deferredRouteCssPaths = getCachedDeferredCssPathsForRoute(deferredRouteKey)
+    const deferredRouteInlineCss = readCssFromDisk(deferredRouteCssPaths, buildDir)
+
+    // URLs of CSS actually inlined above — tells the client (see the bootstrap script pushed in
+    // flush()) which dynamic-import CSS fetches Vite would otherwise duplicate during hydration.
+    const headInlinedCssUrls = chunkExtractor
+        ? getInlinedCssPaths([...criticalAssets.css, ...deferredRouteCssPaths], buildDir).map((p) =>
+              chunkExtractor.toCssUrl(p)
+          )
+        : []
 
     const jsScripts = generateScriptElements(criticalAssets.js)
     const criticalPreloadLinks = generateModulePreloadLinkElements(criticalAssets.js, "critical-js")
@@ -270,6 +278,10 @@ const _renderMarkUp = async (
                         )
                     }
 
+                    if (!isBot && chunkExtractor) {
+                        this.push(generateInlinedCssUrlsBootstrapScript(headInlinedCssUrls))
+                    }
+
                     const { newCssPaths } = registerDeferredAssetsForRoute(
                         deferredRouteKey,
                         deferredAssets,
@@ -277,6 +289,14 @@ const _renderMarkUp = async (
                     )
                     if (newCssPaths.length) {
                         this.push(`<style>${readCssFromDisk(newCssPaths, buildDir)}</style>`)
+                        if (!isBot && chunkExtractor) {
+                            const inlinedNewCssPaths = getInlinedCssPaths(newCssPaths, buildDir)
+                            this.push(
+                                generateInlinedCssUrlsExtendScript(
+                                    inlinedNewCssPaths.map((p) => chunkExtractor.toCssUrl(p))
+                                )
+                            )
+                        }
                     }
                     if (!isBot) {
                         this.push(generateScriptStrings(deferredAssets.js))


### PR DESCRIPTION
## Summary
- Vite's dynamic-import CSS preloading (`__vitePreload`) doesn't know a chunk's CSS was already delivered as an inline `<style>` in the SSR response, so hydration's eager prefetch of SSR'd `split()` components re-fetches that CSS over the network.
- The server now records which CSS URLs it inlined (critical + deferred-route-promoted + newly-deferred) and pushes a small bootstrap `<script>` (through the existing tail-stream mechanism used for `window.__SSR_RENDERED_COMPONENTS__`) that patches `document.head.appendChild`: if Vite's preload helper tries to insert a `<link rel="stylesheet">` for one of those URLs, its `href` is swapped to an inert `data:` URI, and its `rel` is rewritten from `stylesheet` to `prefetch` (dropping any `as` hint) before insertion. The browser resolves the `data:` URI locally (no network request), `load` still fires so Vite's own preload promise resolves normally, and the `rel` rewrite moves DevTools' Network panel categorization from "CSS" to "Other" so the (harmless, zero-byte) ghost entry doesn't clutter CSS-specific filtering.
- The link is genuinely inserted into the DOM (see "History" below for why), then removed as soon as its own `load` fires, so nothing lingers in `<head>`.
- CSS not in that set — e.g. reached only via later client-side navigation, never inlined for this response — is left completely untouched and loads exactly as before; this only ever affects the exact condition `link.rel === "stylesheet" && __INLINED_CSS_URLS__.has(link.href)` (checked *before* any rewriting happens).

## History (worth reading before reviewing the diff)
An earlier version went further: rather than inserting a neutralized `data:` link, it dispatched a synthetic `load` event on a fully detached node, so nothing ever touched the DOM at all. That looked correct in isolation and in sequential tests — but broke real hydration. Verified against the real `mweb` app: ~10 SSR'd widgets prefetch concurrently on `window.load`, several sharing common CSS chunks. Vite's `__vitePreload` appears to dedupe/cache concurrent requests for the *same* dependency URL in a way that depends on the link actually being connected to the document — with a detached node, only the first widget requesting a shared URL ever resolved; every other concurrent requester hung forever (no error — `Promise.all` in `hydrationReady()` never settled, `hydrateRoot()` was never called, entire page stayed unhydrated with nothing pointing at it in the console).

Reverted to inserting the link (data: URI swap, real appendChild). That fixed hydration but left the neutralized links sitting in `<head>` permanently. Removing them immediately on `load` is safe for the same concurrent case that broke the detached-node version, since every widget's deps are enumerated synchronously (`split()` calls run in the same tick), so any dedup check against a given link has already happened by the time `load` fires asynchronously and removal runs — verified under staggered/shared-dependency timing.

Finally, the `rel="prefetch"` rewrite: the ghost link — even zero-byte and removed immediately — still showed up in DevTools' Network panel under the "CSS" filter, since `rel="stylesheet"` is what triggered the fetch/load in the first place. Rewriting `rel` *after* the href swap doesn't change any of the above safety properties (the dedup-sensitive check happens earlier, before rewriting), but moves it out of CSS-specific tooling into "Other" — re-verified the full safety case (staggered timing in isolation, then hydration + zero-fetch + zero-lingering-node against the real app) after this change too.

## Verification
- Verified the exact mechanism against Vite's compiled runtime source (v6.4.3): `__vitePreload` always sets `link.href` before calling `document.head.appendChild(link)`, and its dedup check only inspects existing `<link>` elements — never `<style>` tags.
- Isolated browser tests: zero network requests for the "already inlined" URL, clean `load` resolution, genuinely new/non-inlined URLs still fetch normally, and — for both the removal timing and the `rel` rewrite — concurrent widgets sharing a CSS dependency (with 0ms/5ms/50ms staggered kickoff) all resolve correctly.
- End-to-end in the `catalyst-core-test` fixture app: added a real widget CSS module, confirmed via the browser's Resource Timing API that zero CSS network requests fire for content already inlined, and client-side navigation to a route never touched by SSR still fetches its own JS/CSS normally.
- **End-to-end against the real `mweb` app** (temporarily, via a throwaway branch/worktree — not part of this PR, reverted afterward): 44 of 44 CSS files previously being duplicated on the homepage remain at zero network fetches, hydration completes correctly (React fiber present), client-side navigation to an unrelated page works and hydrates there too, and zero neutralized links are left in the DOM on either page.

## Test plan
- [x] `npm run test:unit` in `packages/catalyst-core` — 15/15 pass
- [x] `npx eslint` on the changed files — no new errors (pre-existing `globalThis` baseline errors unrelated to this change)
- [x] Manual browser verification in `catalyst-core-test` (see above)
- [x] Manual browser verification against a real consumer app (`mweb`), confirming hydration actually completes and no ghost nodes remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)