### PR TITLE
fix(android): wire catalyst-ai native module under its real name + compile it in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,6 +24,7 @@ jobs:
             android: ${{ steps.filter.outputs.android }}
             ios: ${{ steps.filter.outputs.ios }}
             docs: ${{ steps.filter.outputs.docs }}
+            ai_android: ${{ steps.filter.outputs.ai_android }}
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -62,6 +63,16 @@ jobs:
                         - '!packages/catalyst-core/src/native/iosnativeWebView/**'
                         - 'packages/create-catalyst-app/**'
                         - 'packages/catalyst-ai/**'
+                        # catalyst-ai/android is a standalone com.android.library
+                        # module (io.catalyst.nativeai). It is not web code and
+                        # not part of androidProject's Gradle build -- the app
+                        # loads it at runtime via ServiceLoader, and it is only
+                        # linked when ai.enabled=true. Its own jobs
+                        # (catalyst-ai-android-compile / -integration, gated on
+                        # the ai_android filter below) compile it; excluded here
+                        # so a Kotlin-only change doesn't needlessly run the web
+                        # chain.
+                        - '!packages/catalyst-ai/android/**'
                         - 'examples/error-catalog/**'
                       android:
                         - *shared
@@ -69,6 +80,19 @@ jobs:
                       ios:
                         - *shared
                         - 'packages/catalyst-core/src/native/iosnativeWebView/**'
+                      # The optional catalyst-ai native library: its own sources,
+                      # plus the androidProject build wiring that includes and
+                      # links it (settings.gradle.kts / app build.gradle.kts /
+                      # version catalog) and the JS that syncs it into the build
+                      # tree for an ai.enabled build.
+                      ai_android:
+                        - *shared
+                        - 'packages/catalyst-ai/android/**'
+                        - 'packages/catalyst-core/src/native/androidProject/settings.gradle.kts'
+                        - 'packages/catalyst-core/src/native/androidProject/build.gradle.kts'
+                        - 'packages/catalyst-core/src/native/androidProject/app/build.gradle.kts'
+                        - 'packages/catalyst-core/src/native/androidProject/gradle/**'
+                        - 'packages/catalyst-core/src/native/buildAndroid/**'
                       docs:
                         - 'docs/**'
 
@@ -465,6 +489,166 @@ jobs:
                   path: packages/catalyst-core/src/native/androidProject/app/build/reports/jacoco/jacocoTestReport
                   retention-days: 14
 
+    # -----------------------------------------------------------------
+    # catalyst-ai native library (Android) -- two jobs.
+    #
+    # packages/catalyst-ai/android is a standalone com.android.library
+    # module (io.catalyst.nativeai). Nothing in androidProject depends on
+    # it at compile time -- NativeBridge.kt discovers CatalystAIBridge at
+    # runtime via Class.forName + ServiceLoader -- and it is only synced
+    # into the build tree, and linked, when a build sets ai.enabled=true.
+    # So neither the web chain nor android-unit-and-coverage ever compiles
+    # this Kotlin. These jobs do.
+    #
+    # Both are standalone (needs: detect-changes, gated on the ai_android
+    # filter) rather than chained behind an android job: a break here is a
+    # linkage/compile problem in the optional module, independent of the
+    # main app's lint/tests.
+    # -----------------------------------------------------------------
+
+    catalyst-ai-android-compile:
+        # Fast path: sync the module in the way `sync-packages --packages ai`
+        # / an ai.enabled build do (into androidProject/../node_modules),
+        # then prove Gradle picks it up and it compiles -- against the
+        # in-repo androidProject, no scaffold. ~2 min.
+        needs: detect-changes
+        if: needs.detect-changes.outputs.ai_android == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+              with:
+                  distribution: "temurin"
+                  java-version: "17"
+                  cache: gradle
+
+            - name: Sync catalyst-ai into node_modules (mirrors sync-packages --packages ai)
+              run: |
+                  set -euo pipefail
+                  dest=packages/catalyst-core/src/native/node_modules/catalyst-ai
+                  mkdir -p "$dest"
+                  rsync -a --exclude node_modules --exclude .git \
+                    packages/catalyst-ai/ "$dest/"
+
+            - name: Assert Gradle includes :catalyst-ai
+              # This is the regression test for the bug this module's wiring
+              # had: settings.gradle.kts looked for a package name that
+              # never existed, so the include silently no-op'd and the
+              # module was compiled by nothing. A bare compile check would
+              # pass vacuously in that state (no module => nothing to
+              # build). Fail loudly if the include is not active.
+              working-directory: packages/catalyst-core/src/native/androidProject
+              run: |
+                  set -euo pipefail
+                  chmod +x ./gradlew
+                  ./gradlew projects --console=plain | tee /tmp/projects.txt
+                  grep -q "Project ':catalyst-ai'" /tmp/projects.txt \
+                    || { echo "::error::androidProject did not include :catalyst-ai after sync -- check settings.gradle.kts"; exit 1; }
+
+            - name: Compile :catalyst-ai (Kotlin)
+              working-directory: packages/catalyst-core/src/native/androidProject
+              run: ./gradlew :catalyst-ai:compileDebugKotlin --console=plain
+
+            - name: Compile :app against :catalyst-ai with ai.enabled=true
+              # ai.enabled=true puts :catalyst-ai on the app's
+              # implementation config (APK bundling) and flips
+              # useLegacyPackaging. Exercises manifest merge (minSdk
+              # alignment) and the app's own Kotlin compile with the module
+              # present.
+              working-directory: packages/catalyst-core/src/native/androidProject
+              run: |
+                  set -euo pipefail
+                  printf '%s' '{"WEBVIEW_CONFIG":{"ai":{"enabled":true},"android":{"buildType":"debug"}}}' > /tmp/ai-config.json
+                  ./gradlew :app:processDebugMainManifest :app:compileDebugKotlin \
+                    -PconfigPath=/tmp/ai-config.json --console=plain
+
+    catalyst-ai-android-integration:
+        # Dev-accurate path: scaffold an app with create-catalyst-app,
+        # install the local catalyst-ai the way a developer would, turn on
+        # ai.enabled, run the real headless Android prep
+        # (buildAndroidForTesting -> syncAIPackageIfEnabled), then compile
+        # the module inside the scaffolded app's copy of androidProject.
+        # This is the end-to-end check of the JS sync + npm packaging that
+        # the compile job above skips. ~5-8 min.
+        needs: detect-changes
+        if: needs.detect-changes.outputs.ai_android == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            - name: Setup Node.js
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version-file: ".nvmrc"
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+              with:
+                  distribution: "temurin"
+                  java-version: "17"
+                  cache: gradle
+
+            - name: Install workspace deps
+              run: node -v && npm ci
+
+            - name: Scaffold a release sandbox app (no build)
+              run: |
+                  set -euo pipefail
+                  node scripts/create-release-sandbox.js \
+                    --target-dir "$RUNNER_TEMP/ai-sandbox" \
+                    --name ai-test-app --yes --force --skip-build
+
+            - name: Install local catalyst-ai into the sandbox
+              # file: install from a fresh pack, mirroring how
+              # create-release-sandbox.js already sources catalyst-core --
+              # so this tests the PR's module, not whatever is on npm.
+              run: |
+                  set -euo pipefail
+                  app_dir="$RUNNER_TEMP/ai-sandbox/ai-test-app"
+                  tgz=$(npm pack --workspace packages/catalyst-ai --pack-destination "$RUNNER_TEMP" --silent | tail -1)
+                  ( cd "$app_dir" && npm install --no-save "file:$RUNNER_TEMP/$tgz" )
+                  test -f "$app_dir/node_modules/catalyst-ai/android/build.gradle.kts"
+
+            - name: Enable ai in the sandbox app config
+              run: |
+                  set -euo pipefail
+                  cfg="$RUNNER_TEMP/ai-sandbox/ai-test-app/config/config.json"
+                  node -e '
+                    const fs = require("fs");
+                    const p = process.argv[1];
+                    const c = JSON.parse(fs.readFileSync(p, "utf8"));
+                    c.WEBVIEW_CONFIG = c.WEBVIEW_CONFIG || {};
+                    c.WEBVIEW_CONFIG.ai = { enabled: true };
+                    fs.writeFileSync(p, JSON.stringify(c, null, 4));
+                  ' "$cfg"
+
+            - name: Run headless Android prep (buildAndroidForTesting)
+              # Drives the real code path: initializeConfig -> asset copy ->
+              # plugin compose -> syncAIPackageIfEnabled. No emulator/device.
+              working-directory: ${{ runner.temp }}/ai-sandbox/ai-test-app
+              run: |
+                  set -euo pipefail
+                  node -e '
+                    const { createAndroidBuild } = require("catalyst-core/dist/native/buildAndroid/index.js");
+                    const cfg = require("./config/config.json");
+                    createAndroidBuild({ WEBVIEW_CONFIG: cfg.WEBVIEW_CONFIG, BUILD_OUTPUT_PATH: cfg.BUILD_OUTPUT_PATH })
+                      .buildAndroidForTesting()
+                      .then(r => { if (!r || !r.success) { console.error("buildAndroidForTesting did not succeed"); process.exit(1); } })
+                      .catch(e => { console.error(e); process.exit(1); });
+                  '
+
+            - name: Assert Gradle includes :catalyst-ai and it compiles
+              working-directory: ${{ runner.temp }}/ai-sandbox/ai-test-app/node_modules/catalyst-core/dist/native/androidProject
+              run: |
+                  set -euo pipefail
+                  chmod +x ./gradlew
+                  ./gradlew projects --console=plain | tee /tmp/projects.txt
+                  grep -q "Project ':catalyst-ai'" /tmp/projects.txt \
+                    || { echo "::error::scaffolded androidProject did not include :catalyst-ai after an ai.enabled prep -- the JS sync path is broken"; exit 1; }
+                  ./gradlew :catalyst-ai:compileDebugKotlin --console=plain
+
     # Split from what was a single test-ios-unit job into two: CoreLogic
     # (this job) runs first, has zero dependencies, needs no simulator, and
     # is the only iOS target that can produce a real coverage percentage
@@ -823,7 +1007,7 @@ jobs:
     # because a skipped platform (e.g. an android-only PR, where the iOS
     # and web jobs never run) must still count as fine here, not failure.
     coverage-summary:
-        needs: [detect-changes, lint, unit-and-contract-tests, web-integration-smoke, error-catalog, android-unit-and-coverage, ios-corelogic-and-coverage, ios-app-simulator-tests]
+        needs: [detect-changes, lint, unit-and-contract-tests, web-integration-smoke, error-catalog, android-unit-and-coverage, catalyst-ai-android-compile, catalyst-ai-android-integration, ios-corelogic-and-coverage, ios-app-simulator-tests]
         if: always()
         runs-on: ubuntu-latest
         steps:
@@ -835,6 +1019,8 @@ jobs:
                   web_smoke_status="${{ needs.web-integration-smoke.result }}"
                   error_catalog_status="${{ needs.error-catalog.result }}"
                   android_status="${{ needs.android-unit-and-coverage.result }}"
+                  ai_android_compile_status="${{ needs.catalyst-ai-android-compile.result }}"
+                  ai_android_integration_status="${{ needs.catalyst-ai-android-integration.result }}"
                   ios_corelogic_status="${{ needs.ios-corelogic-and-coverage.result }}"
                   ios_app_status="${{ needs.ios-app-simulator-tests.result }}"
                   web_pct="${{ needs.unit-and-contract-tests.outputs.line_pct }}"
@@ -858,6 +1044,8 @@ jobs:
                   report_platform "web-integration-smoke (not a coverage platform, pass/fail only)" "$web_smoke_status" ""
                   report_platform "error-catalog (error-contract gate, pass/fail only)" "$error_catalog_status" ""
                   report_platform "android (jacoco)" "$android_status" "$android_pct"
+                  report_platform "catalyst-ai-android-compile (module compile gate, pass/fail only)" "$ai_android_compile_status" ""
+                  report_platform "catalyst-ai-android-integration (scaffold+sync e2e, pass/fail only)" "$ai_android_integration_status" ""
                   report_platform "ios-corelogic (CatalystCoreLogic, llvm-cov)" "$ios_corelogic_status" "$ios_corelogic_pct"
                   report_platform "ios-app (iosnativeWebView.app target, xccov)" "$ios_app_status" "$ios_app_pct"
 
@@ -873,7 +1061,7 @@ jobs:
                   fi
 
                   fail=0
-                  for pair in "lint:$lint_status" "web:$web_status" "web-integration-smoke:$web_smoke_status" "error-catalog:$error_catalog_status" "android:$android_status" "ios-corelogic:$ios_corelogic_status" "ios-app:$ios_app_status"; do
+                  for pair in "lint:$lint_status" "web:$web_status" "web-integration-smoke:$web_smoke_status" "error-catalog:$error_catalog_status" "android:$android_status" "catalyst-ai-android-compile:$ai_android_compile_status" "catalyst-ai-android-integration:$ai_android_integration_status" "ios-corelogic:$ios_corelogic_status" "ios-app:$ios_app_status"; do
                     platform="${pair%%:*}"
                     status="${pair#*:}"
                     if [ "$status" != "success" ] && [ "$status" != "skipped" ]; then

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -565,16 +565,20 @@ jobs:
                     -PconfigPath=/tmp/ai-config.json --console=plain
 
     catalyst-ai-android-integration:
-        # Dev-accurate path: scaffold an app with create-catalyst-app,
-        # install the local catalyst-ai the way a developer would, turn on
-        # ai.enabled, run the real headless Android prep
-        # (buildAndroidForTesting -> syncAIPackageIfEnabled), then compile
-        # the module inside the scaffolded app's copy of androidProject.
-        # This is the end-to-end check of the JS sync + npm packaging that
-        # the compile job above skips. ~5-8 min.
+        # Dev-accurate path: the maintained examples/useai app, which
+        # already ships a config with ai.enabled=true. Sync the local
+        # catalyst-core + catalyst-ai into it the way a developer does
+        # (npm run sync-core / sync-packages), run the real headless
+        # Android prep (buildAndroidForTesting -> syncAIPackageIfEnabled),
+        # then include-assert + compile the module inside the app's synced
+        # copy of androidProject. This is the end-to-end check of the JS
+        # sync path that the compile job above skips. ~5-8 min.
         needs: detect-changes
         if: needs.detect-changes.outputs.ai_android == 'true'
         runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: examples/useai
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -590,63 +594,59 @@ jobs:
                   java-version: "17"
                   cache: gradle
 
-            - name: Install workspace deps
+            - name: Install root workspace deps
+              working-directory: .
               run: node -v && npm ci
 
-            - name: Scaffold a release sandbox app (no build)
+            - name: Prepare examples/useai (config + install + sync core & ai)
+              # config.template.json already has AI_CONFIG.enabled and
+              # WEBVIEW_CONFIG.ai.enabled = true -- no patching. sync-core
+              # builds catalyst-core and installs the packed local build;
+              # sync-packages copies the local catalyst-ai into
+              # node_modules (its android/ module included), which is what
+              # settings.gradle.kts and syncAIPackageIfEnabled both target.
               run: |
                   set -euo pipefail
-                  node scripts/create-release-sandbox.js \
-                    --target-dir "$RUNNER_TEMP/ai-sandbox" \
-                    --name ai-test-app --yes --force --skip-build
-
-            - name: Install local catalyst-ai into the sandbox
-              # file: install from a fresh pack, mirroring how
-              # create-release-sandbox.js already sources catalyst-core --
-              # so this tests the PR's module, not whatever is on npm.
-              run: |
-                  set -euo pipefail
-                  app_dir="$RUNNER_TEMP/ai-sandbox/ai-test-app"
-                  tgz=$(npm pack --workspace packages/catalyst-ai --pack-destination "$RUNNER_TEMP" --silent | tail -1)
-                  ( cd "$app_dir" && npm install --no-save "file:$RUNNER_TEMP/$tgz" )
-                  test -f "$app_dir/node_modules/catalyst-ai/android/build.gradle.kts"
-
-            - name: Enable ai in the sandbox app config
-              run: |
-                  set -euo pipefail
-                  cfg="$RUNNER_TEMP/ai-sandbox/ai-test-app/config/config.json"
-                  node -e '
-                    const fs = require("fs");
-                    const p = process.argv[1];
-                    const c = JSON.parse(fs.readFileSync(p, "utf8"));
-                    c.WEBVIEW_CONFIG = c.WEBVIEW_CONFIG || {};
-                    c.WEBVIEW_CONFIG.ai = { enabled: true };
-                    fs.writeFileSync(p, JSON.stringify(c, null, 4));
-                  ' "$cfg"
+                  cp config/config.template.json config/config.json
+                  npm install
+                  npm run sync-core
+                  # useai's sync-packages script already ends with `--packages`,
+                  # so the arg is just the package short-name.
+                  npm run sync-packages -- ai
+                  test -f node_modules/catalyst-ai/android/build.gradle.kts
 
             - name: Run headless Android prep (buildAndroidForTesting)
-              # Drives the real code path: initializeConfig -> asset copy ->
-              # plugin compose -> syncAIPackageIfEnabled. No emulator/device.
-              working-directory: ${{ runner.temp }}/ai-sandbox/ai-test-app
+              # Real code path: initializeConfig -> asset copy -> plugin
+              # compose -> syncAIPackageIfEnabled. No emulator/device.
+              # catalystCorePath resolves to examples/useai/node_modules/
+              # catalyst-core, so the AI module is synced to that package's
+              # dist/native/node_modules/catalyst-ai -- the sibling of the
+              # androidProject the next step runs in.
               run: |
                   set -euo pipefail
                   node -e '
-                    const { createAndroidBuild } = require("catalyst-core/dist/native/buildAndroid/index.js");
+                    const path = require("path");
+                    // catalyst-core has an "exports" map, so a deep
+                    // require("catalyst-core/dist/native/...") is blocked.
+                    // Resolve the package dir and require the file by
+                    // absolute path -- the same thing bin/catalyst.js does.
+                    const coreDir = path.dirname(require.resolve("catalyst-core/package.json"));
+                    const { createAndroidBuild } = require(path.join(coreDir, "dist/native/buildAndroid/index.js"));
                     const cfg = require("./config/config.json");
                     createAndroidBuild({ WEBVIEW_CONFIG: cfg.WEBVIEW_CONFIG, BUILD_OUTPUT_PATH: cfg.BUILD_OUTPUT_PATH })
                       .buildAndroidForTesting()
                       .then(r => { if (!r || !r.success) { console.error("buildAndroidForTesting did not succeed"); process.exit(1); } })
-                      .catch(e => { console.error(e); process.exit(1); });
+                      .catch(e => { console.error(e && e.stack || e); process.exit(1); });
                   '
 
             - name: Assert Gradle includes :catalyst-ai and it compiles
-              working-directory: ${{ runner.temp }}/ai-sandbox/ai-test-app/node_modules/catalyst-core/dist/native/androidProject
+              working-directory: examples/useai/node_modules/catalyst-core/dist/native/androidProject
               run: |
                   set -euo pipefail
                   chmod +x ./gradlew
                   ./gradlew projects --console=plain | tee /tmp/projects.txt
                   grep -q "Project ':catalyst-ai'" /tmp/projects.txt \
-                    || { echo "::error::scaffolded androidProject did not include :catalyst-ai after an ai.enabled prep -- the JS sync path is broken"; exit 1; }
+                    || { echo "::error::useai's androidProject did not include :catalyst-ai after an ai.enabled prep -- the JS sync path is broken"; exit 1; }
                   ./gradlew :catalyst-ai:compileDebugKotlin --console=plain
 
     # Split from what was a single test-ios-unit job into two: CoreLogic

--- a/examples/sync-packages.js
+++ b/examples/sync-packages.js
@@ -74,15 +74,18 @@ function syncPackage(shortName) {
 
   ok(`${packageName} → ${path.relative(REPO_ROOT, targetDir)}`);
 
-  // For ai, remind dev to wire up the android module (useNativeAI) in settings.gradle.kts
+  // For ai, point at the android module (useNativeAI). No manual
+  // settings.gradle.kts edit needed: androidProject/settings.gradle.kts
+  // auto-includes :catalyst-ai when node_modules/catalyst-ai/android exists
+  // (this sync's target). Set `ai.enabled: true` in the app config so the
+  // module is bundled into the APK.
   if (shortName === 'ai') {
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal - targetDir is derived earlier from the fixed PACKAGE_MAP lookup; 'android' is a hardcoded literal, not request input.
     const androidDir = path.join(targetDir, 'android');
     if (fs.existsSync(androidDir)) {
       console.log(`\x1b[36m  ℹ  Android module at: ${path.relative(REPO_ROOT, androidDir)}\x1b[0m`);
-      console.log(`\x1b[33m  ⚠  Add to settings.gradle.kts:\x1b[0m`);
-      console.log(`       include(":catalyst-ai")`);
-      console.log(`       project(":catalyst-ai").projectDir = File("node_modules/catalyst-ai/android")`);
+      console.log(`\x1b[36m  ℹ  androidProject/settings.gradle.kts auto-includes :catalyst-ai from here.\x1b[0m`);
+      console.log(`\x1b[33m  ⚠  Set "ai": { "enabled": true } in your app config to bundle it into the APK.\x1b[0m`);
     }
   }
 }

--- a/packages/catalyst-core/src/native/androidProject/app/build.gradle.kts
+++ b/packages/catalyst-core/src/native/androidProject/app/build.gradle.kts
@@ -220,7 +220,7 @@ android {
                 java.srcDirs("src/noFcm/java")
             }
             // AI has no source-set swap — CatalystAIBridge self-registers via ServiceLoader
-            // when @catalyst/cloud-ai is on the classpath.
+            // when catalyst-ai is on the classpath.
         }
     }
 }
@@ -273,11 +273,18 @@ dependencies {
     implementation("io.ktor:ktor-server-sse:3.0.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
 
-    // Native AI — compileOnly always (for types), implementation only when ai.enabled=true (for runtime bundling)
-    if (project.findProject(":catalyst-cloud-ai") != null) {
-        compileOnly(project(":catalyst-cloud-ai"))
+    // Native AI (catalyst-ai). The module is only ever on the classpath when
+    // ai.enabled=true -- that's the sole sync trigger (settings.gradle.kts
+    // guards on node_modules/catalyst-ai/android existing, and the auto-sync
+    // in buildAndroid/index.js only runs for ai.enabled). The app has no
+    // compile-time dependency on it: NativeBridge.kt discovers CatalystAIBridge
+    // at runtime via Class.forName + ServiceLoader. compileOnly is kept so the
+    // module still builds/type-checks when present; implementation adds it to
+    // the APK for runtime bundling.
+    if (project.findProject(":catalyst-ai") != null) {
+        compileOnly(project(":catalyst-ai"))
         if (isAIEnabled()) {
-            implementation(project(":catalyst-cloud-ai"))
+            implementation(project(":catalyst-ai"))
         }
     }
 

--- a/packages/catalyst-core/src/native/androidProject/build.gradle.kts
+++ b/packages/catalyst-core/src/native/androidProject/build.gradle.kts
@@ -7,5 +7,6 @@ buildscript {
 
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
 }

--- a/packages/catalyst-core/src/native/androidProject/gradle/libs.versions.toml
+++ b/packages/catalyst-core/src/native/androidProject/gradle/libs.versions.toml
@@ -49,5 +49,10 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+# Same AGP version as android-application -- needed so the optional
+# :catalyst-ai library module (wired in settings.gradle.kts when the npm
+# package is installed) can apply `id("com.android.library")` without
+# declaring its own version.
+android-library = { id = "com.android.library", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }

--- a/packages/catalyst-core/src/native/androidProject/settings.gradle.kts
+++ b/packages/catalyst-core/src/native/androidProject/settings.gradle.kts
@@ -34,12 +34,15 @@ dependencyResolutionManagement {
 rootProject.name = "Catalyst Application"
 include(":app")
 
-// @catalyst/cloud-ai — include when the package is installed.
-// The npm package ships an /android library module for native AI; wire it here so Gradle picks it up.
-// After running: npm install @catalyst/cloud-ai && npm run sync-packages -- --packages cloud-ai
-// Also set ai.enabled=true in your app config to enable useLegacyPackaging for GPU dlopen().
-val cloudAiDir = File(rootDir, "../node_modules/@catalyst/cloud-ai/android")
-if (cloudAiDir.exists()) {
-    include(":catalyst-cloud-ai")
-    project(":catalyst-cloud-ai").projectDir = cloudAiDir
+// catalyst-ai — include when the npm package is installed.
+// The package ships an /android library module (namespace io.catalyst.nativeai)
+// for native AI; wire it here so Gradle picks it up. After running:
+//   npm install catalyst-ai && npm run sync-packages -- --packages ai
+// (an `ai.enabled=true` build syncs it automatically -- see
+// buildAndroid/index.js:syncAIPackageIfEnabled). Also set ai.enabled=true in
+// your app config to enable useLegacyPackaging for GPU dlopen().
+val catalystAiDir = File(rootDir, "../node_modules/catalyst-ai/android")
+if (catalystAiDir.exists()) {
+    include(":catalyst-ai")
+    project(":catalyst-ai").projectDir = catalystAiDir
 }

--- a/packages/catalyst-core/src/native/terminalProgress.js
+++ b/packages/catalyst-core/src/native/terminalProgress.js
@@ -1,4 +1,4 @@
-import * as pc from "ansis"
+import pc from "ansis"
 
 class TerminalProgress {
     constructor(steps, title = "Setup Progress", options = {}) {


### PR DESCRIPTION
## What

Three related fixes for the optional **catalyst-ai** Android library (`packages/catalyst-ai/android`, namespace `io.catalyst.nativeai`):

### 1. `fix(android)` — wire the module under its real name (the `ai.enabled` bug)

`settings.gradle.kts` / `app/build.gradle.kts` referenced the module as **`@catalyst/cloud-ai` / `:catalyst-cloud-ai`** — a name nothing in the toolchain produces. The published package is [`catalyst-ai`](https://www.npmjs.com/package/catalyst-ai); `sync-packages` and `buildAndroid/index.js:syncAIPackageIfEnabled` both sync it to `node_modules/catalyst-ai/android`. So `include(":catalyst-cloud-ai")` never fired — the module's Kotlin was compiled by **nothing**, even on `ai.enabled=true` builds.

- `settings.gradle.kts`: look for `node_modules/catalyst-ai/android`; `include(":catalyst-ai")`.
- `app/build.gradle.kts`: `findProject(":catalyst-ai")` + `compileOnly`/`implementation`; rewrote the stale "compileOnly always (for types)" comment.
- `libs.versions.toml` + root `build.gradle.kts`: add a `com.android.library` plugin alias (same AGP version) — without it `include(":catalyst-ai")` fails at configuration time.
- `examples/sync-packages.js`: drop the "hand-edit `settings.gradle.kts`" hint (now automatic).

### 2. `fix(native)` — ansis default import in `terminalProgress.js`

Found while wiring the integration job. #381 migrated `picocolors` → `ansis`; every consumer switched to `import pc from "ansis"` **except `terminalProgress.js`**, which kept `import * as pc from "ansis"`. ansis puts its colour fns on the default export, so `pc.red`/`pc.green`/… are `undefined` and **`progress.log()` throws `color is not a function` on first call**.

Web suites never call `progress.log()`, so CI stayed green — but **`catalyst buildApp:android` / `setupEmulator:android` crash on their first log line** on any build off this stack. (`main` still has the picocolors import, where `import * as` works — so this is specific to the epic/329 line.) One-line fix, matches the other 6 ansis consumers. **A release hotfix off `main` would not need this** (main isn't affected); a hotfix off epic/329 would.

### 3. `ci` — compile the module in CI

New `ai_android` path filter + two standalone jobs (`needs: detect-changes`), both in `coverage-summary`:

| Job | ~Time | Covers |
|---|---|---|
| **catalyst-ai-android-compile** ✅ passing | 2 min | rsync module → `./gradlew projects` **asserts `:catalyst-ai` is included** (regression test for the wiring bug — a bare compile check passes vacuously if the include silently no-op's) → `:catalyst-ai:compileDebugKotlin` → `:app:compileDebugKotlin -PconfigPath=<ai.enabled=true>` |
| **catalyst-ai-android-integration** | 5-8 min | the maintained **`examples/useai`** app (config already has `ai.enabled: true`): `cp config.template.json` → `npm install` → `npm run sync-core` → `npm run sync-packages -- ai` → headless `buildAndroidForTesting` (`→ syncAIPackageIfEnabled`) → include-assert + compile in useai's synced `androidProject`. End-to-end check of the JS sync path the compile job skips. |

`packages/catalyst-ai/android/**` also excluded from the `web` filter.

## Verification

Local (Gradle 8.13 / AGP 8.11.1):
- `./gradlew projects` — `:catalyst-ai` **absent before sync, present after**.
- `:catalyst-ai:compileDebugKotlin` — BUILD SUCCESSFUL.
- `:app:processDebugMainManifest :app:compileDebugKotlin -PconfigPath=<ai.enabled=true>` — BUILD SUCCESSFUL.
- **Full integration path via `examples/useai`** (with fix #2): `sync-core` + `sync-packages -- ai` + headless `buildAndroidForTesting()` → `catalyst-ai synced ... for Gradle`, `./gradlew projects` shows `:catalyst-ai`, `compileDebugKotlin` BUILD SUCCESSFUL.
- `./gradlew lintDebug` — same 5 pre-existing errors with and without this change (0 new).

`catalyst-ai-android-compile` verified on CI.

## Stack / base

Based on `feature/418-ci-workflow-split`. `feature/418` does not yet have the `android-lint` job or its 5 lint fixes (those are in PR #462) — the new `ai_android` jobs are independent of `android-lint` and go green regardless. Rebase after #462 merges.

## Follow-ups

- catalyst-ai/android has no ktlint/detekt (Kotlin style).
- SwiftLint/Android-lint CI images are tag-pinned, not digest-pinned (tracked from #462).

🤖 Generated with [Claude Code](https://claude.com/claude-code)