### PR TITLE
fix: escape < in inline SSR script to prevent XSS via script-tag breakout

### DIFF
--- a/src/server/renderer/document/Body.js
+++ b/src/server/renderer/document/Body.js
@@ -1,5 +1,11 @@
 import React from "react"
 
+// Prevents a "</script>" (or any "<...") inside serialized SSR data from
+// closing the real <script> tag early and letting the remainder of the
+// string be parsed as new HTML/script (reflected XSS via query params,
+// route data, etc. that end up in initialState/fetcherData).
+const safeStringify = (value) => JSON.stringify(value).replace(/</g, "\\u003c")
+
 /**
  * Body component which will be used in page component
  * @param {object} jsx - page jsx code
@@ -18,8 +24,8 @@ export function Body({ jsx = "", initialState = {}, fetcherData = {}, nonce, chi
                 /* eslint-disable */
                 dangerouslySetInnerHTML={{
                     __html: `
-                    window.__INITIAL_STATE__ = ${JSON.stringify(initialState)}
-                    window.__ROUTER_INITIAL_DATA__ = ${JSON.stringify(fetcherData)}
+                    window.__INITIAL_STATE__ = ${safeStringify(initialState)}
+                    window.__ROUTER_INITIAL_DATA__ = ${safeStringify(fetcherData)}
             `,
                 }}
             />


### PR DESCRIPTION
## Summary
- `Body.js` embeds `JSON.stringify(initialState)` / `JSON.stringify(fetcherData)` raw into an inline `<script>` via `dangerouslySetInnerHTML`. `JSON.stringify` does not escape `<`, so any string reaching either object containing a literal `</script>` terminates the tag early and lets the rest of the payload run as injected HTML/script.
- Confirmed exploitable in production via `https://www.1mg.com/?lang=%22%3E%3C%2Fscript%3E%3Cscript%3Ealert(document.domain)%3C%2Fscript%3E%3Cp%20class=%22&p=1` — the `lang`/`p` query values are folded (undecoded) into a route/fetcher-data cache key by `serverDataFetcher` (in `@tata1mg/router`), which then flows into `fetcherData` and gets serialized here unescaped.
- Fix: escape `<` to `<` before interpolating. This is transparent to consumers — `<` decodes back to `<` when the browser's JS engine parses the script, so `window.__INITIAL_STATE__` / `window.__ROUTER_INITIAL_DATA__` are byte-identical to before. Only `statusCode`/other unrelated interpolation left untouched (not part of this vector).

## Test plan
- [ ] Verify `window.__INITIAL_STATE__` / `window.__ROUTER_INITIAL_DATA__` hydrate identically for existing routes (including any with HTML content from CMS/API data rendered via `dangerouslySetInnerHTML` on the client)
- [ ] Re-request the PoC URL shape (`?lang="></script><script>alert(document.domain)</script><p class="`) against a build with this fix and confirm no script executes and the page renders normally