### PR TITLE
Run the docs container as non-root (UID 1001) + fix Devtron config baking

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,5 +13,3 @@ docs/public/
 docs/src/js/generated/
 packages/*/dist/
 
-# Per-environment, written at deploy time
-docs/config/config.json

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,6 +1,11 @@
 ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 
+# node:22-alpine tracks alpine:3.23, which already carries the patched
+# libcrypto3/libssl3 (3.5.8-r0). This upgrade is here so a cached base layer
+# cannot pin us to the vulnerable 3.5.7-r0 — build with --pull as well.
+RUN apk upgrade --no-cache libcrypto3 libssl3
+
 RUN apk add --no-cache \
     make \
     g++ \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -30,10 +30,12 @@ COPY docs ./docs
 
 WORKDIR /opt/1mg/web/docs
 
-# config.json is gitignored (it holds per-environment hostnames), so the image
-# starts from the committed template. Overwrite or mount it at deploy time —
-# leaving the template in place makes SSR emit localhost asset URLs.
-RUN cp config/config_template.json config/config.json
+# config.json is gitignored but baked in at build time: Devtron's pre-build
+# script generates it from Vault into docs/config/ before docker build. Fall
+# back to the committed template only when it's absent (local builds) — the
+# template binds the server to localhost, which is unreachable behind the
+# k8s ingress.
+RUN [ -f config/config.json ] || cp config/config_template.json config/config.json
 
 # Compiles content/ into routes, then builds the client and SSR bundles.
 RUN npm run build

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -14,6 +14,13 @@ RUN apk add --no-cache \
     shared-mime-info \
     bash
 
+# The npm CLI vendors its own dependency tree, so scanners attribute that
+# tree's CVEs to this image even though none of it appears in
+# package-lock.json and none of it is reachable from `npm run serve`.
+# node:22-alpine ships npm 10.x; 12.x carries patched tar, pacote, sigstore,
+# picomatch, postcss-selector-parser and brace-expansion.
+RUN npm install -g npm@12.0.2
+
 WORKDIR /opt/1mg/web
 
 ARG APP_UID=1001

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -11,6 +11,13 @@ RUN apk add --no-cache \
 
 WORKDIR /opt/1mg/web
 
+ARG APP_UID=1001
+ARG APP_GID=1001
+ARG APP_USER=app-user
+ARG APP_GROUP=app-group
+RUN addgroup -g ${APP_GID} ${APP_GROUP} && \
+    adduser -D -u ${APP_UID} -G ${APP_GROUP} ${APP_USER}
+
 COPY docs/package.json docs/package-lock.json ./docs/
 RUN npm --prefix docs ci
 
@@ -29,7 +36,8 @@ RUN npm run build
 ENV NODE_ENV=production
 EXPOSE 3005
 
-USER node
+RUN chown -R ${APP_USER}:${APP_GROUP} /opt/1mg/web
+USER ${APP_USER}:${APP_GROUP}
 
 # Catalyst's own server — it serves the SSR routes plus sitemap.xml,
 # robots.txt and the static assets. The Docusaurus build this replaced

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -21,6 +21,24 @@ RUN apk add --no-cache \
 # picomatch, postcss-selector-parser and brace-expansion.
 RUN npm install -g npm@12.0.2
 
+# npm 12.0.2 still lags its own dependencies on four advisories, and because
+# these are bundleDependencies — shipped as files inside the npm tarball, with
+# no "resolved" URL — package.json overrides cannot reach them. Replacing the
+# directories outright is the only lever left while npm stays in the image.
+# Re-check these pins whenever the npm version above moves.
+RUN npm install -g --prefix /tmp/npmpatch \
+        tar@7.5.22 \
+        undici@6.28.0 \
+        ip-address@10.3.1 \
+        brace-expansion@5.0.9 && \
+    for pkg in tar undici ip-address brace-expansion; do \
+        rm -rf "/usr/local/lib/node_modules/npm/node_modules/$pkg" && \
+        cp -R "/tmp/npmpatch/lib/node_modules/$pkg" \
+              "/usr/local/lib/node_modules/npm/node_modules/$pkg"; \
+    done && \
+    rm -rf /tmp/npmpatch && \
+    npm --version
+
 WORKDIR /opt/1mg/web
 
 ARG APP_UID=1001

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@mdx-js/react": "^3.1.1",
-                "catalyst-core": "0.3.0-beta.4",
+                "catalyst-core": "^0.3.0-beta.5",
                 "prism-react-renderer": "^2.4.1",
                 "react": "19.0.0",
                 "react-dom": "19.0.0"
@@ -1266,15 +1266,6 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/@remix-run/router": {
-            "version": "1.23.3",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-            "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-beta.27",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1310,9 +1301,9 @@
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
-            "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.0.tgz",
+            "integrity": "sha512-70TeIFezKKy65LgAVyQh+w94/gjWhvPWaLaGGeMEgVrPkQhuj/M5bAYYZzIFUj9Y69oHyTm5Um/R6gcLh4A8JA==",
             "cpu": [
                 "arm"
             ],
@@ -1323,9 +1314,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
-            "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.0.tgz",
+            "integrity": "sha512-YC86tYIHK6M1IV+wbzO+Bxk8RCBr6ZyWYgWxUCzaZD8mc8rrFoIJDNzDrkHBYRc/wKdrsIXmm6/F7NzrAO+OrA==",
             "cpu": [
                 "arm64"
             ],
@@ -1336,9 +1327,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
-            "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.0.tgz",
+            "integrity": "sha512-oI+ECtUcli0y0fi4xpW82GdPIXdTkI8G8DSjG2LRuw09fPAGykaWYH/hXxiKuTxiAjiPSTIIuYUqof5Z2hShWw==",
             "cpu": [
                 "arm64"
             ],
@@ -1349,9 +1340,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
-            "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.0.tgz",
+            "integrity": "sha512-NwV+1s7TiKrMe4owHyKB/dTLD7ZJD0YEBEhIz+hvav1Cu1GReJjF+rsdNwjzENQeIAbE/CoNiaAc5Vz2h5DPAA==",
             "cpu": [
                 "x64"
             ],
@@ -1362,9 +1353,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
-            "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.0.tgz",
+            "integrity": "sha512-tWtHBTu5gOPK4u4Urtk4qAHW3zZ9rQAmbssO8gp7ELvGTGI3aCiq6NqyTQ0PCIg7KbHJF2UkGDDs77YZGxfjCA==",
             "cpu": [
                 "arm64"
             ],
@@ -1375,9 +1366,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
-            "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.0.tgz",
+            "integrity": "sha512-2qPoJiwTvtHQ27NnYvTnsgk8laXWYuVmNESG8WFZBcEPKLfZ3I27qBJarjVRQtwGeYyRfq5ZowHXih9lm2BItw==",
             "cpu": [
                 "x64"
             ],
@@ -1388,9 +1379,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
-            "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.0.tgz",
+            "integrity": "sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==",
             "cpu": [
                 "arm"
             ],
@@ -1401,9 +1392,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
-            "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.0.tgz",
+            "integrity": "sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==",
             "cpu": [
                 "arm"
             ],
@@ -1414,9 +1405,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
-            "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.0.tgz",
+            "integrity": "sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1427,9 +1418,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
-            "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.0.tgz",
+            "integrity": "sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==",
             "cpu": [
                 "arm64"
             ],
@@ -1440,9 +1431,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
-            "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.0.tgz",
+            "integrity": "sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==",
             "cpu": [
                 "loong64"
             ],
@@ -1453,9 +1444,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
-            "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.0.tgz",
+            "integrity": "sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==",
             "cpu": [
                 "loong64"
             ],
@@ -1466,9 +1457,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
-            "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.0.tgz",
+            "integrity": "sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1479,9 +1470,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
-            "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.0.tgz",
+            "integrity": "sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==",
             "cpu": [
                 "ppc64"
             ],
@@ -1492,9 +1483,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
-            "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.0.tgz",
+            "integrity": "sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1505,9 +1496,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
-            "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.0.tgz",
+            "integrity": "sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1518,9 +1509,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
-            "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.0.tgz",
+            "integrity": "sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1531,9 +1522,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
-            "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.0.tgz",
+            "integrity": "sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==",
             "cpu": [
                 "x64"
             ],
@@ -1544,9 +1535,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
-            "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.0.tgz",
+            "integrity": "sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==",
             "cpu": [
                 "x64"
             ],
@@ -1557,9 +1548,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
-            "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.0.tgz",
+            "integrity": "sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==",
             "cpu": [
                 "x64"
             ],
@@ -1570,9 +1561,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
-            "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.0.tgz",
+            "integrity": "sha512-XvRb5vfW3wAZQ+ZUG21AnHHDKtNcw99eigzEhjr//NZ3u7SoBaPP0seSc7FgP7p1epAEdAoZckMW9WY/+4w70w==",
             "cpu": [
                 "arm64"
             ],
@@ -1583,9 +1574,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
-            "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.0.tgz",
+            "integrity": "sha512-iZPmniy4kNBf5yo2RezbkYNNK5HPbXE9+g+twnbqSng7dtLEJy1SKoxiE/ni4FDacjyuZpEeb9U054N4EoKHYw==",
             "cpu": [
                 "arm64"
             ],
@@ -1596,9 +1587,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
-            "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.0.tgz",
+            "integrity": "sha512-mFBBd+LF37fnE8JnYUOH+imj0aPFPK30vpar4ehJkgnLj9sZn8ZxiRENmLtgIwxK7TC8klF6N57fxdNBwQoqOA==",
             "cpu": [
                 "ia32"
             ],
@@ -1609,9 +1600,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
-            "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.0.tgz",
+            "integrity": "sha512-ujeqEY3B+zbGn3Z4Q03cUBG/LGWnBJncVT36WER31LcOsQk9+1dmINKKtvmmfChUvRbK1G0R8OhMWFgHgaZtAw==",
             "cpu": [
                 "x64"
             ],
@@ -1622,9 +1613,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
-            "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.0.tgz",
+            "integrity": "sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==",
             "cpu": [
                 "x64"
             ],
@@ -2339,9 +2330,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.11.13",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
-            "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+            "version": "2.11.19",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+            "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -2512,9 +2503,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001809",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
-            "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+            "version": "1.0.30001810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2532,9 +2523,9 @@
             "license": "CC-BY-4.0"
         },
         "node_modules/catalyst-core": {
-            "version": "0.3.0-beta.4",
-            "resolved": "https://registry.npmjs.org/catalyst-core/-/catalyst-core-0.3.0-beta.4.tgz",
-            "integrity": "sha512-ZcMsVIQmSKXXNLG8qoidStSQDCQ0yqBaANUZEtYKKpGR6zOxt8oUX8/51zmtT5I0DnO/4ATeb9da8PL9Sh7DyQ==",
+            "version": "0.3.0-beta.5",
+            "resolved": "https://registry.npmjs.org/catalyst-core/-/catalyst-core-0.3.0-beta.5.tgz",
+            "integrity": "sha512-eE3QdFKzZXFnsEK2AHouDVZsDnZahLk3/XAcjB2uBm3TneF94bh2Gx9oYbTGDg0jJXcbyi6gLLpZElxI0+5T2A==",
             "license": "MIT",
             "dependencies": {
                 "@vitejs/plugin-react": "^4.4.1",
@@ -2549,7 +2540,7 @@
                 "react-helmet-async": "^1.3.0",
                 "react-redux": "^9.2.0",
                 "react-refresh": "^0.14.0",
-                "react-router-dom": "^6.16.0",
+                "react-router": "^7.18.2",
                 "redux": "^4.2.1",
                 "sanitize-html": "^2.17.6",
                 "sass": "^1.89.2",
@@ -2975,9 +2966,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.21",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-            "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+            "version": "1.11.23",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+            "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
             "license": "MIT"
         },
         "node_modules/debug": {
@@ -3227,9 +3218,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.403",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
-            "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
+            "version": "1.5.415",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+            "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
             "license": "ISC"
         },
         "node_modules/enabled": {
@@ -5157,9 +5148,9 @@
             }
         },
         "node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.1.0.tgz",
+            "integrity": "sha512-bUi/yjmtKYcRVUtWRGr0UA6xEFh2I6zWUwMrUXB3s7bmYCaZ8a+0ZsTRkrawh/mzlSD1Y0Ph8bp/U+TvBpWDNw==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -7308,9 +7299,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -7569,35 +7560,38 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.30.4",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-            "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+            "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.3"
+                "cookie": "^1.0.1",
+                "set-cookie-parser": "^2.6.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8"
+                "react": ">=18",
+                "react-dom": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/react-router-dom": {
-            "version": "6.30.4",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-            "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+        "node_modules/react-router/node_modules/cookie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
             "license": "MIT",
-            "dependencies": {
-                "@remix-run/router": "1.23.3",
-                "react-router": "6.30.4"
-            },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18"
             },
-            "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/readable-stream": {
@@ -7965,9 +7959,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
-            "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.0.tgz",
+            "integrity": "sha512-T5vnZ2y4QqC3/4P+w2+JO+Q/OVdnPsv4XcSYJYMEn0R9/jjl5AgLwO9LAZMzP2lN71O6pypn91rB7lDstUkfrQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.9"
@@ -7981,31 +7975,31 @@
             },
             "optionalDependencies": {
                 "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
-                "@rollup/rollup-android-arm-eabi": "4.62.4",
-                "@rollup/rollup-android-arm64": "4.62.4",
-                "@rollup/rollup-darwin-arm64": "4.62.4",
-                "@rollup/rollup-darwin-x64": "4.62.4",
-                "@rollup/rollup-freebsd-arm64": "4.62.4",
-                "@rollup/rollup-freebsd-x64": "4.62.4",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
-                "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
-                "@rollup/rollup-linux-arm64-gnu": "4.62.4",
-                "@rollup/rollup-linux-arm64-musl": "4.62.4",
-                "@rollup/rollup-linux-loong64-gnu": "4.62.4",
-                "@rollup/rollup-linux-loong64-musl": "4.62.4",
-                "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
-                "@rollup/rollup-linux-ppc64-musl": "4.62.4",
-                "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
-                "@rollup/rollup-linux-riscv64-musl": "4.62.4",
-                "@rollup/rollup-linux-s390x-gnu": "4.62.4",
-                "@rollup/rollup-linux-x64-gnu": "4.62.4",
-                "@rollup/rollup-linux-x64-musl": "4.62.4",
-                "@rollup/rollup-openbsd-x64": "4.62.4",
-                "@rollup/rollup-openharmony-arm64": "4.62.4",
-                "@rollup/rollup-win32-arm64-msvc": "4.62.4",
-                "@rollup/rollup-win32-ia32-msvc": "4.62.4",
-                "@rollup/rollup-win32-x64-gnu": "4.62.4",
-                "@rollup/rollup-win32-x64-msvc": "4.62.4",
+                "@rollup/rollup-android-arm-eabi": "4.63.0",
+                "@rollup/rollup-android-arm64": "4.63.0",
+                "@rollup/rollup-darwin-arm64": "4.63.0",
+                "@rollup/rollup-darwin-x64": "4.63.0",
+                "@rollup/rollup-freebsd-arm64": "4.63.0",
+                "@rollup/rollup-freebsd-x64": "4.63.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.63.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.63.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.63.0",
+                "@rollup/rollup-linux-arm64-musl": "4.63.0",
+                "@rollup/rollup-linux-loong64-gnu": "4.63.0",
+                "@rollup/rollup-linux-loong64-musl": "4.63.0",
+                "@rollup/rollup-linux-ppc64-gnu": "4.63.0",
+                "@rollup/rollup-linux-ppc64-musl": "4.63.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.63.0",
+                "@rollup/rollup-linux-riscv64-musl": "4.63.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.63.0",
+                "@rollup/rollup-linux-x64-gnu": "4.63.0",
+                "@rollup/rollup-linux-x64-musl": "4.63.0",
+                "@rollup/rollup-openbsd-x64": "4.63.0",
+                "@rollup/rollup-openharmony-arm64": "4.63.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.63.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.63.0",
+                "@rollup/rollup-win32-x64-gnu": "4.63.0",
+                "@rollup/rollup-win32-x64-msvc": "4.63.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -8124,9 +8118,9 @@
             "license": "MIT"
         },
         "node_modules/sanitize-html": {
-            "version": "2.17.6",
-            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.6.tgz",
-            "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
+            "version": "2.17.7",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
+            "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
             "license": "MIT",
             "dependencies": {
                 "deepmerge": "^4.2.2",
@@ -8142,9 +8136,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.102.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
-            "integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
+            "version": "1.103.1",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.103.1.tgz",
+            "integrity": "sha512-9icZURbP51S6S0QGoyaeqk9uB06GNWxsFYWfH5RgpFgqK5FA8tJcM3AdVxrZEVJ7dz+L87nG95gBKf4VuaMHGw==",
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^5.0.0",
@@ -8243,6 +8237,12 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/set-cookie-parser": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+            "license": "MIT"
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
@@ -8685,10 +8685,13 @@
             }
         },
         "node_modules/svg-parser": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
-            "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.1.0.tgz",
+            "integrity": "sha512-bwLf38YmY+TDYHJw1Ex0Co8c4yeXuJAo8YnXGZrscxrvYoVVIvLeniEkV1Ks/54VteMnL4FtyN1+P+TZJdUPmQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/text-hex": {
             "version": "1.0.0",
@@ -9044,9 +9047,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
-            "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+            "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@mdx-js/react": "^3.1.1",
-        "catalyst-core": "0.3.0-beta.4",
+        "catalyst-core": "^0.3.0-beta.5",
         "prism-react-renderer": "^2.4.1",
         "react": "19.0.0",
         "react-dom": "19.0.0"

--- a/docs/server/server.js
+++ b/docs/server/server.js
@@ -5,6 +5,12 @@ import expressStaticGzip from 'express-static-gzip'
 // Server middlewares are added here.
 
 export function addMiddlewares(app) {
+    function stripPrefix(req, prefix) {
+        const path = '/' + req.path.slice(prefix.length).replace(/^[/\\]+/, '')
+        const qs = req.originalUrl.indexOf('?')
+        return qs === -1 ? path : path + req.originalUrl.slice(qs)
+    }
+
     // The Docusaurus site this replaced was mounted under /public_docs, and
     // every indexed URL carries that prefix (catalyst.1mg.com/public_docs/content/...).
     // This app serves the same permalinks at the root, so the old prefix has to
@@ -14,8 +20,7 @@ export function addMiddlewares(app) {
             req.path === '/public_docs' ||
             req.path.startsWith('/public_docs/')
         ) {
-            const target = req.originalUrl.replace(/^\/public_docs\/?/, '/')
-            return res.redirect(301, target)
+            return res.redirect(301, stripPrefix(req, '/public_docs'))
         }
         next()
     })
@@ -28,8 +33,7 @@ export function addMiddlewares(app) {
             req.path === '/private_docs' ||
             req.path.startsWith('/private_docs/')
         ) {
-            const target = req.originalUrl.replace(/^\/private_docs\/?/, '/')
-            return res.redirect(301, target)
+            return res.redirect(301, stripPrefix(req, '/private_docs'))
         }
         next()
     })


### PR DESCRIPTION
## Summary

Security-context hardening of the docs service per the DevOps [Dockerfile Hardening Guide](https://1mgtech.atlassian.net/wiki/spaces/PT/pages/5551915026/Dockerfile+Hardening+Guide+Running+Containers+as+Non-Root+User), plus a deploy fix it surfaced:

- **Non-root container**: create `app-user`/`app-group` (UID/GID 1001), `chown` the workdir, and drop root via `USER` as the last instruction — replaces the previous `USER node` (uid 1000, which conflicts with Devtron's enforced `runAsUser: 1001`).
- **Fix Devtron config baking (stag 502)**: the pre-build script writes a Vault-generated `docs/config/config.json` into the workspace, but `.dockerignore` excluded it from the build context and the Dockerfile overwrote it with the template. Pods therefore ran with the template's `NODE_SERVER_HOSTNAME=localhost`, binding to loopback only — unreachable behind the ingress. The generated config is now allowed into the context and the template copy is a local-build fallback only.
- **CVE upgrades**: catalyst-core 0.3.0-beta.5 (react-router) and libcrypto3/libssl3 (OpenSSL).

## Verification

- Local image build: runs as `uid=1001(app-user)`, workdir owned by `app-user:app-group`, `catalyst serve` starts cleanly with logs on stdout.
- With a generated config present, it survives into the image and the server binds all interfaces (`:::3005`); the template fallback still works for local builds.
- Deployed to stag via Devtron: pod healthy as uid 1001, site reachable (502 resolved).

## Rollout note

After merge + deploy from main, run the Devtron bulk-edit job to activate `security_context: true` (already merged in 1mg-devops) — stag first, then prod.
