### PR TITLE
fix: stop hydration from re-fetching CSS already inlined by SSR

### DIFF
--- a/src/server/renderer/ChunkExtractor.js
+++ b/src/server/renderer/ChunkExtractor.js
@@ -114,7 +114,13 @@ export class ChunkExtractor {
         return `${this.publicPath}${cleaned}`
     }
 
-    _toCssUrl(filePath) {
+    /**
+     * Public asset URL for a manifest-relative CSS path. Must stay byte-identical to how Vite's
+     * compiled client bundle concatenates `config.base + <css path>` for its own dynamic-import CSS
+     * deps — the client-side appendChild patch (see extract.js) only recognizes a dep as "already
+     * inlined" if this matches Vite's own `link.href` exactly.
+     */
+    toCssUrl(filePath) {
         const cleaned = filePath.replace(/^\/+/, "")
         return `${this.publicPath}${cleaned}`
     }

--- a/src/server/renderer/extract.js
+++ b/src/server/renderer/extract.js
@@ -205,6 +205,7 @@ export const generateInlinedCssUrlsBootstrapScript = (cssUrls = [], nonce) => {
         `(function(){var o=document.head.appendChild.bind(document.head);` +
         `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
         `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,";` +
+        `n.rel="prefetch";n.removeAttribute("as");` +
         `n.addEventListener("load",function(){try{n.remove()}catch(e){}})}}` +
         `catch(e){}return o(n)}})()</script>`
     )

--- a/src/server/renderer/extract.js
+++ b/src/server/renderer/extract.js
@@ -174,16 +174,23 @@ export const generateScriptElements = (jsUrls = [], nonce) =>
  * <link rel="stylesheet"> for one of those URLs, its href is swapped to an inert `data:` URI
  * before insertion — eliminating the redundant network fetch while `load` still fires
  * (from the browser resolving the data: URI), so Vite's own preload promise resolves normally.
+ * The link is removed from the DOM once its own `load` fires, so it doesn't linger.
  *
- * The link is still inserted (not left detached) deliberately: Vite's __vitePreload appears to
- * dedupe/cache concurrent requests for the same dependency URL in a way that depends on the link
- * actually being connected — a detached node whose `load` is dispatched synthetically resolves
- * the widget that triggered it, but leaves any other widget concurrently awaiting the same URL
- * hanging forever (verified empirically: real hydration prefetches ~10 SSR'd widgets at once,
- * several sharing common CSS deps; a detached-node version left 9 of them stuck pending
- * indefinitely, with only the first resolving — no errors, just a silent hang). Keeping the real
- * appendChild call, with only the href swapped, avoids this: same zero-network-fetch outcome,
- * but Vite's own dedup path sees a real inserted link and behaves correctly for later requests.
+ * The link is still genuinely inserted (not left detached) deliberately: Vite's __vitePreload
+ * appears to dedupe/cache concurrent requests for the same dependency URL in a way that depends
+ * on the link actually being connected — a detached node whose `load` is dispatched synthetically
+ * resolves the widget that triggered it, but leaves any other widget concurrently awaiting the
+ * same URL hanging forever (verified empirically: real hydration prefetches ~10 SSR'd widgets at
+ * once, several sharing common CSS deps; a detached-node version left 9 of them stuck pending
+ * indefinitely, with only the first resolving — no errors, just a silent hang).
+ *
+ * Removing on `load` — rather than never inserting — is safe for the same concurrent-widget case:
+ * every widget's `__vitePreload` deps are enumerated synchronously (in the same tick split()s run
+ * in), so any dedup check against this exact link has already happened by the time `load` fires
+ * asynchronously and removal runs. A widget that somehow checks after removal just creates (and
+ * this patch again neutralizes) a fresh link for the same URL — still zero network fetches, only
+ * a harmless redundant no-op, never a hang. Verified under staggered/shared-dependency timing
+ * before relying on this in the real app.
  *
  * CSS not in this set — e.g. reached only via later client-side navigation, never inlined for
  * this response — is left untouched and fetches exactly as Vite already does.
@@ -197,7 +204,8 @@ export const generateInlinedCssUrlsBootstrapScript = (cssUrls = [], nonce) => {
         `<script${nonceAttr}>window.__INLINED_CSS_URLS__=new Set(${urlsJson});` +
         `(function(){var o=document.head.appendChild.bind(document.head);` +
         `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
-        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,"}}` +
+        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,";` +
+        `n.addEventListener("load",function(){try{n.remove()}catch(e){}})}}` +
         `catch(e){}return o(n)}})()</script>`
     )
 }

--- a/src/server/renderer/extract.js
+++ b/src/server/renderer/extract.js
@@ -171,12 +171,16 @@ export const generateScriptElements = (jsUrls = [], nonce) =>
  * Inline bootstrap <script>. Records which CSS URLs were already inlined as <style> for this
  * response (window.__INLINED_CSS_URLS__) and patches document.head.appendChild so that if
  * hydration's dynamic-import prefetch (via Vite's own __vitePreload) tries to insert a
- * <link rel="stylesheet"> for one of those URLs, its href is swapped to an inert `data:` URI
- * before insertion — eliminating the redundant network fetch while `load` still fires
- * synchronously, so Vite's own preload promise resolves normally instead of hanging.
+ * <link rel="stylesheet"> for one of those URLs, the node is never actually connected to the
+ * document — its href is swapped to an inert `data:` URI first (harmless if anything else ever
+ * reads it) and a synthetic `load` event is dispatched on it directly, so Vite's own preload
+ * promise resolves normally instead of hanging. Since the link never touches the DOM there's no
+ * network fetch, no CSSOM/style-recalc cost, and nothing left behind to inspect.
  *
- * Verified against Vite's compiled output (v6.4.3): __vitePreload always sets `link.href` before
- * calling `document.head.appendChild(link)`, so appendChild is the single interception point.
+ * Verified against Vite's compiled output (v6.4.3): __vitePreload only awaits the link's `load`
+ * event — it never reads the element back afterward — so a synthetic event on a detached node is
+ * indistinguishable to it from a real one, and appendChild is the single interception point (it
+ * always sets `link.href` before calling `document.head.appendChild(link)`).
  * CSS not in this set — e.g. reached only via later client-side navigation, never inlined for
  * this response — is left untouched and fetches exactly as Vite already does.
  * @param {string[]} cssUrls
@@ -189,7 +193,8 @@ export const generateInlinedCssUrlsBootstrapScript = (cssUrls = [], nonce) => {
         `<script${nonceAttr}>window.__INLINED_CSS_URLS__=new Set(${urlsJson});` +
         `(function(){var o=document.head.appendChild.bind(document.head);` +
         `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
-        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,"}}` +
+        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){` +
+        `n.href="data:text/css,";n.dispatchEvent(new Event("load"));return n}}` +
         `catch(e){}return o(n)}})()</script>`
     )
 }

--- a/src/server/renderer/extract.js
+++ b/src/server/renderer/extract.js
@@ -171,16 +171,20 @@ export const generateScriptElements = (jsUrls = [], nonce) =>
  * Inline bootstrap <script>. Records which CSS URLs were already inlined as <style> for this
  * response (window.__INLINED_CSS_URLS__) and patches document.head.appendChild so that if
  * hydration's dynamic-import prefetch (via Vite's own __vitePreload) tries to insert a
- * <link rel="stylesheet"> for one of those URLs, the node is never actually connected to the
- * document — its href is swapped to an inert `data:` URI first (harmless if anything else ever
- * reads it) and a synthetic `load` event is dispatched on it directly, so Vite's own preload
- * promise resolves normally instead of hanging. Since the link never touches the DOM there's no
- * network fetch, no CSSOM/style-recalc cost, and nothing left behind to inspect.
+ * <link rel="stylesheet"> for one of those URLs, its href is swapped to an inert `data:` URI
+ * before insertion — eliminating the redundant network fetch while `load` still fires
+ * (from the browser resolving the data: URI), so Vite's own preload promise resolves normally.
  *
- * Verified against Vite's compiled output (v6.4.3): __vitePreload only awaits the link's `load`
- * event — it never reads the element back afterward — so a synthetic event on a detached node is
- * indistinguishable to it from a real one, and appendChild is the single interception point (it
- * always sets `link.href` before calling `document.head.appendChild(link)`).
+ * The link is still inserted (not left detached) deliberately: Vite's __vitePreload appears to
+ * dedupe/cache concurrent requests for the same dependency URL in a way that depends on the link
+ * actually being connected — a detached node whose `load` is dispatched synthetically resolves
+ * the widget that triggered it, but leaves any other widget concurrently awaiting the same URL
+ * hanging forever (verified empirically: real hydration prefetches ~10 SSR'd widgets at once,
+ * several sharing common CSS deps; a detached-node version left 9 of them stuck pending
+ * indefinitely, with only the first resolving — no errors, just a silent hang). Keeping the real
+ * appendChild call, with only the href swapped, avoids this: same zero-network-fetch outcome,
+ * but Vite's own dedup path sees a real inserted link and behaves correctly for later requests.
+ *
  * CSS not in this set — e.g. reached only via later client-side navigation, never inlined for
  * this response — is left untouched and fetches exactly as Vite already does.
  * @param {string[]} cssUrls
@@ -193,8 +197,7 @@ export const generateInlinedCssUrlsBootstrapScript = (cssUrls = [], nonce) => {
         `<script${nonceAttr}>window.__INLINED_CSS_URLS__=new Set(${urlsJson});` +
         `(function(){var o=document.head.appendChild.bind(document.head);` +
         `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
-        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){` +
-        `n.href="data:text/css,";n.dispatchEvent(new Event("load"));return n}}` +
+        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,"}}` +
         `catch(e){}return o(n)}})()</script>`
     )
 }

--- a/src/server/renderer/extract.js
+++ b/src/server/renderer/extract.js
@@ -94,6 +94,10 @@ export const generateModulePreloadLinkElements = (jsUrls = [], keyPrefix = "modu
  * @param {string} basePath  - Build output directory on disk.
  * @returns {string} Concatenated CSS content.
  */
+// nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal - asset paths come from the Vite build manifest generated at build time, never from a request, so there is no user-controlled input here.
+const resolveCssFilePath = (asset, basePath) =>
+    path.isAbsolute(asset) ? asset : path.join(basePath, asset.replace(/^\/+/, ""))
+
 export const readCssFromDisk = (cssPaths = [], basePath) => {
     if (!cssPaths.length) return ""
 
@@ -105,7 +109,7 @@ export const readCssFromDisk = (cssPaths = [], basePath) => {
         seen.add(asset)
         if (asset.startsWith("http")) continue
 
-        const filePath = path.isAbsolute(asset) ? asset : path.join(basePath, asset.replace(/^\/+/, ""))
+        const filePath = resolveCssFilePath(asset, basePath)
 
         try {
             if (!process.cssFileCache[filePath]) {
@@ -120,6 +124,28 @@ export const readCssFromDisk = (cssPaths = [], basePath) => {
     }
 
     return chunks.join("\n")
+}
+
+/**
+ * Filters cssPaths down to those actually inlined by a prior readCssFromDisk call for the same
+ * basePath (i.e. present and non-empty in process.cssFileCache). The client-side appendChild patch
+ * (see generateInlinedCssUrlsBootstrapScript) must only be told about these — a URL for a path whose
+ * CSS silently failed to read would suppress Vite's own fetch with nothing to fall back on.
+ * @param {string[]} cssPaths - Relative CSS paths (from manifest).
+ * @param {string} basePath  - Build output directory on disk.
+ * @returns {string[]} The subset of cssPaths whose content is cached (deduped).
+ */
+export const getInlinedCssPaths = (cssPaths = [], basePath) => {
+    const seen = new Set()
+    const inlined = []
+    for (const asset of cssPaths) {
+        if (!asset || seen.has(asset) || asset.startsWith("http")) continue
+        seen.add(asset)
+        if (process.cssFileCache[resolveCssFilePath(asset, basePath)]) {
+            inlined.push(asset)
+        }
+    }
+    return inlined
 }
 
 // ── React elements (for SSR rendering inside <Head>) ───────────────────
@@ -142,10 +168,44 @@ export const generateScriptElements = (jsUrls = [], nonce) =>
 // ── HTML strings (for streaming injection after body via res.write) ────
 
 /**
- * <link rel="stylesheet"> HTML strings for deferred CSS (non-blocking, after body).
+ * Inline bootstrap <script>. Records which CSS URLs were already inlined as <style> for this
+ * response (window.__INLINED_CSS_URLS__) and patches document.head.appendChild so that if
+ * hydration's dynamic-import prefetch (via Vite's own __vitePreload) tries to insert a
+ * <link rel="stylesheet"> for one of those URLs, its href is swapped to an inert `data:` URI
+ * before insertion — eliminating the redundant network fetch while `load` still fires
+ * synchronously, so Vite's own preload promise resolves normally instead of hanging.
+ *
+ * Verified against Vite's compiled output (v6.4.3): __vitePreload always sets `link.href` before
+ * calling `document.head.appendChild(link)`, so appendChild is the single interception point.
+ * CSS not in this set — e.g. reached only via later client-side navigation, never inlined for
+ * this response — is left untouched and fetches exactly as Vite already does.
+ * @param {string[]} cssUrls
+ * @param {string} [nonce] - CSP nonce, applied when nonce-based CSP is enabled (see CSP_NONCE_ENABLE).
  */
-export const generateCssLinkStrings = (cssUrls = []) =>
-    [...new Set(cssUrls)].map((url) => `<link rel="stylesheet" href="${url}">`).join("")
+export const generateInlinedCssUrlsBootstrapScript = (cssUrls = [], nonce) => {
+    const urlsJson = JSON.stringify([...new Set(cssUrls)])
+    const nonceAttr = nonce ? ` nonce="${nonce}"` : ""
+    return (
+        `<script${nonceAttr}>window.__INLINED_CSS_URLS__=new Set(${urlsJson});` +
+        `(function(){var o=document.head.appendChild.bind(document.head);` +
+        `document.head.appendChild=function(n){try{if(n&&n.tagName==="LINK"&&n.rel==="stylesheet"` +
+        `&&window.__INLINED_CSS_URLS__&&window.__INLINED_CSS_URLS__.has(n.href)){n.href="data:text/css,"}}` +
+        `catch(e){}return o(n)}})()</script>`
+    )
+}
+
+/**
+ * Extends window.__INLINED_CSS_URLS__ (see generateInlinedCssUrlsBootstrapScript) with CSS URLs
+ * inlined after the initial <head> — the first-ever deferred <style> streamed for a route.
+ * @param {string[]} cssUrls
+ * @param {string} [nonce] - CSP nonce, applied when nonce-based CSP is enabled (see CSP_NONCE_ENABLE).
+ */
+export const generateInlinedCssUrlsExtendScript = (cssUrls = [], nonce) => {
+    if (!cssUrls.length) return ""
+    const urlsJson = JSON.stringify([...new Set(cssUrls)])
+    const nonceAttr = nonce ? ` nonce="${nonce}"` : ""
+    return `<script${nonceAttr}>${urlsJson}.forEach(function(u){window.__INLINED_CSS_URLS__.add(u)})</script>`
+}
 
 /**
  * <link rel="modulepreload"> + <script type="module"> HTML strings.

--- a/src/server/renderer/handler.jsx
+++ b/src/server/renderer/handler.jsx
@@ -13,8 +13,10 @@ import { validateConfigureStore, validateGetRoutes, safeCall } from "../utils/va
 import { ChunkExtractor } from "./ChunkExtractor.js"
 import {
     readCssFromDisk,
+    getInlinedCssPaths,
     generateScriptElements,
-    generateCssLinkStrings,
+    generateInlinedCssUrlsBootstrapScript,
+    generateInlinedCssUrlsExtendScript,
     generateScriptStrings,
     getDeferredRouteKey,
     getCachedDeferredCssPathsForRoute,
@@ -154,10 +156,16 @@ const _renderMarkUp = async (
     const inlineCss = readCssFromDisk(criticalAssets.css, buildDir)
 
     const deferredRouteKey = getDeferredRouteKey(req, allMatches)
-    const deferredRouteInlineCss = readCssFromDisk(
-        getCachedDeferredCssPathsForRoute(deferredRouteKey),
-        buildDir
-    )
+    const deferredRouteCssPaths = getCachedDeferredCssPathsForRoute(deferredRouteKey)
+    const deferredRouteInlineCss = readCssFromDisk(deferredRouteCssPaths, buildDir)
+
+    // URLs of CSS actually inlined above — tells the client (see the bootstrap script pushed in
+    // flush()) which dynamic-import CSS fetches Vite would otherwise duplicate during hydration.
+    const headInlinedCssUrls = chunkExtractor
+        ? getInlinedCssPaths([...criticalAssets.css, ...deferredRouteCssPaths], buildDir).map((p) =>
+              chunkExtractor.toCssUrl(p)
+          )
+        : []
 
     const jsScripts = generateScriptElements(criticalAssets.js, nonce)
     const criticalPreloadLinks = generateModulePreloadLinkElements(criticalAssets.js, "critical-js", nonce)
@@ -247,6 +255,10 @@ const _renderMarkUp = async (
                         )
                     }
 
+                    if (!isBot && chunkExtractor) {
+                        this.push(generateInlinedCssUrlsBootstrapScript(headInlinedCssUrls, nonce))
+                    }
+
                     const { newCssPaths } = registerDeferredAssetsForRoute(
                         deferredRouteKey,
                         deferredAssets,
@@ -254,6 +266,15 @@ const _renderMarkUp = async (
                     )
                     if (newCssPaths.length) {
                         this.push(`<style>${readCssFromDisk(newCssPaths, buildDir)}</style>`)
+                        if (!isBot && chunkExtractor) {
+                            const inlinedNewCssPaths = getInlinedCssPaths(newCssPaths, buildDir)
+                            this.push(
+                                generateInlinedCssUrlsExtendScript(
+                                    inlinedNewCssPaths.map((p) => chunkExtractor.toCssUrl(p)),
+                                    nonce
+                                )
+                            )
+                        }
                     }
                     if (!isBot) {
                         this.push(generateScriptStrings(deferredAssets.js, nonce))


### PR DESCRIPTION
## Summary
- Same fix as tata1mg/catalyst-core#459, ported onto this branch (the lineage `mweb`'s `package.json` was pinned to when this was tested — note mweb has since moved to `feature/cloudflare-early-hints-mweb-master`; port there too if that's now the branch mweb should track).
- Vite's dynamic-import CSS preloading (`__vitePreload`) doesn't know a chunk's CSS was already delivered as an inline `<style>` in the SSR response, so hydration's eager prefetch of SSR'd `split()` components re-fetches that CSS over the network.
- The server now records which CSS URLs it inlined (critical + deferred-route-promoted + newly-deferred) and pushes a small bootstrap `<script>` (through the existing tail-stream mechanism used for `window.__SSR_RENDERED_COMPONENTS__`) that patches `document.head.appendChild`: if Vite's preload helper tries to insert a `<link rel="stylesheet">` for one of those URLs, its `href` is swapped to an inert `data:` URI, and its `rel` is rewritten from `stylesheet` to `prefetch` (dropping any `as` hint) before insertion. The browser resolves the `data:` URI locally (no network request), `load` still fires so Vite's own preload promise resolves normally, and the `rel` rewrite moves DevTools' Network panel categorization from "CSS" to "Other" so the (harmless, zero-byte) ghost entry doesn't clutter CSS-specific filtering.
- The link is genuinely inserted into the DOM (see "History" below for why), then removed as soon as its own `load` fires, so nothing lingers in `<head>`.
- CSS not in that set — e.g. reached only via later client-side navigation, never inlined for this response — is left completely untouched and loads exactly as before; this only ever affects the exact condition `link.rel === "stylesheet" && __INLINED_CSS_URLS__.has(link.href)` (checked *before* any rewriting happens).
- The bootstrap script picks up a CSP `nonce` the same way the other inline scripts already pushed from this tail-flush do, respecting `CSP_NONCE_ENABLE`.

## History (worth reading before reviewing the diff)
An earlier version went further: rather than inserting a neutralized `data:` link, it dispatched a synthetic `load` event on a fully detached node, so nothing ever touched the DOM at all. That looked correct in isolation and in sequential tests — but broke real hydration in this exact app. `mweb`'s homepage prefetches ~10 SSR'd widgets concurrently on `window.load`, several sharing common CSS chunks. Vite's `__vitePreload` appears to dedupe/cache concurrent requests for the *same* dependency URL in a way that depends on the link actually being connected to the document — with a detached node, only the first widget requesting a shared URL ever resolved; every other concurrent requester hung forever (no error — the `Promise.all` in `hydrationReady()` never settled, `hydrateRoot()` was never called, entire page stayed unhydrated — confirmed via temporary `__PREFETCH_LOG__` instrumentation showing 9 of 10 SSR'd widgets permanently stuck `"pending"`).

Reverted to inserting the link (data: URI swap, real appendChild) — confirmed that fixed hydration. Removing the links immediately on `load` (rather than leaving them permanently) is safe for the same concurrent case, since every widget's deps are enumerated synchronously (`split()` calls run in the same tick), so any dedup check against a given link has already happened by the time `load` fires asynchronously and removal runs.

Finally, the `rel="prefetch"` rewrite: the ghost link — even zero-byte and removed immediately — still showed up in DevTools' Network panel under the "CSS" filter, since `rel="stylesheet"` is what triggered the fetch/load in the first place. Rewriting `rel` *after* the href swap doesn't change any of the above safety properties (the dedup-sensitive check happens earlier, before rewriting), but moves it out of CSS-specific tooling into "Other" — re-verified the full safety case (staggered timing in isolation, then hydration + zero-fetch + zero-lingering-node against the real app) after this change too.

## Verification
- Verified the exact mechanism against Vite's compiled runtime source (v6.4.3): `__vitePreload` always sets `link.href` before calling `document.head.appendChild(link)`, and its dedup check only inspects existing `<link>` elements — never `<style>` tags.
- Isolated browser tests: zero network requests for the "already inlined" URL, clean `load` resolution, genuinely new/non-inlined URLs still fetch normally, and — for both the removal timing and the `rel` rewrite — concurrent widgets sharing a CSS dependency (with 0ms/5ms/50ms staggered kickoff) all resolve correctly.
- **End-to-end against the real `mweb` app**, built from this branch (temporarily swapped into `mweb`'s `node_modules/catalyst-core`, then fully reverted — not a persistent change to mweb): 44 of 44 CSS files inlined on the homepage remain at zero network fetches, **hydration completes correctly** (React fiber present on the DOM), client-side navigation to a different page (`/labs`) works and hydrates there too, and **zero neutralized `<link>` nodes are left in the DOM** on either page.

## Test plan
- [x] `npx eslint` on the changed files — this branch's lint config has a pre-existing parsing-error issue affecting untouched files too (unrelated to this change); syntax verified via `node --check` instead
- [x] Manual browser verification against the real `mweb` app, confirming hydration actually completes and no ghost nodes remain — this is the check that caught the detached-node regression in the first place

🤖 Generated with [Claude Code](https://claude.com/claude-code)