### PR TITLE
fix: restore sanitizeHtml in generateRouteKey's route-data cache key

### DIFF
--- a/src/web-router/components/RouterDataProvider.jsx
+++ b/src/web-router/components/RouterDataProvider.jsx
@@ -73,7 +73,12 @@ export const serverDataFetcher = async (serverFetchDataProps, fetcherArgs) => {
         let searchParamsString = ""
         if (searchParams) {
             for (const key in searchParams) {
-                searchParamsString += `${key}=${searchParams[key]}&`
+                // Encoded before folding into the route/fetcher-data cache key: this
+                // key ends up as an object key in fetcherData, which is later
+                // JSON.stringify'd into an inline SSR <script> (see Body.jsx). A raw
+                // "<", ">" or '"' from a query value here could otherwise break out
+                // of that script tag.
+                searchParamsString += `${encodeURIComponent(key)}=${encodeURIComponent(searchParams[key])}&`
             }
             searchParamsString = searchParamsString.slice(0, -1)
             searchParamsString = searchParamsString ? `?${searchParamsString}` : searchParamsString

--- a/src/web-router/components/RouterDataProvider.jsx
+++ b/src/web-router/components/RouterDataProvider.jsx
@@ -9,7 +9,7 @@ import {
     matchRoutes,
 } from "react-router"
 import { OneMgRouterContext } from "../context.jsx"
-// import sanitizeHtml from "sanitize-html"
+import sanitizeHtml from "sanitize-html"
 
 /**
  * @description  Router Data
@@ -73,12 +73,7 @@ export const serverDataFetcher = async (serverFetchDataProps, fetcherArgs) => {
         let searchParamsString = ""
         if (searchParams) {
             for (const key in searchParams) {
-                // Encoded before folding into the route/fetcher-data cache key: this
-                // key ends up as an object key in fetcherData, which is later
-                // JSON.stringify'd into an inline SSR <script> (see Body.jsx). A raw
-                // "<", ">" or '"' from a query value here could otherwise break out
-                // of that script tag.
-                searchParamsString += `${encodeURIComponent(key)}=${encodeURIComponent(searchParams[key])}&`
+                searchParamsString += `${key}=${searchParams[key]}&`
             }
             searchParamsString = searchParamsString.slice(0, -1)
             searchParamsString = searchParamsString ? `?${searchParamsString}` : searchParamsString
@@ -161,8 +156,8 @@ const getMatchedRoutes = ({ matches, outlet }) => {
  */
 const generateRouteKey = (match, searchParamsString = "") => {
     const { pathname, route } = match
-    const sanitizedPathname = pathname
-    const sanitizedParams = searchParamsString
+    const sanitizedPathname = sanitizeHtml(pathname)
+    const sanitizedParams = sanitizeHtml(searchParamsString)
     if (route.children) {
         return `index${sanitizedPathname}${sanitizedParams}`
     }


### PR DESCRIPTION
## Summary
- `serverDataFetcher`'s `generateRouteKey` builds the object key used in `fetcherData` (later `JSON.stringify`'d straight into an inline SSR `<script>` in `Body.jsx`) from `pathname` and the raw query string. An unencoded `<`/`>`/`"` in a query value (e.g. `?lang="></script><script>alert(document.domain)</script><p class="`) reaches that key verbatim and can break out of the script tag.
- **Root cause turned out to be a dormant regression, not a missing feature**: `sanitizeHtml` has been imported-but-commented-out in this file since it was first added to catalyst-core (`105bf3ac`, "add router to catalyst", May 2025) — `sanitizedPathname`/`sanitizedParams` were left as plain pass-through aliases that never actually sanitized anything, despite `sanitize-html` already being a real dependency in this package's `package.json`.
- `@tata1mg/router` — the separately-maintained package dweb depends on, which this file was originally derived from — never dropped this. It still calls `sanitizeHtml(pathname)` / `sanitizeHtml(searchParamsString)` before using them as the cache key, which is why dweb wasn't exposed through this specific path the way mweb was.
- Fix: uncomment the import and restore the two `sanitizeHtml(...)` calls, matching `@tata1mg/router` exactly. Verified against the PoC payload — `sanitize-html`'s default config strips `<script>...</script>` entirely and HTML-entity-encodes the remaining stray `>`, so no literal `<` reaches the serialized key.
- (Earlier version of this PR used `encodeURIComponent` instead — replaced with this, since it matches the already-established, already-shipped defense rather than introducing a second technique for the same problem.)

## Test plan
- [ ] Confirm existing routes with query params still hydrate/refetch correctly with sanitized keys
- [ ] Re-request `?lang="></script><script>alert(document.domain)</script><p class="` and confirm the key in `window.__ROUTER_INITIAL_DATA__` contains no literal `<`/`>`/`"` and no script executes